### PR TITLE
Add profile-cards modal variant

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -162,22 +162,52 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  padding: 24px;
 }
 
 .profile-cards-modal .profile-cards-modal-text .card-title {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);;
+  font-family: var(--body-font-family);
+  font-style: normal;
+  font-weight: 400;
+  margin-top: 0;
   margin-bottom: 8px;
 }
 
 .profile-cards-modal .profile-cards-modal-text .card-name {
-  margin-bottom: 12px;
+  margin-top: 0;
+  font-size: var(--type-heading-l-size);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  margin-bottom: 14px;
 }
 
 .profile-cards-modal .profile-cards-modal-text .card-desc {
-  margin-bottom: 12px;
+  color: #2C2C2C;
+  font-family: var(--body-font-family);
+  font-size: var(--type-body-xs-size);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 21px;
+  margin-top: 0;
+  margin-bottom: 24px;
 }
 
 .profile-cards-modal .profile-cards-modal-text .card-social-icons {
-  margin-top: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 17px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  margin-top: 4px;
+}
+
+.profile-cards-modal .profile-cards-modal-text .card-social-icon a {
+  color: var(--color-black);
 }
 
 .profile-cards-modal .profile-cards-modal-image .card-image-container {
@@ -185,6 +215,7 @@
   max-width: 385px;
   height: auto;
   border-radius: 14px;
+  overflow: hidden;
   margin: 0 auto;
 }
 
@@ -193,6 +224,7 @@
   height: auto;
   aspect-ratio: 385 / 217;
   object-fit: cover;
+  display: block;
 }
 
 /* Tablet and up */
@@ -208,6 +240,7 @@
 
   .profile-cards-modal .profile-cards-modal-content {
     gap: 28px;
+    padding: 32px;
   }
 }
 
@@ -289,9 +322,9 @@
   }
 
   .profile-cards-modal .profile-cards-modal-content {
-    align-items: flex-start;
+    align-items: center;
     flex-direction: row;
-    gap: 32px;
+    gap: 40px;
   }
 
   .profile-cards-modal .profile-cards-modal-text {

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -67,6 +67,16 @@
   height: 100%;
 }
 
+.profile-cards.modal .card-container {
+  cursor: pointer;
+  transition: box-shadow 0.3s ease;
+}
+
+.profile-cards.modal .card-container:hover,
+.profile-cards.modal .card-container:focus-visible {
+  box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
+}
+
 .profile-cards.grid .card-image-container {
   height: 213px;
 }
@@ -148,6 +158,43 @@
   color: var(--color-black);
 }
 
+.profile-cards-modal .profile-cards-modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.profile-cards-modal .profile-cards-modal-text .card-title {
+  margin-bottom: 8px;
+}
+
+.profile-cards-modal .profile-cards-modal-text .card-name {
+  margin-bottom: 12px;
+}
+
+.profile-cards-modal .profile-cards-modal-text .card-desc {
+  margin-bottom: 12px;
+}
+
+.profile-cards-modal .profile-cards-modal-text .card-social-icons {
+  margin-top: 0;
+}
+
+.profile-cards-modal .profile-cards-modal-image .card-image-container {
+  width: 100%;
+  max-width: 385px;
+  height: auto;
+  border-radius: 14px;
+  margin: 0 auto;
+}
+
+.profile-cards-modal .profile-cards-modal-image .card-image-container img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 385 / 217;
+  object-fit: cover;
+}
+
 /* Tablet and up */
 @media screen and (min-width: 600px) {
   /* Grid variants: Tablet - all variants get 2 columns */
@@ -157,6 +204,10 @@
   .profile-cards.grid.five-up .cards-wrapper {
     grid-template-columns: repeat(2, 1fr);
     padding: 40px 16px;
+  }
+
+  .profile-cards-modal .profile-cards-modal-content {
+    gap: 28px;
   }
 }
 
@@ -235,5 +286,19 @@
 
   .profile-cards.grid.five-up .cards-wrapper {
     grid-template-columns: repeat(5, 1fr);
+  }
+
+  .profile-cards-modal .profile-cards-modal-content {
+    align-items: flex-start;
+    flex-direction: row;
+    gap: 32px;
+  }
+
+  .profile-cards-modal .profile-cards-modal-text {
+    flex: 1 1 0;
+  }
+
+  .profile-cards-modal .profile-cards-modal-image {
+    flex: 0 0 auto;
   }
 }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -241,6 +241,7 @@
   .profile-cards-modal .profile-cards-modal-content {
     gap: 28px;
     padding: 32px;
+    align-items: flex-start;
   }
 }
 
@@ -333,5 +334,9 @@
 
   .profile-cards-modal .profile-cards-modal-image {
     flex: 0 0 auto;
+  }
+
+  .profile-cards-modal .profile-cards-modal-text .card-desc {
+    max-width: 385px;
   }
 }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -1,5 +1,13 @@
 import buildMiloCarousel from '../../features/carousel/milo-carousel.js';
-import { getMetadata, createTag, getImageSource } from '../../utils/utils.js';
+import {
+  getMetadata,
+  createTag,
+  getImageSource,
+  getEventConfig,
+  LIBS,
+} from '../../utils/utils.js';
+
+let modalLoader;
 
 function decorateImage(card, photo) {
   if (!photo) return;
@@ -168,6 +176,109 @@ function decorateContentSimple(cardContainer, data) {
   cardContainer.append(contentContainer);
 }
 
+function getProfileName(data) {
+  return `${data?.firstName || ''} ${data?.lastName || ''}`.trim();
+}
+
+function getSocialLinks(data) {
+  return data?.socialLinks || data?.socialMedia || [];
+}
+
+function appendBio(contentContainer, bio) {
+  const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
+  if (!trimmedBio) return;
+
+  if (trimmedBio.includes('<')) {
+    const bioContainer = createTag('div', { class: 'card-desc' });
+    bioContainer.innerHTML = trimmedBio;
+    contentContainer.append(bioContainer);
+    return;
+  }
+
+  const description = createTag('p', { class: 'card-desc' }, trimmedBio);
+  contentContainer.append(description);
+}
+
+function getModalId(data, index) {
+  const fullName = getProfileName(data);
+  const slug = fullName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `profile-cards-modal-${slug || index + 1}`;
+}
+
+async function loadMiloModal() {
+  if (!modalLoader) {
+    modalLoader = (async () => {
+      const eventConfig = getEventConfig();
+      const modalBasePath = eventConfig?.miloConfig?.miloLibs || LIBS;
+      const { getModal } = await import(`${modalBasePath}/blocks/modal/modal.js`);
+      return getModal;
+    })();
+  }
+
+  return modalLoader;
+}
+
+async function buildModalContent(profileData) {
+  const content = new DocumentFragment();
+  const modalContent = createTag('div', { class: 'profile-cards-modal-content' });
+  const textContainer = createTag('div', { class: 'profile-cards-modal-text' });
+  const imageContainer = createTag('div', { class: 'profile-cards-modal-image' });
+  const fullName = getProfileName(profileData);
+  const title = createTag('p', { class: 'card-title' }, profileData?.title || '');
+  const name = createTag('h3', { class: 'card-name' }, fullName);
+
+  textContainer.append(title, name);
+  appendBio(textContainer, profileData?.bio);
+  await decorateSocialIcons(textContainer, getSocialLinks(profileData));
+  decorateImage(imageContainer, profileData?.photo);
+
+  modalContent.append(textContainer, imageContainer);
+  content.append(modalContent);
+  return content;
+}
+
+async function openProfileModal(profileData, index) {
+  try {
+    const getModal = await loadMiloModal();
+    const fullName = getProfileName(profileData) || `Profile ${index + 1}`;
+    const content = await buildModalContent(profileData);
+
+    await getModal(null, {
+      id: getModalId(profileData, index),
+      title: `Profile: ${fullName}`,
+      content,
+      class: 'profile-cards-modal',
+    });
+  } catch (error) {
+    window.lana?.log(`Failed to open profile modal:\n${JSON.stringify(error, null, 2)}`);
+  }
+}
+
+function decorateModalTrigger(cardContainer, profileData, index) {
+  const fullName = getProfileName(profileData) || `Profile ${index + 1}`;
+  const openModal = () => {
+    openProfileModal(profileData, index);
+  };
+
+  cardContainer.classList.add('modal-trigger');
+  cardContainer.setAttribute('role', 'button');
+  cardContainer.setAttribute('tabindex', '0');
+  cardContainer.setAttribute('aria-haspopup', 'dialog');
+  cardContainer.setAttribute('aria-label', `Open profile modal for ${fullName}`);
+
+  cardContainer.addEventListener('click', (event) => {
+    if (event.target.closest('a')) return;
+    openModal();
+  });
+
+  cardContainer.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    if (event.target.closest('a')) return;
+    event.preventDefault();
+    openModal();
+  });
+}
+
 function parseStaticCard(row) {
   const cell = row.querySelector(':scope > div');
   if (!cell) return null;
@@ -255,7 +366,7 @@ function parseStaticCard(row) {
   };
 }
 
-function decorateStaticCards(el) {
+function decorateStaticCards(el, { modal } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const rows = Array.from(el.querySelectorAll(':scope > div:not(.cards-wrapper)'));
   
@@ -267,13 +378,16 @@ function decorateStaticCards(el) {
     return;
   }
 
-  cardRows.forEach((row) => {
+  cardRows.forEach((row, index) => {
     const cardData = parseStaticCard(row);
     if (!cardData) return;
 
     const cardContainer = createTag('div', { class: 'card-container' });
     decorateImage(cardContainer, cardData.photo);
     decorateContent(cardContainer, cardData);
+    if (modal) {
+      decorateModalTrigger(cardContainer, cardData, index);
+    }
     cardsWrapper.append(cardContainer);
     
     // Remove the original row
@@ -292,7 +406,7 @@ function decorateStaticCards(el) {
   }
 }
 
-function decorateCards(el, data, { simple } = {}) {
+function decorateCards(el, data, { simple, modal } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const rows = el.querySelectorAll(':scope > div');
   const configRow = rows[1];
@@ -306,7 +420,7 @@ function decorateCards(el, data, { simple } = {}) {
 
   configRow.remove();
 
-  filteredData.forEach((speaker) => {
+  filteredData.forEach((speaker, index) => {
     const cardContainer = createTag('div', { class: 'card-container' });
 
     decorateImage(cardContainer, speaker.photo);
@@ -314,6 +428,9 @@ function decorateCards(el, data, { simple } = {}) {
       decorateContentSimple(cardContainer, speaker);
     } else {
       decorateContent(cardContainer, speaker);
+    }
+    if (modal) {
+      decorateModalTrigger(cardContainer, speaker, index);
     }
 
     cardsWrapper.append(cardContainer);
@@ -339,6 +456,7 @@ export default function init(el) {
   // Check if the first cell of configRow (if it exists) contains 'type'
   const firstCell = configRow?.querySelectorAll(':scope > div')?.[0];
   const isMetadataDriven = firstCell?.textContent.toLowerCase().trim() === 'type';
+  const isModal = el.classList.contains('modal');
 
   // Handle grid variant: add default three-up if no *-up class is present
   if (el.classList.contains('grid')) {
@@ -369,8 +487,8 @@ export default function init(el) {
     }
 
     const isSimple = el.classList.contains('simple');
-    decorateCards(el, data, { simple: isSimple });
+    decorateCards(el, data, { simple: isSimple, modal: isModal });
   } else {
-    decorateStaticCards(el);
+    decorateStaticCards(el, { modal: isModal });
   }
 }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -157,6 +157,17 @@ function decorateContent(cardContainer, data) {
   cardContainer.append(contentContainer);
 }
 
+function decorateContentSimple(cardContainer, data) {
+  const contentContainer = createTag('div', { class: 'card-content' });
+  const textContainer = createTag('div', { class: 'card-text-container' });
+  const title = createTag('p', { class: 'card-title' }, data.title);
+  const name = createTag('h3', { class: 'card-name' }, `${data.firstName} ${data.lastName}`);
+
+  textContainer.append(title, name);
+  contentContainer.append(textContainer);
+  cardContainer.append(contentContainer);
+}
+
 function parseStaticCard(row) {
   const cell = row.querySelector(':scope > div');
   if (!cell) return null;
@@ -281,7 +292,7 @@ function decorateStaticCards(el) {
   }
 }
 
-function decorateCards(el, data) {
+function decorateCards(el, data, { simple } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const rows = el.querySelectorAll(':scope > div');
   const configRow = rows[1];
@@ -299,7 +310,11 @@ function decorateCards(el, data) {
     const cardContainer = createTag('div', { class: 'card-container' });
 
     decorateImage(cardContainer, speaker.photo);
-    decorateContent(cardContainer, speaker);
+    if (simple) {
+      decorateContentSimple(cardContainer, speaker);
+    } else {
+      decorateContent(cardContainer, speaker);
+    }
 
     cardsWrapper.append(cardContainer);
   });
@@ -353,7 +368,8 @@ export default function init(el) {
       return;
     }
 
-    decorateCards(el, data);
+    const isSimple = el.classList.contains('simple');
+    decorateCards(el, data, { simple: isSimple });
   } else {
     decorateStaticCards(el);
   }

--- a/test/unit/blocks/profile-cards/mocks/default.html
+++ b/test/unit/blocks/profile-cards/mocks/default.html
@@ -57,6 +57,25 @@
   </div>
 </div>
 <div>
+  <div id='simple-cards' class="profile-cards simple">
+    <div>
+      <div>
+        <h2 id="simple-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>type</div>
+      <div>speaker</div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
+<div>
   <div id='keynotes-cards' class="profile-cards">
     <div>
       <div>

--- a/test/unit/blocks/profile-cards/mocks/default.html
+++ b/test/unit/blocks/profile-cards/mocks/default.html
@@ -76,6 +76,25 @@
   </div>
 </div>
 <div>
+  <div id='modal-speakers-cards' class="profile-cards modal">
+    <div>
+      <div>
+        <h2 id="modal-speakers">Modal Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>type</div>
+      <div>speaker</div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
+<div>
   <div id='keynotes-cards' class="profile-cards">
     <div>
       <div>
@@ -85,6 +104,29 @@
     <div>
       <div>type</div>
       <div>keynote</div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
+<div>
+  <div id='static-modal-cards' class="profile-cards modal">
+    <div>
+      <div>
+        <h2 id="static-speakers">Static Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <p>Speaker title</p>
+        <h3>Static Speaker</h3>
+        <p>Static speaker bio content.</p>
+        <p><a href="https://www.instagram.com/staticspeaker">https://www.instagram.com/staticspeaker</a></p>
+      </div>
     </div>
   </div>
   <div class="section-metadata">

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -53,6 +53,25 @@ describe('Profile Cards Module', () => {
 
       expect(noSpeakers).to.be.null;
     });
+
+    it('should render simple variant with only image, title and name (no bio or social icons)', () => {
+      const el = document.querySelector('#simple-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+
+      expect(el).to.not.be.null;
+      expect(cards).to.have.lengthOf(3);
+
+      cards.forEach((card) => {
+        expect(card.querySelector('.card-image-container')).to.not.be.null;
+        expect(card.querySelector('.card-content')).to.not.be.null;
+        expect(card.querySelector('.card-title')).to.not.be.null;
+        expect(card.querySelector('.card-name')).to.not.be.null;
+        expect(card.querySelector('.card-desc')).to.be.null;
+        expect(card.querySelector('.card-social-icons')).to.be.null;
+      });
+    });
   });
 
   describe('createSocialIcon', () => {

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -72,6 +72,42 @@ describe('Profile Cards Module', () => {
         expect(card.querySelector('.card-social-icons')).to.be.null;
       });
     });
+
+    it('should make metadata-driven modal cards interactive', () => {
+      const el = document.querySelector('#modal-speakers-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      const firstCard = cards[0];
+      const keydownEvent = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      firstCard.dispatchEvent(keydownEvent);
+
+      expect(cards).to.have.lengthOf(3);
+      expect(firstCard.getAttribute('role')).to.equal('button');
+      expect(firstCard.getAttribute('tabindex')).to.equal('0');
+      expect(firstCard.getAttribute('aria-haspopup')).to.equal('dialog');
+      expect(firstCard.getAttribute('aria-label')).to.include('Open profile modal for');
+      expect(keydownEvent.defaultPrevented).to.be.true;
+    });
+
+    it('should make static-authored modal cards interactive', () => {
+      const el = document.querySelector('#static-modal-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      const firstCard = cards[0];
+
+      expect(cards).to.have.lengthOf(1);
+      expect(firstCard.getAttribute('role')).to.equal('button');
+      expect(firstCard.getAttribute('tabindex')).to.equal('0');
+      expect(firstCard.getAttribute('aria-haspopup')).to.equal('dialog');
+      expect(firstCard.getAttribute('aria-label')).to.equal('Open profile modal for Static Speaker');
+    });
   });
 
   describe('createSocialIcon', () => {


### PR DESCRIPTION
Add the new `modal` variant for `profile-cards` with hover elevation and Milo modal rendering for full profile content across metadata-driven and static-authored cards. The variant is responsive and caps modal image width at 385px.

Resolves: [MWPW-185422](https://jira.corp.adobe.com/browse/MWPW-185422)
Resolves: [MWPW-184307](https://jira.corp.adobe.com/browse/MWPW-184307)

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/.snapshots/esp-stage/create-now/qiyun-test-emc-v2-venue-fix/san-jose/ca/us/2026-02-13
- After: https://main--da-events--adobecom.aem.page/.snapshots/esp-stage/create-now/qiyun-test-emc-v2-venue-fix/san-jose/ca/us/2026-02-13?eventlibs=mwpw-185422


Made with [Cursor](https://cursor.com)