### PR TITLE
Expose chrono-box schedule JSON on DOM for extensions

### DIFF
--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -186,7 +186,7 @@ export default async function init(el) {
   }
 
   // Expose parsed schedule on DOM for consumers (e.g. Chrome extensions)
-  el.setAttribute('data-event-libs-schedule-json', JSON.stringify(thisSchedule));
+  el.setAttribute('data-tf-schedule-json', JSON.stringify(thisSchedule));
   el.innerHTML = '';
 
   const pluginsOutputs = await initPlugins(thisSchedule);

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -185,6 +185,8 @@ export default async function init(el) {
     return Promise.resolve();
   }
 
+  // Expose parsed schedule on DOM for consumers (e.g. Chrome extensions)
+  el.setAttribute('data-event-libs-schedule-json', JSON.stringify(thisSchedule));
   el.innerHTML = '';
 
   const pluginsOutputs = await initPlugins(thisSchedule);


### PR DESCRIPTION
## Summary
After the chrono-box block parses the schedule, the schedule JSON is now stored on the block root element via `data-event-libs-schedule-json` so Chrome extensions (and other consumers) can read it from the DOM.

## Change
- **File:** `event-libs/v1/blocks/chrono-box/chrono-box.js`
- Set `data-tf-schedule-json` on the chrono-box element with `JSON.stringify(thisSchedule)` immediately after resolving the schedule and before clearing inner HTML. Attribute persists for the lifetime of the element.

## Usage (e.g. in extension)
```js
const scheduleJson = document.querySelector('.chrono-box')?.getAttribute('data-tf-schedule-json');
const schedule = scheduleJson ? JSON.parse(scheduleJson) : null;
```

Before: https://main--da-events--adobecom.aem.live/drafts/events/create-now/adobe-creative-cafe-san-jose/san-jose/ca/2025-01-27
After: https://main--da-events--adobecom.aem.live/drafts/events/create-now/adobe-creative-cafe-san-jose/san-jose/ca/2025-01-27?eventlibs=schedule-DOM-retention