### PR TITLE
[Fix] Remove forced text align and let dir='rtl' function as intended

### DIFF
--- a/event-libs/v1/blocks/event-subscription-form/event-subscription-form.css
+++ b/event-libs/v1/blocks/event-subscription-form/event-subscription-form.css
@@ -178,7 +178,6 @@
     h2 {
       font-size: 2.625rem;
       line-height: 1;
-      text-align: left;
       color: rgb(44 44 44);
       margin: 0;
       font-weight: 400;


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: https://jira.corp.adobe.com/browse/MWPW-191635

Test URLs:
- Before: https://dev--event-libs--adobecom.aem.live/?martech=off
- After: https://remove-forced-sub-form-text-align--event-libs--adobecom.aem.live/?martech=off
