### PR TITLE
fix(profile-cards): restore social icons for metadata-driven speakers

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -85,12 +85,27 @@ async function decorateSocialIcons(cardContainer, socialLinks) {
 
   const svgEls = await getSVGsfromFile(svgPath, SUPPORTED_PLATFORMS);
   if (!svgEls || svgEls.length === 0) return;
-  socialLinks.forEach((link) => {
-    if (!link || !(link instanceof HTMLAnchorElement)) return;
+
+  (socialLinks || []).forEach((entry) => {
+    let href = '';
+    let sourceAnchor = null;
+    let metadataEntry = null;
+
+    if (entry instanceof HTMLAnchorElement) {
+      sourceAnchor = entry;
+      href = entry.href;
+    } else if (typeof entry === 'string' && entry.trim()) {
+      href = entry.trim();
+    } else if (entry && typeof entry === 'object' && typeof entry.link === 'string' && entry.link.trim()) {
+      metadataEntry = entry;
+      href = entry.link.trim();
+    } else {
+      return;
+    }
 
     let platform = 'web'; // Default fallback
     try {
-      const url = new URL(link.href);
+      const url = new URL(href);
       const hostname = url.hostname.toLowerCase();
 
       // Find the platform by testing against regex patterns
@@ -108,10 +123,21 @@ async function decorateSocialIcons(cardContainer, socialLinks) {
     const li = createTag('li', { class: 'card-social-icon' });
     const icon = createSocialIcon(svgEl.svg, platform);
 
-    const a = link.cloneNode(true);
-    a.setAttribute('target', '_blank');
-    a.setAttribute('rel', 'noopener noreferrer');
-    a.textContent = '';
+    let a;
+    if (sourceAnchor) {
+      a = sourceAnchor.cloneNode(true);
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+      a.textContent = '';
+    } else {
+      const ariaLabel = metadataEntry?.serviceName || platform;
+      a = createTag('a', {
+        href,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        'aria-label': ariaLabel,
+      });
+    }
 
     a.append(icon);
     li.append(a);
@@ -148,7 +174,7 @@ function decorateContent(cardContainer, data) {
 
   contentContainer.append(textContainer);
 
-  decorateSocialIcons(contentContainer, data.socialLinks);
+  decorateSocialIcons(contentContainer, data.socialLinks || data.socialMedia || []);
 
   cardContainer.append(contentContainer);
 }

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -5,6 +5,14 @@ import init, { createSocialIcon } from '../../../../event-libs/v1/blocks/profile
 const head = await readFile({ path: './mocks/head.html' });
 const body = await readFile({ path: './mocks/default.html' });
 
+async function waitForSocialIcons(el, timeoutMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (el.querySelector('.card-social-icons a')) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
 describe('Profile Cards Module', () => {
   describe('init', () => {
     beforeEach(() => {
@@ -43,6 +51,15 @@ describe('Profile Cards Module', () => {
       expect(el).to.not.be.null;
       expect(hostCards).to.have.lengthOf(1);
       expect(el.classList.contains('single')).to.be.true;
+    });
+
+    it('should render social icons for metadata-driven speakers', async () => {
+      const el = document.querySelector('#speakers-cards');
+      init(el);
+      await waitForSocialIcons(el);
+
+      const socialAnchors = el.querySelectorAll('.card-social-icons a');
+      expect(socialAnchors.length).to.be.greaterThan(0);
     });
 
     it('show remove block if no related profile types found', () => {


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-191275

## Summary
Metadata-driven profile cards stopped showing social icons after `decorateSocialIcons` was changed to only accept `HTMLAnchorElement` (so static authoring could `cloneNode` anchors and preserve `aria-label` and other attributes). ESP still provides `socialLinks` as `{ link, serviceName }` objects, so every entry was skipped.

## Changes
- **`decorateSocialIcons`**: Normalize each entry — clone `HTMLAnchorElement` as before; for metadata objects or string URLs, build anchors with `createTag`, using `serviceName` or detected platform for `aria-label`.
- **`decorateContent`**: Restore `data.socialLinks || data.socialMedia || []`.
- **Tests**: Async test on metadata fixture that waits for SVG load before asserting `.card-social-icons` links exist.

## Test plan
- [x] `npx wtr test/unit/blocks/profile-cards/profile-cards.test.js --node-resolve --port=2000`

Made with [Cursor](https://cursor.com)