### PR TITLE
fix(chrono-box): modal deeplink after scheduled fragment

### DIFF
--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -254,11 +254,49 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
   return worker;
 }
 
+function requestAnimationFramePromise() {
+  return new Promise((r) => {
+    requestAnimationFrame(r);
+  });
+}
+
+/**
+ * After fragment load and height unlock: wait for layout, then scroll to the page hash.
+ * Bounded rAF retry so ids from async nested blocks can appear before scrolling.
+ * @param {(hash: string) => void} scrollToHashedElement
+ */
+async function scrollToHashAfterFragmentLayout(scrollToHashedElement) {
+  const hash = window.location.hash;
+  if (!hash || hash.includes('=')) return;
+
+  await requestAnimationFramePromise();
+  await requestAnimationFramePromise();
+
+  let id = '';
+  try {
+    id = decodeURIComponent(hash.slice(1));
+  } catch {
+    id = hash.slice(1);
+  }
+
+  const maxAttempts = 12;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (!id || document.getElementById(id)) {
+      scrollToHashedElement(hash);
+      return;
+    }
+    await requestAnimationFramePromise();
+  }
+  scrollToHashedElement(hash);
+}
+
 export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  const [{ default: loadFragment }, { createTag, getLocale, getConfig }] = await Promise.all([
+  const [{ default: loadFragment }, {
+    createTag, getLocale, getConfig, scrollToHashedElement,
+  }] = await Promise.all([
     import(`${miloLibs}/blocks/fragment/fragment.js`),
     import(`${miloLibs}/utils/utils.js`),
   ]);
@@ -369,21 +407,30 @@ export default async function init(el) {
 
       ensureChronoBoxReparentObserver(el);
 
-      loadFragment(a).then(() => {
-        el.removeAttribute('style');
-      }).catch((error) => {
-        window.lana?.log(`Error loading fragment ${fragmentPath}: ${error.message}`);
-        el.removeAttribute('style');
-        el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';
-        el.classList.add('error');
-      });
-
       if (worker._blobUrl) {
         URL.revokeObjectURL(worker._blobUrl);
         worker._blobUrl = null;
       }
 
-      resolve();
+      loadFragment(a)
+        .then(async () => {
+          el.removeAttribute('style');
+          if (typeof scrollToHashedElement === 'function') {
+            try {
+              await scrollToHashAfterFragmentLayout(scrollToHashedElement);
+            } catch (error) {
+              window.lana?.log(`chrono-box hash scroll: ${error.message}`);
+            }
+          }
+          resolve();
+        })
+        .catch((error) => {
+          window.lana?.log(`Error loading fragment ${fragmentPath}: ${error.message}`);
+          el.removeAttribute('style');
+          el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';
+          el.classList.add('error');
+          resolve();
+        });
     };
   });
 }

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -260,43 +260,71 @@ function requestAnimationFramePromise() {
   });
 }
 
-/**
- * After fragment load and height unlock: wait for layout, then scroll to the page hash.
- * Bounded rAF retry so ids from async nested blocks can appear before scrolling.
- * @param {(hash: string) => void} scrollToHashedElement
- */
-async function scrollToHashAfterFragmentLayout(scrollToHashedElement) {
-  const hash = window.location.hash;
-  if (!hash || hash.includes('=')) return;
+function anchorWithModalHashExists(hash) {
+  return Array.from(document.querySelectorAll('a[data-modal-hash]')).some(
+    (a) => a.getAttribute('data-modal-hash') === hash,
+  );
+}
 
-  await requestAnimationFramePromise();
-  await requestAnimationFramePromise();
-
-  let id = '';
+function modalDialogForHashIsOpen(hash) {
+  if (!hash || hash.length < 2) return false;
+  let modalId;
   try {
-    id = decodeURIComponent(hash.slice(1));
+    modalId = decodeURIComponent(hash.slice(1));
   } catch {
-    id = hash.slice(1);
+    modalId = hash.slice(1);
   }
+  const existing = document.getElementById(modalId);
+  return Boolean(existing?.classList.contains('dialog-modal'));
+}
+
+/**
+ * Collapse duplicate `modal:open` in the same burst (Milo nested loadArea + chrono-box + extra worker ticks).
+ * Keep the window short so closing the modal and a quick fragment retry can still reopen within a few hundred ms.
+ */
+let chronoBoxLastModalOpenDispatch = { hash: '', at: 0 };
+const CHRONO_BOX_MODAL_OPEN_DEDUPE_MS = 350;
+
+function dispatchModalOpenOnceForHash(hash) {
+  if (!hash) return;
+  if (modalDialogForHashIsOpen(hash)) return;
+
+  const now = Date.now();
+  const { hash: prev, at } = chronoBoxLastModalOpenDispatch;
+  if (hash === prev && now - at < CHRONO_BOX_MODAL_OPEN_DEDUPE_MS) return;
+
+  chronoBoxLastModalOpenDispatch = { hash, at: now };
+  window.dispatchEvent(new CustomEvent('modal:open', { bubbles: true, detail: { hash } }));
+}
+
+/**
+ * Re-run Milo modal opening for the current URL hash after scheduled fragment content is in the DOM.
+ * Milo listens on `window` for `modal:open` (see utils initModalEventListener). Optional rAF deferral
+ * and bounded polling give RSVP / async blocks time to expose `a[data-modal-hash]`.
+ */
+async function openModalFromPageHashAfterFragment() {
+  const hash = window.location.hash;
+  if (!hash) return;
+
+  await requestAnimationFramePromise();
+  await requestAnimationFramePromise();
 
   const maxAttempts = 12;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    if (!id || document.getElementById(id)) {
-      scrollToHashedElement(hash);
+    if (anchorWithModalHashExists(hash)) {
+      dispatchModalOpenOnceForHash(hash);
       return;
     }
     await requestAnimationFramePromise();
   }
-  scrollToHashedElement(hash);
+  dispatchModalOpenOnceForHash(hash);
 }
 
 export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  const [{ default: loadFragment }, {
-    createTag, getLocale, getConfig, scrollToHashedElement,
-  }] = await Promise.all([
+  const [{ default: loadFragment }, { createTag, getLocale, getConfig }] = await Promise.all([
     import(`${miloLibs}/blocks/fragment/fragment.js`),
     import(`${miloLibs}/utils/utils.js`),
   ]);
@@ -415,12 +443,10 @@ export default async function init(el) {
       loadFragment(a)
         .then(async () => {
           el.removeAttribute('style');
-          if (typeof scrollToHashedElement === 'function') {
-            try {
-              await scrollToHashAfterFragmentLayout(scrollToHashedElement);
-            } catch (error) {
-              window.lana?.log(`chrono-box hash scroll: ${error.message}`);
-            }
+          try {
+            await openModalFromPageHashAfterFragment();
+          } catch (error) {
+            window.lana?.log(`chrono-box modal hash: ${error.message}`);
           }
           resolve();
         })


### PR DESCRIPTION
## Summary
Chrono-box loads timed fragments via the timing worker and Milo `loadFragment`. URL hash modal deep links were unreliable after injection; this wires an explicit `modal:open` after each successful fragment load and aligns block `init` resolution with `loadFragment` when a path is present.

## Behavior
- **Non-empty `pathToFragment`:** `init` Promise resolves only after `loadFragment` completes (success or error), then runs modal hash handling. Does not block the main thread (async only); may defer Milo `loadArea` completion for this block until the first fragment load finishes.
- **Empty / missing `pathToFragment`:** No `loadFragment`; `resolve()` runs immediately in the worker handler (avoids `href=""` recursion). Chrono-box body is cleared until a later worker message supplies a path. No `modal:open` from this path on that step.
- **Modal deep link:** After height unlock, two rAFs + up to 12 frames polling for `a[data-modal-hash]` matching the full hash, then `dispatchModalOpenOnceForHash`: skip if `#id` already has `.dialog-modal`; skip duplicate same-hash `modal:open` within 350ms (Milo + duplicate worker ticks). Fallback dispatch after poll cap so Milo `findDetails` can still run if markup differs slightly.
- **Click handler:** Existing `replaceState` + `location.hash` for `data-modal-hash` when hash already matches is unchanged.

## Regressions / tradeoffs
- **Non-modal hash scrolling** is not re-invoked from chrono-box after fragment load (earlier scroll helper was removed in favor of modal flow). Nested Milo `loadArea` may still scroll per Milo.
- **Dedupe window:** Very unlikely: user closes the modal and a new fragment swap should reopen within 350ms of our last dispatch—second open could be skipped; widen window if reported.
- **Concurrent worker messages** before the prior `loadFragment` finishes could still race on the same host element (pre-existing); not addressed here.

## Testing
- `npx eslint event-libs/v1/blocks/chrono-box/chrono-box.js`
- `npx wtr test/unit/blocks/chrono-box/chrono-box.test.js`

## Manual
Load with a modal hash while the scheduled fragment contains the RSVP `data-modal-hash` link; confirm single modal open and behavior after schedule-driven fragment swaps.