### PR TITLE
fix(chrono-box): only remove reparented nodes outside the host

### DIFF
--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -60,7 +60,8 @@ function disconnectReparentObserverAndRemoveOrphans(chronoBoxEl) {
   if (!(roots instanceof Set)) return;
   roots.forEach((node) => {
     try {
-      if (node?.isConnected) node.remove();
+      // Only detach nodes Milo moved outside the host; innerHTML handles the rest on swap.
+      if (node?.isConnected && !chronoBoxEl.contains(node)) node.remove();
     } catch (error) {
       window.lana?.log(`chrono-box reparent cleanup: ${error.message}`);
     }

--- a/test/unit/blocks/chrono-box/chrono-box.test.js
+++ b/test/unit/blocks/chrono-box/chrono-box.test.js
@@ -94,5 +94,31 @@ describe('Chrono Box', () => {
       cleanupChronoBoxOutboundNodes(host);
       expect(main.contains(section)).to.equal(false);
     });
+
+    it('does not remove nodes that were only moved within chrono-box (reorder)', async () => {
+      const {
+        cleanupChronoBoxOutboundNodes,
+        ensureChronoBoxReparentObserver,
+      } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+
+      const host = document.createElement('div');
+      host.dataset.chronoBoxInstance = 'reorder-test';
+      document.body.append(host);
+
+      const inner = document.createElement('div');
+      const section = document.createElement('section');
+      host.append(inner);
+      inner.append(section);
+      expect(inner.contains(section)).to.equal(true);
+
+      ensureChronoBoxReparentObserver(host);
+      host.append(section);
+
+      expect(host.contains(section)).to.equal(true);
+      expect(inner.contains(section)).to.equal(false);
+
+      cleanupChronoBoxOutboundNodes(host);
+      expect(host.contains(section)).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Tightens chrono-box reparent cleanup so we only `remove()` nodes that Milo (or similar) moved **outside** the chrono-box host. Nodes that only moved **within** the subtree are still cleared on the next swap via `innerHTML`; skipping explicit `remove()` avoids redundant teardown and keeps behavior aligned with clearing the slot in one shot.

## Changes
- Guard orphan removal with `!chronoBoxEl.contains(node)` (still require `isConnected`).
- Unit test: in-host reorder must not be removed by `cleanupChronoBoxOutboundNodes`.

## Testing
- `npx wtr test/unit/blocks/chrono-box/chrono-box.test.js --node-resolve --port=2000`

Made with [Cursor](https://cursor.com)