### PR TITLE
[fix]: Add sortDataByOrdinals

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -316,6 +316,11 @@ function decorateCards(el, data) {
   }
 }
 
+function sortDataByOrdinals(data) {
+  // sort by ordinal. if no ordinal, append to the end
+  return data.sort((a, b) => (a.ordinal || 0) - (b.ordinal || 0));
+}
+
 export default function init(el) {
   const rows = el.querySelectorAll(':scope > div');
   const configRow = rows[1];
@@ -353,7 +358,8 @@ export default function init(el) {
       return;
     }
 
-    decorateCards(el, data);
+    const sortedData = sortDataByOrdinals(data);
+    decorateCards(el, sortedData);
   } else {
     decorateStaticCards(el);
   }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -317,9 +317,16 @@ function decorateCards(el, data) {
 }
 
 function sortDataByOrdinals(data) {
-  // sort by ordinal. if no ordinal, append to the end
-  return data.sort((a, b) => (a.ordinal || 0) - (b.ordinal || 0));
+  return [...data].sort((a, b) => {
+    const aHas = a.ordinal != null;
+    const bHas = b.ordinal != null;
+    if (aHas && bHas) return a.ordinal - b.ordinal;
+    if (aHas) return -1;
+    if (bHas) return 1;
+    return 0;
+  });
 }
+
 
 export default function init(el) {
   const rows = el.querySelectorAll(':scope > div');


### PR DESCRIPTION
Add optional sorting if speaker data contains ordinal attribute

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--event-libs--adobecom.aem.live/?martech=off
- After: https://speaker-sorting-issue--event-libs--adobecom.aem.live/?martech=off
