### PR TITLE
[fix] Aria Label Profile Cards Override issue

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -154,7 +154,6 @@ function decorateContent(cardContainer, data) {
 }
 
 function parseStaticCard(row) {
-  console.log(row.cloneNode(true).innerHTML);
   const cell = row.querySelector(':scope > div');
   if (!cell) return null;
 

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -85,14 +85,12 @@ async function decorateSocialIcons(cardContainer, socialLinks) {
 
   const svgEls = await getSVGsfromFile(svgPath, SUPPORTED_PLATFORMS);
   if (!svgEls || svgEls.length === 0) return;
-  socialLinks.forEach((social) => {
-    const { link } = social;
-
-    if (!link) return;
+  socialLinks.forEach((link) => {
+    if (!link || !(link instanceof HTMLAnchorElement)) return;
 
     let platform = 'web'; // Default fallback
     try {
-      const url = new URL(link);
+      const url = new URL(link.href);
       const hostname = url.hostname.toLowerCase();
 
       // Find the platform by testing against regex patterns
@@ -110,13 +108,11 @@ async function decorateSocialIcons(cardContainer, socialLinks) {
     const li = createTag('li', { class: 'card-social-icon' });
     const icon = createSocialIcon(svgEl.svg, platform);
 
-    const a = createTag('a', {
-      href: link,
-      target: '_blank',
-      rel: 'noopener noreferrer',
-      'aria-label': platform,
-    });
+    const a = link.cloneNode(true);
+    a.setAttribute('target', '_blank');
+    a.setAttribute('rel', 'noopener noreferrer');
     a.textContent = '';
+
     a.append(icon);
     li.append(a);
     socialList.append(li);
@@ -152,12 +148,13 @@ function decorateContent(cardContainer, data) {
 
   contentContainer.append(textContainer);
 
-  decorateSocialIcons(contentContainer, data.socialLinks || data.socialMedia || []);
+  decorateSocialIcons(contentContainer, data.socialLinks);
 
   cardContainer.append(contentContainer);
 }
 
 function parseStaticCard(row) {
+  console.log(row.cloneNode(true).innerHTML);
   const cell = row.querySelector(':scope > div');
   if (!cell) return null;
 
@@ -219,7 +216,7 @@ function parseStaticCard(row) {
         // This is a social link paragraph
         const anchor = child.querySelector('a');
         if (anchor?.href) {
-          socialLinks.push({ link: anchor.href });
+          socialLinks.push(anchor);
         }
       } else if (child !== heading) {
         // This is bio content - keep the HTML


### PR DESCRIPTION
Resolves: [MWPW-189907](https://jira.corp.adobe.com/browse/MWPW-189907)

The static variant profile cards block is unnecessarily overriding the Aria Label populated by Milo link decoration. This fix will make sure the block doesn't manipulate the links and only adding new tab behavior and standard security practice attributes

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/drafts/qiyundai/creativecollective
- After: https://main--da-events--adobecom.aem.page/drafts/qiyundai/creativecollective?eventlibs=aria-profile-fix
