### PR TITLE
hotfix(chrono-box): skip loadFragment when pathToFragment is empty or missing

### DIFF
--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -238,18 +238,32 @@ export default async function init(el) {
     worker.onmessage = (event) => {
       clearTimeout(timeout);
 
-      const { pathToFragment } = event.data;
+      const rawPath = event.data?.pathToFragment;
+      const fragmentPath = typeof rawPath === 'string' ? rawPath.trim() : '';
+
       const { prefix } = getLocale(getConfig().locales);
       el.style.height = `${el.clientHeight}px`;
 
       el.innerHTML = '';
 
-      const a = createTag('a', { href: `${pathToFragment.startsWith('/') ? prefix : ''}${pathToFragment}` }, '', { parent: el });
+      // href="" resolves to the current page; loadFragment would fetch and inject the full
+      // document (including nested chrono-box blocks), causing unbounded recursion.
+      if (!fragmentPath) {
+        el.removeAttribute('style');
+        if (worker._blobUrl) {
+          URL.revokeObjectURL(worker._blobUrl);
+          worker._blobUrl = null;
+        }
+        resolve();
+        return;
+      }
+
+      const a = createTag('a', { href: `${fragmentPath.startsWith('/') ? prefix : ''}${fragmentPath}` }, '', { parent: el });
 
       loadFragment(a).then(() => {
         el.removeAttribute('style');
       }).catch((error) => {
-        window.lana?.log(`Error loading fragment ${pathToFragment}: ${error.message}`);
+        window.lana?.log(`Error loading fragment ${fragmentPath}: ${error.message}`);
         el.removeAttribute('style');
         el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';
         el.classList.add('error');


### PR DESCRIPTION
## Summary
Schedules can use a final row with `pathToFragment: ""` (or omit the property) to clear timed content after `toggleTime`. Previously chrono-box built `<a href="">`, which resolves to the **current document**. Milo `loadFragment` then fetched and injected the full page, which could include another chrono-box and cause unbounded recursion / repeated reloads.

## Changes
- Normalize `pathToFragment` as a trimmed string; treat missing/non-string as empty.
- When empty: clear the block (existing `innerHTML = ''`), remove the fixed height, revoke the worker blob URL if present, and **do not** call `loadFragment`.

## Testing
- `npx eslint event-libs/v1/blocks/chrono-box/chrono-box.js`
- `npx wtr test/unit/blocks/chrono-box/chrono-box.test.js --node-resolve --port=2000`

Made with [Cursor](https://cursor.com)