### PR TITLE
fix(meta-pixel): use capture phase for Lead click listener so it fires before IMS redirect

### DIFF
--- a/event-libs/scripts/meta-pixel.js
+++ b/event-libs/scripts/meta-pixel.js
@@ -128,7 +128,7 @@ function attachLeadTracking() {
       rsvpFormInteracted = true;
       safeFbq('track', 'Lead');
     }
-  });
+  }, { capture: true });
 }
 
 /**


### PR DESCRIPTION
## Summary
Use the capture phase for the Meta Pixel Lead click listener so it runs before the RSVP button's handler, ensuring Lead is tracked when logged-out users click RSVP in non-guestReg events.

## Problem
The Lead event was not firing when a logged-out user clicked the RSVP button and the event did not allow guest registration. In that case, `decorate.js` attaches a click handler to the RSVP button that calls `preventDefault()` and `signIn()`, triggering an immediate redirect to Adobe IMS. The page unloads before the document-level Lead listener (which used the default bubble phase) could run.

## Root cause
Event phase ordering: both listeners used the bubble phase. The button's handler runs first (closer to the target), then the event would bubble to document. The IMS redirect caused the page to unload before the document listener ran.

## Solution
Add `{ capture: true }` to the Lead listener in `attachLeadTracking()`. The capture phase runs before the bubble phase (document → target), so the Lead fires during capture, then the button handler runs (preventDefault, signIn, redirect).

## Changes
- **`event-libs/scripts/meta-pixel.js`**: Pass `{ capture: true }` as the third argument to `document.addEventListener('click', ...)` in `attachLeadTracking()`