### PR TITLE
Campaign capacity in RSVP button and campaign-full error/form state

### DIFF
--- a/docs/dictionary-manager-consolidation.md
+++ b/docs/dictionary-manager-consolidation.md
@@ -39,6 +39,8 @@ const waitlistText = dictionaryManager.getValue('waitlist-cta-text');
 const closedText = dictionaryManager.getValue('event-full-cta-text');
 ```
 
+Form error messages (events-form, on submit 400): `event-full-error-msg`, `event-full-no-waitlist-error-msg`, `campaign-full-error-msg`, `campaign-full-no-waitlist-error-msg`, `rsvp-error-msg`.
+
 ## Benefits of the Current Implementation
 
 1. **Unified Interface**: All key replacement functionality is handled through a single `DictionaryManager` class

--- a/docs/rsvp-button-authoring-guidelines.md
+++ b/docs/rsvp-button-authoring-guidelines.md
@@ -102,6 +102,18 @@ Button text is managed through the dictionary system. The following keys are use
 - `waitlist-cta-text` - Join waitlist text
 - `event-full-cta-text` - Event full text
 
+### Form error messages (RSVP form submit)
+
+When the form submit returns 400 (capacity full), the following keys are used:
+
+- `event-full-error-msg` - Shown when the **event** is full and waitlisting is allowed
+- `event-full-no-waitlist-error-msg` - Shown when the **event** is full and waitlisting is disabled
+- `campaign-full-error-msg` - Shown when the **campaign** (URL param `?campaign=...`) is full and waitlisting is allowed
+- `campaign-full-no-waitlist-error-msg` - Shown when the **campaign** is full and waitlisting is disabled
+- `rsvp-error-msg` - Generic RSVP error for other failure statuses
+
+Campaign-full keys are used only when the user submitted with a valid campaign ID in the URL and the capacity limit that was reached is the campaign's, not the event's.
+
 ## User Authentication Handling
 
 ### Guest Users

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -1,9 +1,9 @@
-import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent } from '../../utils/esp-controller.js';
+import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent, getCampaign } from '../../utils/esp-controller.js';
 import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
 import { dictionaryManager } from '../../utils/dictionary-manager.js';
 import { getEventConfig, LIBS, getMetadata, getSusiOptions } from '../../utils/utils.js';
-import { FALLBACK_LOCALES } from '../../utils/constances.js';
+import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN } from '../../utils/constances.js';
 
 const eventConfig = getEventConfig();
 const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
@@ -14,7 +14,6 @@ const { default: sanitizeComment } = await import(`${miloLibs}/utils/sanitizeCom
 const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
 const { default: loadFragment } = await import(`${miloLibs}/blocks/fragment/fragment.js`);
 
-const CAMPAIGN_ID_PATTERN = /^[\w-]{1,128}$/;
 const VALID_REGISTRATION_STATUS = ['registered', 'waitlisted'];
 
 const RULE_OPERATORS = {
@@ -230,19 +229,62 @@ function clearForm(form) {
   });
 }
 
-async function buildErrorMsg(parent, status) {
-  const eventObj = await getEvent(getMetadata('event-id'));
+/**
+ * Resolves full state from event and optionally campaign (when campaign ID in URL).
+ * @param {string} eventId - Event ID
+ * @returns {Promise<{ full: boolean, waitlistEnabled: boolean, usedCampaign: boolean }>}
+ */
+export async function getFullState(eventId) {
+  const eventObj = await getEvent(eventId);
+  let full = false;
+  let waitlistEnabled = false;
+  let usedCampaign = false;
+
+  if (!eventObj.ok) {
+    return { full: false, waitlistEnabled: false, usedCampaign: false };
+  }
+
+  const { isFull, allowWaitlisting, attendeeCount, attendeeLimit } = eventObj.data;
+  full = isFull || (!allowWaitlisting && +attendeeCount >= +attendeeLimit);
+  waitlistEnabled = allowWaitlisting;
+
+  const campaignId = new URLSearchParams(window.location.search).get('campaign');
+  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId)) {
+    const campaignInfo = await getCampaign(eventId, campaignId);
+    if (campaignInfo.ok && campaignInfo.data.attendeeLimit != null) {
+      const { attendeeLimit: campLimit, attendeeCount: campCount, waitlistAttendeeCount } = campaignInfo.data;
+      full = campLimit === campCount
+        || (campLimit > campCount && waitlistAttendeeCount > 0);
+      usedCampaign = true;
+    }
+  }
+
+  return { full, waitlistEnabled, usedCampaign };
+}
+
+export async function buildErrorMsg(parent, status) {
+  const eventId = getMetadata('event-id');
+  const eventObj = await getEvent(eventId);
 
   if (!eventObj.ok) return;
-  const eventInfo = eventObj.data;
-  const errorKeyMap = { 400: eventInfo?.allowWaitlisting === 'true' ? 'event-full-error-msg' : 'event-full-no-waitlist-error-msg' };
+
+  let errorKey = 'rsvp-error-msg';
+  if (status === 400) {
+    const { full, waitlistEnabled, usedCampaign } = await getFullState(eventId);
+    if (full && usedCampaign) {
+      errorKey = waitlistEnabled ? 'campaign-full-error-msg' : 'campaign-full-no-waitlist-error-msg';
+    } else {
+      const eventInfo = eventObj.data;
+      errorKey = eventInfo?.allowWaitlisting === 'true' ? 'event-full-error-msg' : 'event-full-no-waitlist-error-msg';
+    }
+  }
 
   const existingErrors = parent.querySelectorAll('.error');
   if (existingErrors.length) {
     existingErrors.forEach((err) => err.remove());
   }
 
-  const errorMsg = dictionaryManager.getValue(errorKeyMap[status] || 'rsvp-error-msg');
+  const errorMsg = dictionaryManager.getValue(errorKey);
   const error = createTag('p', { class: 'error' }, errorMsg);
   parent.append(error);
   setTimeout(() => {
@@ -304,20 +346,14 @@ function createButton({ type, label }, bp) {
           const { status } = respJson;
 
           if (status === 400) {
-            const eventResp = await getEvent(getMetadata('event-id'));
-            if (eventResp.ok) {
-              const { isFull, allowWaitlisting, attendeeCount, attendeeLimit } = eventResp.data;
-              const eventFull = isFull
-              || (!allowWaitlisting && +attendeeCount >= +attendeeLimit);
-
-              if (eventFull) {
-                if (allowWaitlisting) {
-                  button.textContent = dictionaryManager.getValue('waitlist-cta-text');
-                  button.disabled = false;
-                } else {
-                  button.textContent = dictionaryManager.getValue('event-full-cta-text');
-                  button.disabled = true;
-                }
+            const fullState = await getFullState(getMetadata('event-id'));
+            if (fullState.full) {
+              if (fullState.waitlistEnabled) {
+                button.textContent = dictionaryManager.getValue('waitlist-cta-text');
+                button.disabled = false;
+              } else {
+                button.textContent = dictionaryManager.getValue('event-full-cta-text');
+                button.disabled = true;
               }
             }
 

--- a/event-libs/v1/utils/constances.js
+++ b/event-libs/v1/utils/constances.js
@@ -1,6 +1,7 @@
 export const META_REG = /\[\[(.*?)\]\]/g;
 export const ICON_REG = /@@(.*?)@@/g;
 export const CONDITIONAL_REG = /(\w[\w.=\s-&|"@!]*)\?\(([^)]*(?:\([^)]*\))*[^)]*)\):\(([^)]*(?:\([^)]*\))*[^)]*)\)/;
+export const CAMPAIGN_ID_PATTERN = /^[\w-]{1,128}$/;
 export const SUSI_OPTIONS = {
   dctx_id: {
     stage: 'v:2,s,bg:milo,51364e80-648b-11ef-9bf6-ad6724e2c153',

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -144,7 +144,8 @@ export async function updateRSVPButtonState(rsvpBtn) {
   }
 
   const campaignId = new URLSearchParams(window.location.search).get('campaign');
-  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId)) {
+  const hasImsToken = !!window.adobeIMS?.getAccessToken()?.token;
+  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId) && hasImsToken) {
     const campaignInfo = await getCampaign(getMetadata('event-id'), campaignId);
     if (campaignInfo.ok && campaignInfo.data.attendeeLimit != null) {
       const { attendeeLimit, attendeeCount, waitlistAttendeeCount } = campaignInfo.data;

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -144,8 +144,9 @@ export async function updateRSVPButtonState(rsvpBtn) {
   }
 
   const campaignId = new URLSearchParams(window.location.search).get('campaign');
-  const hasImsToken = !!window.adobeIMS?.getAccessToken()?.token;
-  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId) && hasImsToken) {
+  const profile = BlockMediator.get('imsProfile');
+  const isLoggedInNonGuest = profile && !profile.noProfile && profile.account_type !== 'guest';
+  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId) && isLoggedInNonGuest) {
     const campaignInfo = await getCampaign(getMetadata('event-id'), campaignId);
     if (campaignInfo.ok && campaignInfo.data.attendeeLimit != null) {
       const { attendeeLimit, attendeeCount, waitlistAttendeeCount } = campaignInfo.data;

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -5,9 +5,10 @@ import {
   ALLOWED_EMAIL_DOMAINS,
   FALLBACK_LOCALES,
   CONDITIONAL_REG,
+  CAMPAIGN_ID_PATTERN,
 } from './constances.js';
 import BlockMediator from '../deps/block-mediator.min.js';
-import { getEvent } from './esp-controller.js';
+import { getEvent, getCampaign } from './esp-controller.js';
 import { dictionaryManager } from './dictionary-manager.js';
 import {
   getMetadata,
@@ -140,6 +141,17 @@ export async function updateRSVPButtonState(rsvpBtn) {
       || (!allowWaitlisting && attendeeCount >= attendeeLimit);
     waitlistEnabled = allowWaitlisting;
     BlockMediator.set('eventData', eventInfo.data);
+  }
+
+  const campaignId = new URLSearchParams(window.location.search).get('campaign');
+  if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId)) {
+    const campaignInfo = await getCampaign(getMetadata('event-id'), campaignId);
+    if (campaignInfo.ok && campaignInfo.data.attendeeLimit != null) {
+      const { attendeeLimit, attendeeCount, waitlistAttendeeCount } = campaignInfo.data;
+      const campaignFull = attendeeLimit === attendeeCount
+        || (attendeeLimit > attendeeCount && waitlistAttendeeCount > 0);
+      eventFull = campaignFull;
+    }
   }
 
   const rsvpData = BlockMediator.get('rsvpData');

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -545,4 +545,146 @@ describe('Events Form', () => {
       expect(personalizeForm.calledOnce).to.be.true;
     });
   });
+
+  describe('getFullState and buildErrorMsg (campaign-aware 400)', () => {
+    let sandbox;
+    let originalHref;
+    let getFullState;
+    let buildErrorMsg;
+
+    before(async () => {
+      const module = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      getFullState = module.getFullState;
+      buildErrorMsg = module.buildErrorMsg;
+    });
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      originalHref = window.location.href;
+      window.adobeIMS = window.adobeIMS || { getAccessToken: () => ({ token: 'test-token' }) };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      window.history.replaceState({}, '', originalHref);
+    });
+
+    function stubFetchByUrl(eventResponse, campaignResponse = null) {
+      sandbox.stub(window, 'fetch').callsFake((url) => {
+        if (typeof url === 'string' && url.includes('/campaigns/')) {
+          return Promise.resolve(campaignResponse != null ? campaignResponse : { json: () => ({}), ok: false, status: 404 });
+        }
+        return Promise.resolve(eventResponse);
+      });
+    }
+
+    it('getFullState returns event-based full when no campaign in URL', async () => {
+      stubFetchByUrl({
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      });
+      const state = await getFullState('test-event-id');
+      expect(state.full).to.be.true;
+      expect(state.usedCampaign).to.be.false;
+      expect(state.waitlistEnabled).to.be.false;
+    });
+
+    it('getFullState returns campaign-based full when campaign in URL and campaign full', async () => {
+      window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+      stubFetchByUrl(
+        {
+          json: () => ({
+            isFull: false,
+            allowWaitlisting: true,
+            attendeeCount: 50,
+            attendeeLimit: 100,
+          }),
+          ok: true,
+        },
+        {
+          json: () => ({
+            campaignId: 'camp-1',
+            attendeeLimit: 100,
+            attendeeCount: 100,
+            waitlistAttendeeCount: 0,
+          }),
+          ok: true,
+        },
+      );
+      const state = await getFullState('test-event-id');
+      expect(state.full).to.be.true;
+      expect(state.usedCampaign).to.be.true;
+      expect(state.waitlistEnabled).to.be.true;
+    });
+
+    it('getFullState falls back to event when campaign in URL but getCampaign fails', async () => {
+      window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+      stubFetchByUrl(
+        {
+          json: () => ({
+            isFull: true,
+            allowWaitlisting: false,
+            attendeeCount: 100,
+            attendeeLimit: 100,
+          }),
+          ok: true,
+        },
+        { json: () => ({ message: 'Not found' }), ok: false, status: 404 },
+      );
+      const state = await getFullState('test-event-id');
+      expect(state.full).to.be.true;
+      expect(state.usedCampaign).to.be.false;
+    });
+
+    it('buildErrorMsg uses campaign-full error key when status 400 and campaign full', async () => {
+      window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+      stubFetchByUrl(
+        {
+          json: () => ({
+            isFull: false,
+            allowWaitlisting: true,
+            attendeeCount: 50,
+            attendeeLimit: 100,
+          }),
+          ok: true,
+        },
+        {
+          json: () => ({
+            campaignId: 'camp-1',
+            attendeeLimit: 100,
+            attendeeCount: 100,
+            waitlistAttendeeCount: 0,
+          }),
+          ok: true,
+        },
+      );
+      const form = document.createElement('form');
+      await buildErrorMsg(form, 400);
+      const errorEl = form.querySelector('.error');
+      expect(errorEl).to.not.be.null;
+      expect(errorEl.textContent).to.equal('campaign-full-error-msg');
+    });
+
+    it('buildErrorMsg uses event-full error key when status 400 and no campaign in URL', async () => {
+      stubFetchByUrl({
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      });
+      const form = document.createElement('form');
+      await buildErrorMsg(form, 400);
+      const errorEl = form.querySelector('.error');
+      expect(errorEl).to.not.be.null;
+      expect(errorEl.textContent).to.equal('event-full-no-waitlist-error-msg');
+    });
+  });
 });

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -14,6 +14,7 @@ import {
 const {
   decorateEvent,
   updateAnalyticTag,
+  updateRSVPButtonState,
   signIn,
   validatePageAndRedirect,
   updatePictureElement,
@@ -109,6 +110,199 @@ describe('updateAnalyticTag', () => {
     const element = document.createElement('div');
     updateAnalyticTag(element, 'new text');
     expect(element.getAttribute('daa-ll')).to.equal('new text|Create Now Chicago 2024 Test');
+  });
+});
+
+describe('updateRSVPButtonState', () => {
+  let sandbox;
+  let rsvpBtn;
+  let originalHref;
+
+  function stubFetchByUrl(sandbox, { eventResponse, campaignResponse }) {
+    sandbox.stub(window, 'fetch').callsFake((url) => {
+      if (typeof url === 'string' && url.includes('/campaigns/')) {
+        return Promise.resolve(campaignResponse != null ? campaignResponse : { json: () => ({}), ok: false, status: 404 });
+      }
+      return Promise.resolve(eventResponse);
+    });
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    originalHref = window.location.href;
+    setMetadata('event-id', 'ev-1');
+    BlockMediator.set('rsvpData', null);
+    window.adobeIMS = window.adobeIMS || { getAccessToken: () => ({ token: 'test-token' }) };
+    const el = document.createElement('a');
+    el.href = '#rsvp-form';
+    el.dataset.modalHash = '#rsvp-form';
+    el.textContent = 'Register';
+    rsvpBtn = { el, originalText: 'Register' };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    window.history.replaceState({}, '', originalHref);
+  });
+
+  it('uses event capacity when no campaign in URL', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('uses event capacity when campaign in URL but getCampaign fails', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+      campaignResponse: { json: () => ({ message: 'Not found' }), ok: false, status: 404 },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+  });
+
+  it('uses campaign capacity when campaign in URL and campaign has capacity', async () => {
+    setMetadata('allow-wait-listing', 'true');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: true,
+          attendeeCount: 50,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+      campaignResponse: {
+        json: () => ({
+          campaignId: 'camp-1',
+          attendeeLimit: 100,
+          attendeeCount: 50,
+          waitlistAttendeeCount: 0,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+  });
+
+  it('shows toWaitlist when campaign in URL and campaign full and waitlist enabled', async () => {
+    setMetadata('allow-wait-listing', 'true');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: true,
+          attendeeCount: 50,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+      campaignResponse: {
+        json: () => ({
+          campaignId: 'camp-1',
+          attendeeLimit: 100,
+          attendeeCount: 100,
+          waitlistAttendeeCount: 0,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('shows eventClosed when campaign in URL and campaign full and waitlist disabled', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: false,
+          attendeeCount: 50,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+      campaignResponse: {
+        json: () => ({
+          campaignId: 'camp-1',
+          attendeeLimit: 100,
+          attendeeCount: 100,
+          waitlistAttendeeCount: 0,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('falls back to event capacity when campaign in URL but campaign has no attendeeLimit', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+      campaignResponse: {
+        json: () => ({ campaignId: 'camp-1' }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+  });
+
+  it('ignores invalid campaign ID in URL', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=<>`);
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
   });
 });
 

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -132,6 +132,7 @@ describe('updateRSVPButtonState', () => {
     originalHref = window.location.href;
     setMetadata('event-id', 'ev-1');
     BlockMediator.set('rsvpData', null);
+    BlockMediator.set('imsProfile', { account_type: 'type3' });
     window.adobeIMS = window.adobeIMS || { getAccessToken: () => ({ token: 'test-token' }) };
     const el = document.createElement('a');
     el.href = '#rsvp-form';
@@ -305,10 +306,10 @@ describe('updateRSVPButtonState', () => {
     expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
   });
 
-  it('uses event capacity when campaign in URL but no IMS token (avoids 403)', async () => {
+  it('uses event capacity when campaign in URL but user is guest (avoids 403)', async () => {
     setMetadata('allow-wait-listing', 'false');
     window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
-    window.adobeIMS = { getAccessToken: () => ({}) };
+    BlockMediator.set('imsProfile', { account_type: 'guest' });
     let campaignUrlCalled = false;
     sandbox.stub(window, 'fetch').callsFake((url) => {
       if (typeof url === 'string' && url.includes('/campaigns/')) {

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -304,6 +304,31 @@ describe('updateRSVPButtonState', () => {
     await updateRSVPButtonState(rsvpBtn);
     expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
   });
+
+  it('uses event capacity when campaign in URL but no IMS token (avoids 403)', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    window.history.replaceState({}, '', `${originalHref.split('?')[0]}?campaign=camp-1`);
+    window.adobeIMS = { getAccessToken: () => ({}) };
+    let campaignUrlCalled = false;
+    sandbox.stub(window, 'fetch').callsFake((url) => {
+      if (typeof url === 'string' && url.includes('/campaigns/')) {
+        campaignUrlCalled = true;
+        return Promise.resolve({ json: () => ({}), ok: false, status: 404 });
+      }
+      return Promise.resolve({
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      });
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+    expect(campaignUrlCalled).to.be.false;
+  });
 });
 
 describe('signIn', () => {


### PR DESCRIPTION
## Summary
- **RSVP button**: Uses campaign capacity when a valid `?campaign=...` is in the URL (same full rule as `getAndCreateAndAddAttendee`). Falls back to event capacity when no campaign, invalid ID, or `getCampaign` fails.
- **Form 400 handling**: When submit returns 400 and URL has campaign, error message uses `campaign-full-error-msg` / `campaign-full-no-waitlist-error-msg` and submit button is updated to waitlist or event-full (and disabled when no waitlist) so copy and UI stay consistent when the campaign is full but the event is not.

## Changes
- `constances.js`: Add and export `CAMPAIGN_ID_PATTERN`.
- `decorate.js`: Import `getCampaign`, `CAMPAIGN_ID_PATTERN`; in `updateRSVPButtonState` read campaign from URL and apply campaign capacity when valid.
- `events-form.js`: Import `getCampaign`; add `getFullState(eventId)`; `buildErrorMsg` and submit handler use campaign-aware full for 400; export `getFullState` and `buildErrorMsg` for tests.
- `events-form.js`: Use `CAMPAIGN_ID_PATTERN` from constances (remove local def).
- Docs: Document new campaign-full error keys and when they are used.
- Tests: `updateRSVPButtonState` with/without campaign; `getFullState` and `buildErrorMsg` for 400 with campaign.

Made with [Cursor](https://cursor.com)