### PR TITLE
feat(rsvp): campaign-aware RSVP registration

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -13,6 +13,8 @@ const { default: sanitizeComment } = await import(`${miloLibs}/utils/sanitizeCom
 const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
 const { default: loadFragment } = await import(`${miloLibs}/blocks/fragment/fragment.js`);
 
+const CAMPAIGN_ID_PATTERN = /^[\w-]{1,128}$/;
+
 const RULE_OPERATORS = {
   equal: '=',
   notEqual: '!=',
@@ -198,6 +200,11 @@ async function submitForm(bp) {
   }, true);
 
   if (!isValid) return false;
+
+  const campaignId = new URLSearchParams(window.location.search).get('campaign');
+  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId)) {
+    payload.campaignId = campaignId;
+  }
 
   return getAndCreateAndAddAttendee(getMetadata('event-id'), payload);
 }

--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -14,6 +14,7 @@ export const EVENT_ATTENDEE_DATA_FILTER = {
   invitedBy: { type: 'string', submittable: true },
   shareInfoWithPartners: { type: 'boolean', submittable: true },
   ccSentiment: { type: 'string', submittable: true },
+  campaignId: { type: 'string', submittable: true },
 };
 
 /**

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -277,6 +277,30 @@ export async function deleteAttendeeFromEvent(eventId, attendeeId = null) {
   }
 }
 
+export async function getCampaign(eventId, campaignId) {
+  const eventServiceEnv = getEventServiceEnv();
+  const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
+  const options = await constructRequestOptions('GET');
+
+  try {
+    const response = await fetch(
+      `${serviceApiEndpoints.esl}/v1/events/${eventId}/campaigns/${campaignId}`,
+      options,
+    );
+    const data = await response.json();
+
+    if (!response.ok) {
+      window.lana?.log(`Error: Failed to get campaign ${campaignId} for event ${eventId}. Status:${JSON.stringify(response)}`);
+      return { ok: false, status: response.status, error: data };
+    }
+
+    return { ok: true, data };
+  } catch (error) {
+    window.lana?.log(`Error: Failed to get campaign ${campaignId} for event ${eventId}:${JSON.stringify(error)}`);
+    return { ok: false, status: 'Network Error', error: error.message };
+  }
+}
+
 // compound helper functions
 export async function getAndCreateAndAddAttendee(eventId, attendeeData) {
   const profile = BlockMediator.get('imsProfile');
@@ -311,6 +335,17 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData) {
   const newAttendeeData = attendee.data;
 
   if (eventObj.data.isFull) registrationStatus = 'waitlisted';
+
+  if (attendeeData.campaignId && registrationStatus !== 'waitlisted') {
+    const campaign = await getCampaign(eventId, attendeeData.campaignId);
+    if (campaign.ok && campaign.data.attendeeLimit != null) {
+      const { attendeeLimit, attendeeCount, waitlistAttendeeCount } = campaign.data;
+      if (attendeeLimit === attendeeCount
+        || (attendeeLimit > attendeeCount && waitlistAttendeeCount > 0)) {
+        registrationStatus = 'waitlisted';
+      }
+    }
+  }
 
   // Use EventAttendee filter for adding attendee to event
   const eventAttendeePayload = getEventAttendeePayload({

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import BlockMediator from '../../../event-libs/v1/deps/block-mediator.min.js';
 
 describe('Adobe Event Service API', () => {
   let api;
@@ -147,6 +148,157 @@ describe('Adobe Event Service API', () => {
       const error = await api.deleteAttendeeFromEvent('123');
       expect(error).to.be.an('object');
       expect(error.ok).to.be.false;
+    });
+  });
+
+  describe('getCampaign', () => {
+    it('should fetch campaign details', async () => {
+      const campaignData = {
+        campaignId: 'camp-1',
+        name: 'Test Campaign',
+        status: 'Active',
+        attendeeLimit: 100,
+        attendeeCount: 50,
+        waitlistAttendeeCount: 0,
+      };
+      sandbox.stub(window, 'fetch').resolves({ json: () => campaignData, ok: true });
+
+      const result = await api.getCampaign('event-1', 'camp-1');
+      expect(result.ok).to.be.true;
+      expect(result.data).to.deep.equal(campaignData);
+    });
+
+    it('should return an error if campaign fetch fails', async () => {
+      sandbox.stub(window, 'fetch').resolves({ json: () => ({ message: 'Not found' }), ok: false, status: 404 });
+
+      const result = await api.getCampaign('event-1', 'camp-1');
+      expect(result.ok).to.be.false;
+      expect(result.status).to.equal(404);
+    });
+
+    it('should handle network errors', async () => {
+      sandbox.stub(window, 'fetch').rejects(new Error('Network failure'));
+
+      const result = await api.getCampaign('event-1', 'camp-1');
+      expect(result.ok).to.be.false;
+      expect(result.status).to.equal('Network Error');
+    });
+  });
+
+  describe('getAndCreateAndAddAttendee', () => {
+    const eventId = 'event-123';
+    const attendeeData = { firstName: 'John', lastName: 'Doe', email: 'john@test.com' };
+    const attendeeResp = { attendeeId: 'att-1', firstName: 'John', lastName: 'Doe', email: 'john@test.com' };
+
+    beforeEach(() => {
+      BlockMediator.set('imsProfile', { account_type: 'type1' });
+    });
+
+    it('should register when event is not full and no campaign', async () => {
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true, status: 200 });
+      fetchStub.onCall(2).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'registered' }), ok: true });
+
+      const result = await api.getAndCreateAndAddAttendee(eventId, attendeeData);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('registered');
+    });
+
+    it('should waitlist when event is full regardless of campaign', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: true }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({ json: () => ({ registrationStatus: 'waitlisted' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(fetchStub.callCount).to.equal(3);
+    });
+
+    it('should register with campaign when campaign has no attendeeLimit', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({
+        json: () => ({ campaignId: 'camp-1', attendeeCount: 50, waitlistAttendeeCount: 0 }),
+        ok: true,
+      });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'registered', campaignId: 'camp-1' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('registered');
+    });
+
+    it('should register when campaign has capacity and no waitlist', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({
+        json: () => ({ campaignId: 'camp-1', attendeeLimit: 100, attendeeCount: 50, waitlistAttendeeCount: 0 }),
+        ok: true,
+      });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'registered', campaignId: 'camp-1' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('registered');
+    });
+
+    it('should waitlist when campaign attendeeLimit equals attendeeCount', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({
+        json: () => ({ campaignId: 'camp-1', attendeeLimit: 100, attendeeCount: 100, waitlistAttendeeCount: 0 }),
+        ok: true,
+      });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'waitlisted', campaignId: 'camp-1' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('waitlisted');
+    });
+
+    it('should waitlist when campaign has capacity but waitlist backlog exists', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({
+        json: () => ({ campaignId: 'camp-1', attendeeLimit: 100, attendeeCount: 80, waitlistAttendeeCount: 5 }),
+        ok: true,
+      });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'waitlisted', campaignId: 'camp-1' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('waitlisted');
+    });
+
+    it('should fall back to event-level status when campaign lookup fails', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({ json: () => ({ message: 'Not found' }), ok: false, status: 404 });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'registered', campaignId: 'camp-1' }), ok: true });
+
+      const dataWithCampaign = { ...attendeeData, campaignId: 'camp-1' };
+      const result = await api.getAndCreateAndAddAttendee(eventId, dataWithCampaign);
+      expect(result.ok).to.be.true;
+      expect(result.data.registrationStatus).to.equal('registered');
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds campaign-aware RSVP registration: pages with `?campaign=<id>` can pass the campaign ID into the event attendee payload and use campaign capacity (attendeeLimit, attendeeCount, waitlistAttendeeCount) to set registration vs waitlist status.

## Changes
- **events-form.js**: Read and sanitize `campaign` URL param on submit; add `campaignId` to payload when valid (regex `^[\w-]{1,128}$`).
- **data-utils.js**: Add `campaignId` to `EVENT_ATTENDEE_DATA_FILTER` so it is sent in the event attendee API body.
- **esp-controller.js**:
  - New `getCampaign(eventId, campaignId)` helper (GET `/v1/events/{eventId}/campaigns/{campaignId}`).
  - In `getAndCreateAndAddAttendee`: if `campaignId` present and event not already full, fetch campaign and apply waitlist rules:
    - No `attendeeLimit`: pass `campaignId` only, no campaign logic.
    - `attendeeLimit === attendeeCount` → waitlisted.
    - `attendeeLimit > attendeeCount && waitlistAttendeeCount > 0` → waitlisted.
    - `attendeeLimit > attendeeCount && waitlistAttendeeCount === 0` → registered.
  - Skip campaign lookup when event is full.
- **esp-controller.test.js**: Tests for `getCampaign` and campaign-aware `getAndCreateAndAddAttendee` (7 new cases).

## Testing
- `npm test` passes (377 tests).
- New unit tests cover getCampaign success/error and all campaign registration branches.

Made with [Cursor](https://cursor.com)