### PR TITLE
fix(events-form): trim RSVP form field names for visible/required match

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -774,6 +774,7 @@ async function createForm(bp, formData) {
     json.data = json.data
       .map((obj) => {
         const lowkey = lowercaseKeys(obj);
+        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
         if (required.includes(lowkey.field)) lowkey.required = 'x';
         return lowkey;
       })
@@ -782,6 +783,7 @@ async function createForm(bp, formData) {
     json.data = json.data
       .map((obj) => {
         const lowkey = lowercaseKeys(obj);
+        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
         return lowkey;
       })
       .filter((f) => ['clear', 'submit'].includes(f.field));


### PR DESCRIPTION
## Summary
Form config field names with trailing whitespace (e.g. `shareInfoWithPartners\n`) did not match `rsvp-form-fields` metadata `visible`/`required` arrays, causing fields like `shareInfoWithPartners` to be filtered out and not rendered.

## Change
Normalize field names with `trim()` when building the form in `createForm()` so:
- `visible.includes(f.field)` matches when the config has stray whitespace/newlines
- `required.includes(lowkey.field)` matches consistently
- `data-field-id` and input `id` use the trimmed value

## Testing
- No new tests; existing events-form behavior unchanged for already-clean field names
- Fix is defensive: trim only when `field` is a string

Made with [Cursor](https://cursor.com)