### PR TITLE
fix: keep decorateEvent sync by having blocks await hydration promise

### DIFF
--- a/event-libs/v1/blocks/image-links/image-links.js
+++ b/event-libs/v1/blocks/image-links/image-links.js
@@ -4,7 +4,13 @@ function isOdd(number) {
   return number % 2 !== 0;
 }
 
-export default function init(el) {
+export default async function init(el) {
+  if (el.classList.contains('hydrate')) {
+    const { getHydrationPromise } = await import('../../hydrate/hydrate.js');
+    const hydrationPromise = getHydrationPromise();
+    if (hydrationPromise) await hydrationPromise;
+  }
+
   const rows = [...el.querySelectorAll(':scope > div')];
 
   if (!rows.length) {

--- a/event-libs/v1/hydrate/hydrate.js
+++ b/event-libs/v1/hydrate/hydrate.js
@@ -1,14 +1,37 @@
 /**
+ * Promise for the current hydration run. Set when decorateEvent calls hydrateBlocks
+ * so that blocks that depend on hydrated content can await it before initializing.
+ */
+let currentHydrationPromise = null;
+
+/**
+ * Returns the promise for the current page's hydration, if any.
+ * Blocks that need hydrated DOM (e.g. image-links) should await this before init.
+ * @returns {Promise<void>|null} Resolves when hydration is done, or null if no hydration was started
+ */
+export function getHydrationPromise() {
+  return currentHydrationPromise ?? null;
+}
+
+/**
+ * Stores the hydration promise. Used by decorateEvent so it can stay sync.
+ * @param {Promise<void>} p
+ */
+export function setHydrationPromise(p) {
+  currentHydrationPromise = p;
+}
+
+/**
  * Hydrates blocks in the document that need dynamic content from metadata.
  * Call this before blocks are initialized.
  */
 export async function hydrateBlocks(area = document) {
   const blocks = area.querySelectorAll('.hydrate');
-  
+
   for (const block of blocks) {
     // Extract block name from class list (first class is typically the block name)
     const blockName = block.classList[0];
-    
+
     try {
       const { default: hydrate } = await import(`./${blockName}.js`);
       hydrate(block);

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -25,7 +25,7 @@ import {
   createTag,
 } from './utils.js';
 import { massageMetadata } from './date-time-helper.js';
-import { hydrateBlocks } from '../hydrate/hydrate.js';
+import { hydrateBlocks, setHydrationPromise } from '../hydrate/hydrate.js';
 
 const ICONS_BASE_URL = new URL('../icons/', import.meta.url).href;
 
@@ -948,7 +948,7 @@ function addStylesToEventPage() {
 }
 
 export function decorateEvent(parent) {
-  hydrateBlocks(parent);
+  setHydrationPromise(hydrateBlocks(parent));
 
   // handle photos data parsing
   const photosData = parsePhotosData(parent);


### PR DESCRIPTION
# Keep decorateEvent sync; blocks await hydration when needed

## Problem
`hydrateBlocks()` is async (dynamic imports), but `decorateEvent()` must stay synchronous for the existing call stack. Letting blocks run before hydration finished could leave hydratable blocks (e.g. image-links) with empty or wrong DOM.

## Approach
- **Hydrate module** exposes `getHydrationPromise()` and `setHydrationPromise()`. `decorateEvent` calls `setHydrationPromise(hydrateBlocks(parent))` and continues without awaiting.
- **Blocks that need hydrated DOM** (e.g. image-links) await the stored promise before init, only when the block has the `.hydrate` class.
- **Lazy load** the hydrate module from the block: dynamic import only when `el.classList.contains('hydrate')`, so non-hydrate image-links blocks never load it.

## Changes
- `event-libs/v1/hydrate/hydrate.js`: add `currentHydrationPromise`, `getHydrationPromise()`, `setHydrationPromise()`
- `event-libs/v1/utils/decorate.js`: `setHydrationPromise(hydrateBlocks(parent))` at start of `decorateEvent`
- `event-libs/v1/blocks/image-links/image-links.js`: async init; if `.hydrate`, dynamic import hydrate module, then await `getHydrationPromise()` before continuing

## Testing
- Existing image-links unit tests: no `decorateEvent`, so no hydration promise and no dynamic import; init runs as before.
- Manual: event page with image-links block using `.hydrate` and metadata; block should render after hydration.
