### PR TITLE
T3.26-15 Minor Release

### DIFF
--- a/.cursor/skills/post-hotfix-branch-sync/SKILL.md
+++ b/.cursor/skills/post-hotfix-branch-sync/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: post-hotfix-branch-sync
+description: >-
+  Syncs dev and stage with main after a production hotfix landed only on main.
+  Use when the user mentions hotfix, main ahead of stage/dev, back-merge,
+  release branch sync, or post-hotfix git workflow (feature → dev → stage →
+  main pipeline).
+---
+
+# Post-hotfix branch sync (main → stage → dev)
+
+## Context
+
+Normal flow: `feature/*` → `dev` → `stage` → `main`.
+
+A **hotfix** is branched from `main` and merged straight to `main`, so `main` contains commit(s) that `stage` and `dev` never saw. Until you back-merge, lower environments drift and the next promotion PRs can be painful (false conflicts, missing fixes, or duplicate cherry-picks).
+
+**Goal:** Bring the hotfix into `stage` and `dev` with ordinary merge commits so history stays understandable and the normal promotion path works again.
+
+## Strategy (default)
+
+Treat **`main` as source of truth** for what is already in production. Propagate that state downward with **merge commits** (not rebase on shared branches).
+
+### Steps (direct push allowed)
+
+1. **Fetch and update local refs**
+   ```bash
+   git fetch origin
+   git checkout main && git pull origin main
+   ```
+
+2. **Back-merge `main` into `stage`**
+   ```bash
+   git checkout stage && git pull origin stage
+   git merge origin/main -m "chore: sync stage with main after hotfix"
+   git push origin stage
+   ```
+
+3. **Back-merge into `dev`**
+   - **Preferred if `dev` is always ahead of or aligned with `stage`:** merge updated `stage` so `dev` tracks what was synced to staging.
+     ```bash
+     git checkout dev && git pull origin dev
+     git merge origin/stage -m "chore: sync dev with stage after main hotfix"
+     git push origin dev
+     ```
+   - **Use if `dev` has diverged from `stage` and you must guarantee the hotfix lands regardless:** merge `main` into `dev` (same pattern as step 2 with `dev` and `origin/main`). Resolves “hotfix missing on dev” even when `stage` is not yet merged into `dev` for other reasons.
+
+4. **Verify**
+   - `git log --oneline -5 origin/main origin/stage origin/dev` — hotfix commit(s) appear on all three tips’ ancestry.
+   - Run CI / smoke on `stage` (and `dev` if your team gates there) after push.
+
+### Steps (protected branches — PRs only)
+
+1. From latest `main`, create **`sync/main-to-stage-<date>`** (or use GitHub “compare” `main` → `stage`).
+2. Open PR **base: `stage` ← compare: `main`**. Title e.g. `chore: sync stage with main after hotfix`. Merge when green.
+3. Open PR **base: `dev` ← compare: `stage`** (after step 2 merged), or **base: `dev` ← `main`** if your policy requires identical back-merge from production.
+
+Do not squash the sync PR if you want a clear merge bubble in history; squash is optional per team convention.
+
+## What not to do
+
+- **Do not `git rebase main` on shared `dev` or `stage`** — rewrites published history and breaks collaborators.
+- **Do not cherry-pick the hotfix again** onto `dev`/`stage` if the same change is already on `main` — you risk duplicate commits or divergent fixes unless you know exactly what you are doing.
+- **Do not only update `stage`** and assume `dev` will pick it up later — explicitly sync `dev` unless your automation always merges `stage` → `dev`.
+
+## Conflicts
+
+If merge conflicts appear:
+
+1. Prefer resolving by **keeping production behavior** from `main` for files touched by the hotfix, then re-applying any legitimate `dev`-only changes.
+2. After resolving, run tests and complete the merge; document anything unusual in the merge commit message or PR.
+
+## Quick checklist
+
+- [ ] Hotfix is merged to `main` and tagged/released as your process requires.
+- [ ] `stage` merged from `main` and pushed (or PR merged).
+- [ ] `dev` merged from `stage` or `main` and pushed (or PR merged).
+- [ ] CI / sanity check on updated branches.
+
+## When the agent applies this skill
+
+If the user asks to “sync after a hotfix,” “back-merge main,” or fix `main` being ahead of `dev`/`stage`, guide them through the steps above, adapt branch names if their repo differs, and prefer PR wording if they use protected branches.

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -60,7 +60,8 @@ function disconnectReparentObserverAndRemoveOrphans(chronoBoxEl) {
   if (!(roots instanceof Set)) return;
   roots.forEach((node) => {
     try {
-      if (node?.isConnected) node.remove();
+      // Only detach nodes Milo moved outside the host; innerHTML handles the rest on swap.
+      if (node?.isConnected && !chronoBoxEl.contains(node)) node.remove();
     } catch (error) {
       window.lana?.log(`chrono-box reparent cleanup: ${error.message}`);
     }

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -254,11 +254,49 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
   return worker;
 }
 
+function requestAnimationFramePromise() {
+  return new Promise((r) => {
+    requestAnimationFrame(r);
+  });
+}
+
+/**
+ * After fragment load and height unlock: wait for layout, then scroll to the page hash.
+ * Bounded rAF retry so ids from async nested blocks can appear before scrolling.
+ * @param {(hash: string) => void} scrollToHashedElement
+ */
+async function scrollToHashAfterFragmentLayout(scrollToHashedElement) {
+  const hash = window.location.hash;
+  if (!hash || hash.includes('=')) return;
+
+  await requestAnimationFramePromise();
+  await requestAnimationFramePromise();
+
+  let id = '';
+  try {
+    id = decodeURIComponent(hash.slice(1));
+  } catch {
+    id = hash.slice(1);
+  }
+
+  const maxAttempts = 12;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (!id || document.getElementById(id)) {
+      scrollToHashedElement(hash);
+      return;
+    }
+    await requestAnimationFramePromise();
+  }
+  scrollToHashedElement(hash);
+}
+
 export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  const [{ default: loadFragment }, { createTag, getLocale, getConfig }] = await Promise.all([
+  const [{ default: loadFragment }, {
+    createTag, getLocale, getConfig, scrollToHashedElement,
+  }] = await Promise.all([
     import(`${miloLibs}/blocks/fragment/fragment.js`),
     import(`${miloLibs}/utils/utils.js`),
   ]);
@@ -369,21 +407,30 @@ export default async function init(el) {
 
       ensureChronoBoxReparentObserver(el);
 
-      loadFragment(a).then(() => {
-        el.removeAttribute('style');
-      }).catch((error) => {
-        window.lana?.log(`Error loading fragment ${fragmentPath}: ${error.message}`);
-        el.removeAttribute('style');
-        el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';
-        el.classList.add('error');
-      });
-
       if (worker._blobUrl) {
         URL.revokeObjectURL(worker._blobUrl);
         worker._blobUrl = null;
       }
 
-      resolve();
+      loadFragment(a)
+        .then(async () => {
+          el.removeAttribute('style');
+          if (typeof scrollToHashedElement === 'function') {
+            try {
+              await scrollToHashAfterFragmentLayout(scrollToHashedElement);
+            } catch (error) {
+              window.lana?.log(`chrono-box hash scroll: ${error.message}`);
+            }
+          }
+          resolve();
+        })
+        .catch((error) => {
+          window.lana?.log(`Error loading fragment ${fragmentPath}: ${error.message}`);
+          el.removeAttribute('style');
+          el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';
+          el.classList.add('error');
+          resolve();
+        });
     };
   });
 }

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -1,20 +1,5 @@
 import { getMetadata, getEventConfig, LIBS } from '../../utils/utils.js';
 
-/** `?chronoDebug=1` or `true` — logs worker handoff and fragment loads. */
-function chronoDebugEnabled() {
-  try {
-    const v = new URLSearchParams(window.location.search).get('chronoDebug');
-    return v === '1' || v === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function chronoDebugLog(...args) {
-  if (!chronoDebugEnabled()) return;
-  console.log('[chrono-box]', new Date().toISOString(), ...args);
-}
-
 /** @param {HTMLElement} host */
 function ensureReparentSet(host) {
   if (!host._chronoBoxReparentedRoots) {
@@ -73,19 +58,14 @@ function disconnectReparentObserverAndRemoveOrphans(chronoBoxEl) {
   }
   const roots = chronoBoxEl._chronoBoxReparentedRoots;
   if (!(roots instanceof Set)) return;
-  let removed = 0;
   roots.forEach((node) => {
     try {
-      if (node?.isConnected) {
-        node.remove();
-        removed += 1;
-      }
+      if (node?.isConnected) node.remove();
     } catch (error) {
       window.lana?.log(`chrono-box reparent cleanup: ${error.message}`);
     }
   });
   roots.clear();
-  chronoDebugLog('reparent cleanup', { removedStillConnected: removed });
 }
 
 /**
@@ -127,17 +107,6 @@ export function cleanupChronoBoxOutboundNodes(chronoBoxEl) {
       node.remove();
     });
   }
-}
-
-function summarizeScheduleForDebug(schedule) {
-  if (!Array.isArray(schedule)) return schedule;
-  return schedule.map((row, i) => ({
-    i,
-    pathToFragment: row.pathToFragment,
-    toggleTime: row.toggleTime,
-    hasMobileRider: Boolean(row.mobileRider),
-    hasMetadata: Boolean(row.metadata?.length),
-  }));
 }
 
 function buildScheduleDoubleLinkedList(entries) {
@@ -252,15 +221,6 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
     avoidStreamEndFlag,
   } : null;
 
-  chronoDebugLog('worker init', {
-    workerUrl,
-    usesBlobWorker: Boolean(blobUrl),
-    tabId,
-    testing,
-    pluginsLoaded: Array.from(plugins.keys()),
-    scheduleRows: summarizeScheduleForDebug(schedule),
-  });
-
   const pluginStates = Object.fromEntries(
     Array.from(plugins.entries())
       .map(([n, p]) => [n, { type: n, data: p.getAll ? p.getAll() : p }]),
@@ -288,12 +248,7 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
   }
 
   worker.addEventListener('error', (event) => {
-    chronoDebugLog('worker error event', {
-      message: event.message,
-      filename: event.filename,
-      lineno: event.lineno,
-      colno: event.colno,
-    });
+    window.lana?.log(`chrono-box worker error: ${event.message || 'unknown'}`);
   });
 
   return worker;
@@ -337,13 +292,6 @@ export default async function init(el) {
     el.remove();
     return Promise.resolve();
   }
-
-  chronoDebugLog('schedule resolved', {
-    source: staticSchedule ? 'block' : 'metadata',
-    scheduleId: scheduleId || null,
-    rowCount: Array.isArray(thisSchedule) ? thisSchedule.length : null,
-    scheduleSummary: summarizeScheduleForDebug(thisSchedule),
-  });
 
   el.setAttribute('data-tf-schedule-json', JSON.stringify(thisSchedule));
   el.dataset.chronoBoxInstance = crypto.randomUUID();
@@ -395,8 +343,6 @@ export default async function init(el) {
     worker.onmessage = (event) => {
       clearTimeout(timeout);
 
-      chronoDebugLog('worker message', event.data);
-
       const { pathToFragment } = event.data;
       const { prefix } = getLocale(getConfig().locales);
       el.style.height = `${el.clientHeight}px`;
@@ -410,10 +356,8 @@ export default async function init(el) {
       ensureChronoBoxReparentObserver(el);
 
       loadFragment(a).then(() => {
-        chronoDebugLog('fragment loaded', { pathToFragment });
         el.removeAttribute('style');
       }).catch((error) => {
-        chronoDebugLog('fragment load failed', { pathToFragment, error: error.message });
         window.lana?.log(`Error loading fragment ${pathToFragment}: ${error.message}`);
         el.removeAttribute('style');
         el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -1,5 +1,145 @@
 import { getMetadata, getEventConfig, LIBS } from '../../utils/utils.js';
 
+/** `?chronoDebug=1` or `true` — logs worker handoff and fragment loads. */
+function chronoDebugEnabled() {
+  try {
+    const v = new URLSearchParams(window.location.search).get('chronoDebug');
+    return v === '1' || v === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function chronoDebugLog(...args) {
+  if (!chronoDebugEnabled()) return;
+  console.log('[chrono-box]', new Date().toISOString(), ...args);
+}
+
+/** @param {HTMLElement} host */
+function ensureReparentSet(host) {
+  if (!host._chronoBoxReparentedRoots) {
+    host._chronoBoxReparentedRoots = new Set();
+  }
+  return host._chronoBoxReparentedRoots;
+}
+
+/** Record element nodes removed from the chrono-box subtree (e.g. Milo hoisting a section to `main`). */
+function ingestReparentedRemovedNodes(host, records) {
+  const roots = ensureReparentSet(host);
+  records.forEach((record) => {
+    record.removedNodes.forEach((node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) roots.add(node);
+    });
+  });
+}
+
+/**
+ * Optional fragment teardown when content leaves this `.chrono-box` (teleport hooks, Milo misses).
+ * @param {HTMLElement} chronoBoxEl
+ * @param {() => void} teardown
+ */
+export function registerChronoBoxOutboundCleanup(chronoBoxEl, teardown) {
+  if (!chronoBoxEl || typeof teardown !== 'function') return;
+  if (!Array.isArray(chronoBoxEl._chronoBoxOutboundCleanup)) {
+    chronoBoxEl._chronoBoxOutboundCleanup = [];
+  }
+  chronoBoxEl._chronoBoxOutboundCleanup.push(teardown);
+}
+
+/**
+ * Observe reparents before `loadFragment` so Milo (sticky-section, tabs, etc.) can be cleaned on swap.
+ * @param {HTMLElement} chronoBoxEl
+ */
+export function ensureChronoBoxReparentObserver(chronoBoxEl) {
+  if (!chronoBoxEl) return;
+  ensureReparentSet(chronoBoxEl);
+  if (!chronoBoxEl._chronoBoxReparentObserver) {
+    chronoBoxEl._chronoBoxReparentObserver = new MutationObserver((records) => {
+      ingestReparentedRemovedNodes(chronoBoxEl, records);
+    });
+  }
+  chronoBoxEl._chronoBoxReparentObserver.observe(chronoBoxEl, {
+    childList: true,
+    subtree: true,
+  });
+}
+
+function disconnectReparentObserverAndRemoveOrphans(chronoBoxEl) {
+  if (!chronoBoxEl) return;
+  const obs = chronoBoxEl._chronoBoxReparentObserver;
+  if (obs) {
+    ingestReparentedRemovedNodes(chronoBoxEl, obs.takeRecords());
+    obs.disconnect();
+  }
+  const roots = chronoBoxEl._chronoBoxReparentedRoots;
+  if (!(roots instanceof Set)) return;
+  let removed = 0;
+  roots.forEach((node) => {
+    try {
+      if (node?.isConnected) {
+        node.remove();
+        removed += 1;
+      }
+    } catch (error) {
+      window.lana?.log(`chrono-box reparent cleanup: ${error.message}`);
+    }
+  });
+  roots.clear();
+  chronoDebugLog('reparent cleanup', { removedStillConnected: removed });
+}
+
+/**
+ * Before the next fragment: `before-swap` event, registered cleanups, reparent orphans, teleport markers.
+ * @param {HTMLElement} chronoBoxEl
+ */
+export function cleanupChronoBoxOutboundNodes(chronoBoxEl) {
+  if (!chronoBoxEl) return;
+
+  const instanceId = chronoBoxEl.dataset?.chronoBoxInstance;
+
+  try {
+    if (instanceId) {
+      chronoBoxEl.dispatchEvent(new CustomEvent('chrono-box:before-swap', {
+        bubbles: true,
+        detail: { root: chronoBoxEl, instanceId },
+      }));
+    }
+  } catch (error) {
+    window.lana?.log(`chrono-box:before-swap event: ${error.message}`);
+  }
+
+  const fns = chronoBoxEl._chronoBoxOutboundCleanup;
+  if (Array.isArray(fns)) {
+    fns.forEach((fn) => {
+      try {
+        fn();
+      } catch (error) {
+        window.lana?.log(`chrono-box outbound cleanup: ${error.message}`);
+      }
+    });
+    chronoBoxEl._chronoBoxOutboundCleanup = [];
+  }
+
+  disconnectReparentObserverAndRemoveOrphans(chronoBoxEl);
+
+  if (instanceId) {
+    document.querySelectorAll(`[data-chrono-box-teleport="${instanceId}"]`).forEach((node) => {
+      node.remove();
+    });
+  }
+}
+
+function summarizeScheduleForDebug(schedule) {
+  if (!Array.isArray(schedule)) return schedule;
+  return schedule.map((row, i) => ({
+    i,
+    pathToFragment: row.pathToFragment,
+    toggleTime: row.toggleTime,
+    hasMobileRider: Boolean(row.mobileRider),
+    hasMetadata: Boolean(row.metadata?.length),
+  }));
+}
+
 function buildScheduleDoubleLinkedList(entries) {
   if (!entries.length) return null;
 
@@ -39,14 +179,13 @@ async function initPlugins(schedule) {
   };
   const hasPlugin = (plugin) => schedule.some((item) => item[plugin]);
   const pluginsNeeded = Object.keys(PLUGINS_MAP).filter(hasPlugin);
-  
+
   const plugins = await Promise.all(pluginsNeeded.map((plugin) => {
     const pluginDir = PLUGINS_MAP[plugin];
     const pluginUrl = new URL(`../../features/timing-framework/plugins/${pluginDir}/plugin.js`, import.meta.url);
     return import(pluginUrl.href);
   }));
 
-  // Shared tabId for BroadcastChannel communication across chrono-boxes
   let tabId = sessionStorage.getItem('chrono-box-tab-id');
   if (!tabId) {
     tabId = crypto.randomUUID();
@@ -62,33 +201,29 @@ async function initPlugins(schedule) {
   return { plugins: pluginsModules, tabId };
 }
 
-// Creates blob-based worker for cross-origin scenarios
 async function createBlobWorker(workerUrl) {
   const response = await fetch(workerUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch worker: ${response.status} ${response.statusText}`);
   }
-  
+
   const workerCode = await response.text();
   const blob = new Blob([workerCode], { type: 'application/javascript' });
   return URL.createObjectURL(blob);
 }
 
-// Creates worker with automatic cross-origin fallback
 async function createWorker(workerUrl) {
   let worker;
   let blobUrl = null;
 
   try {
-    // Try direct Worker first (optimal for same-origin)
     worker = new Worker(workerUrl, { type: 'module' });
     return { worker, blobUrl };
   } catch (error) {
-    // Expected: falls back to blob worker for cross-origin
+    // cross-origin: fall through to blob worker
   }
 
   try {
-    // Fallback: blob-based worker for cross-origin
     blobUrl = await createBlobWorker(workerUrl);
     worker = new Worker(blobUrl);
     return { worker, blobUrl };
@@ -110,12 +245,21 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
   const testTiming = params.get('timing');
   const serverTime = params.get('serverTime');
   const avoidStreamEndFlag = params.get('avoidStreamEndFlag');
-  
+
   const testing = (testTiming || serverTime || avoidStreamEndFlag) ? {
     toggleTime: testTiming,
     serverTime,
     avoidStreamEndFlag,
   } : null;
+
+  chronoDebugLog('worker init', {
+    workerUrl,
+    usesBlobWorker: Boolean(blobUrl),
+    tabId,
+    testing,
+    pluginsLoaded: Array.from(plugins.keys()),
+    scheduleRows: summarizeScheduleForDebug(schedule),
+  });
 
   const pluginStates = Object.fromEntries(
     Array.from(plugins.entries())
@@ -142,6 +286,15 @@ async function setScheduleToScheduleWorker(schedule, plugins, tabId) {
   if (blobUrl) {
     worker._blobUrl = blobUrl;
   }
+
+  worker.addEventListener('error', (event) => {
+    chronoDebugLog('worker error event', {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
+  });
 
   return worker;
 }
@@ -185,14 +338,18 @@ export default async function init(el) {
     return Promise.resolve();
   }
 
-  // Expose parsed schedule on DOM for consumers (e.g. Chrome extensions)
+  chronoDebugLog('schedule resolved', {
+    source: staticSchedule ? 'block' : 'metadata',
+    scheduleId: scheduleId || null,
+    rowCount: Array.isArray(thisSchedule) ? thisSchedule.length : null,
+    scheduleSummary: summarizeScheduleForDebug(thisSchedule),
+  });
+
   el.setAttribute('data-tf-schedule-json', JSON.stringify(thisSchedule));
+  el.dataset.chronoBoxInstance = crypto.randomUUID();
   el.innerHTML = '';
 
-  // When the URL hash already matches a modal trigger's target, clicking the link
-  // won't fire hashchange. Clear the hash first so the subsequent navigation
-  // produces an event that Milo's modal listener can act on. Skip if the modal
-  // is already rendered (e.g. from cache/timing) to avoid double-triggering.
+  // Modal hash: clear URL hash so Milo sees a real hashchange when the link target already matches.
   el.addEventListener('click', (e) => {
     const link = e.target.closest('a[data-modal-hash]');
     if (!link) return;
@@ -212,7 +369,7 @@ export default async function init(el) {
 
   const pluginsOutputs = await initPlugins(thisSchedule);
   let worker;
-  
+
   try {
     worker = await setScheduleToScheduleWorker(
       thisSchedule,
@@ -238,17 +395,25 @@ export default async function init(el) {
     worker.onmessage = (event) => {
       clearTimeout(timeout);
 
+      chronoDebugLog('worker message', event.data);
+
       const { pathToFragment } = event.data;
       const { prefix } = getLocale(getConfig().locales);
       el.style.height = `${el.clientHeight}px`;
+
+      cleanupChronoBoxOutboundNodes(el);
 
       el.innerHTML = '';
 
       const a = createTag('a', { href: `${pathToFragment.startsWith('/') ? prefix : ''}${pathToFragment}` }, '', { parent: el });
 
+      ensureChronoBoxReparentObserver(el);
+
       loadFragment(a).then(() => {
+        chronoDebugLog('fragment loaded', { pathToFragment });
         el.removeAttribute('style');
       }).catch((error) => {
+        chronoDebugLog('fragment load failed', { pathToFragment, error: error.message });
         window.lana?.log(`Error loading fragment ${pathToFragment}: ${error.message}`);
         el.removeAttribute('style');
         el.innerHTML = '<div class="error-message">Unable to load content. Please refresh the page.</div>';

--- a/event-libs/v1/blocks/chrono-box/chrono-box.js
+++ b/event-libs/v1/blocks/chrono-box/chrono-box.js
@@ -260,43 +260,71 @@ function requestAnimationFramePromise() {
   });
 }
 
-/**
- * After fragment load and height unlock: wait for layout, then scroll to the page hash.
- * Bounded rAF retry so ids from async nested blocks can appear before scrolling.
- * @param {(hash: string) => void} scrollToHashedElement
- */
-async function scrollToHashAfterFragmentLayout(scrollToHashedElement) {
-  const hash = window.location.hash;
-  if (!hash || hash.includes('=')) return;
+function anchorWithModalHashExists(hash) {
+  return Array.from(document.querySelectorAll('a[data-modal-hash]')).some(
+    (a) => a.getAttribute('data-modal-hash') === hash,
+  );
+}
 
-  await requestAnimationFramePromise();
-  await requestAnimationFramePromise();
-
-  let id = '';
+function modalDialogForHashIsOpen(hash) {
+  if (!hash || hash.length < 2) return false;
+  let modalId;
   try {
-    id = decodeURIComponent(hash.slice(1));
+    modalId = decodeURIComponent(hash.slice(1));
   } catch {
-    id = hash.slice(1);
+    modalId = hash.slice(1);
   }
+  const existing = document.getElementById(modalId);
+  return Boolean(existing?.classList.contains('dialog-modal'));
+}
+
+/**
+ * Collapse duplicate `modal:open` in the same burst (Milo nested loadArea + chrono-box + extra worker ticks).
+ * Keep the window short so closing the modal and a quick fragment retry can still reopen within a few hundred ms.
+ */
+let chronoBoxLastModalOpenDispatch = { hash: '', at: 0 };
+const CHRONO_BOX_MODAL_OPEN_DEDUPE_MS = 350;
+
+function dispatchModalOpenOnceForHash(hash) {
+  if (!hash) return;
+  if (modalDialogForHashIsOpen(hash)) return;
+
+  const now = Date.now();
+  const { hash: prev, at } = chronoBoxLastModalOpenDispatch;
+  if (hash === prev && now - at < CHRONO_BOX_MODAL_OPEN_DEDUPE_MS) return;
+
+  chronoBoxLastModalOpenDispatch = { hash, at: now };
+  window.dispatchEvent(new CustomEvent('modal:open', { bubbles: true, detail: { hash } }));
+}
+
+/**
+ * Re-run Milo modal opening for the current URL hash after scheduled fragment content is in the DOM.
+ * Milo listens on `window` for `modal:open` (see utils initModalEventListener). Optional rAF deferral
+ * and bounded polling give RSVP / async blocks time to expose `a[data-modal-hash]`.
+ */
+async function openModalFromPageHashAfterFragment() {
+  const hash = window.location.hash;
+  if (!hash) return;
+
+  await requestAnimationFramePromise();
+  await requestAnimationFramePromise();
 
   const maxAttempts = 12;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    if (!id || document.getElementById(id)) {
-      scrollToHashedElement(hash);
+    if (anchorWithModalHashExists(hash)) {
+      dispatchModalOpenOnceForHash(hash);
       return;
     }
     await requestAnimationFramePromise();
   }
-  scrollToHashedElement(hash);
+  dispatchModalOpenOnceForHash(hash);
 }
 
 export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  const [{ default: loadFragment }, {
-    createTag, getLocale, getConfig, scrollToHashedElement,
-  }] = await Promise.all([
+  const [{ default: loadFragment }, { createTag, getLocale, getConfig }] = await Promise.all([
     import(`${miloLibs}/blocks/fragment/fragment.js`),
     import(`${miloLibs}/utils/utils.js`),
   ]);
@@ -415,12 +443,10 @@ export default async function init(el) {
       loadFragment(a)
         .then(async () => {
           el.removeAttribute('style');
-          if (typeof scrollToHashedElement === 'function') {
-            try {
-              await scrollToHashAfterFragmentLayout(scrollToHashedElement);
-            } catch (error) {
-              window.lana?.log(`chrono-box hash scroll: ${error.message}`);
-            }
+          try {
+            await openModalFromPageHashAfterFragment();
+          } catch (error) {
+            window.lana?.log(`chrono-box modal hash: ${error.message}`);
           }
           resolve();
         })

--- a/event-libs/v1/blocks/event-subscription-form/event-subscription-form.css
+++ b/event-libs/v1/blocks/event-subscription-form/event-subscription-form.css
@@ -178,7 +178,6 @@
     h2 {
       font-size: 2.625rem;
       line-height: 1;
-      text-align: left;
       color: rgb(44 44 44);
       margin: 0;
       font-weight: 400;

--- a/test/unit/blocks/chrono-box/chrono-box.test.js
+++ b/test/unit/blocks/chrono-box/chrono-box.test.js
@@ -94,5 +94,31 @@ describe('Chrono Box', () => {
       cleanupChronoBoxOutboundNodes(host);
       expect(main.contains(section)).to.equal(false);
     });
+
+    it('does not remove nodes that were only moved within chrono-box (reorder)', async () => {
+      const {
+        cleanupChronoBoxOutboundNodes,
+        ensureChronoBoxReparentObserver,
+      } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+
+      const host = document.createElement('div');
+      host.dataset.chronoBoxInstance = 'reorder-test';
+      document.body.append(host);
+
+      const inner = document.createElement('div');
+      const section = document.createElement('section');
+      host.append(inner);
+      inner.append(section);
+      expect(inner.contains(section)).to.equal(true);
+
+      ensureChronoBoxReparentObserver(host);
+      host.append(section);
+
+      expect(host.contains(section)).to.equal(true);
+      expect(inner.contains(section)).to.equal(false);
+
+      cleanupChronoBoxOutboundNodes(host);
+      expect(host.contains(section)).to.equal(true);
+    });
   });
 });

--- a/test/unit/blocks/chrono-box/chrono-box.test.js
+++ b/test/unit/blocks/chrono-box/chrono-box.test.js
@@ -1,36 +1,98 @@
 import { expect } from '@esm-bundle/chai';
 
 describe('Chrono Box', () => {
-  describe('Module structure', () => {
-    it('should export default init function', async () => {
-      const chronoBoxModule = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
-      expect(chronoBoxModule).to.have.property('default');
-      expect(typeof chronoBoxModule.default).to.equal('function');
-    });
-
-    it('should import required dependencies', async () => {
-      const chronoBoxModule = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
-      expect(chronoBoxModule).to.have.property('default');
+  describe('exports', () => {
+    it('exports init and fragment outbound helpers', async () => {
+      const mod = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+      expect(mod.default).to.be.a('function');
+      expect(mod.registerChronoBoxOutboundCleanup).to.be.a('function');
+      expect(mod.cleanupChronoBoxOutboundNodes).to.be.a('function');
+      expect(mod.ensureChronoBoxReparentObserver).to.be.a('function');
     });
   });
 
-  describe('Functionality', () => {
-    it('should handle module import without errors', async () => {
-      // This test verifies that the module can be imported without throwing errors
-      const chronoBoxModule = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
-      expect(chronoBoxModule).to.have.property('default');
-      expect(chronoBoxModule.default).to.be.a('function');
+  describe('Outbound fragment cleanup', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+      document.head.innerHTML = '';
     });
 
-    it('should have expected module structure', async () => {
-      const chronoBoxModule = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+    it('runs registerChronoBoxOutboundCleanup teardowns once per cleanup call', async () => {
+      const {
+        registerChronoBoxOutboundCleanup,
+        cleanupChronoBoxOutboundNodes,
+      } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
 
-      // Verify the module has the expected structure
-      expect(chronoBoxModule).to.have.property('default');
-      expect(chronoBoxModule.default).to.be.a('function');
+      const el = document.createElement('div');
+      el.dataset.chronoBoxInstance = 'instance-a';
+      let calls = 0;
+      registerChronoBoxOutboundCleanup(el, () => { calls += 1; });
+      cleanupChronoBoxOutboundNodes(el);
+      expect(calls).to.equal(1);
+      cleanupChronoBoxOutboundNodes(el);
+      expect(calls).to.equal(1);
+    });
 
-      // The module should be importable without errors
-      expect(() => chronoBoxModule).to.not.throw();
+    it('removes nodes tagged with data-chrono-box-teleport for this instance', async () => {
+      const { cleanupChronoBoxOutboundNodes } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+
+      const host = document.createElement('div');
+      host.dataset.chronoBoxInstance = 'teleport-target-id';
+      document.body.append(host);
+
+      const stray = document.createElement('aside');
+      stray.setAttribute('data-chrono-box-teleport', 'teleport-target-id');
+      document.body.append(stray);
+
+      cleanupChronoBoxOutboundNodes(host);
+      expect(document.body.contains(stray)).to.equal(false);
+    });
+
+    it('dispatches bubbling chrono-box:before-swap with instanceId', async () => {
+      const { cleanupChronoBoxOutboundNodes } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+
+      const host = document.createElement('div');
+      host.dataset.chronoBoxInstance = 'swap-test-id';
+      document.body.append(host);
+
+      let seen = null;
+      const onSwap = (e) => {
+        seen = e.detail;
+      };
+      document.addEventListener('chrono-box:before-swap', onSwap);
+
+      cleanupChronoBoxOutboundNodes(host);
+      document.removeEventListener('chrono-box:before-swap', onSwap);
+
+      expect(seen).to.include({ instanceId: 'swap-test-id' });
+      expect(seen.root).to.equal(host);
+    });
+
+    it('removes elements reparented out of chrono-box (Milo-style hoist)', async () => {
+      const {
+        cleanupChronoBoxOutboundNodes,
+        ensureChronoBoxReparentObserver,
+      } = await import('../../../../event-libs/v1/blocks/chrono-box/chrono-box.js');
+
+      const host = document.createElement('div');
+      host.dataset.chronoBoxInstance = 'reparent-test';
+      document.body.append(host);
+
+      const main = document.createElement('main');
+      document.body.append(main);
+
+      const section = document.createElement('section');
+      host.append(section);
+      expect(host.contains(section)).to.equal(true);
+
+      ensureChronoBoxReparentObserver(host);
+      main.append(section);
+
+      expect(host.contains(section)).to.equal(false);
+      expect(main.contains(section)).to.equal(true);
+
+      cleanupChronoBoxOutboundNodes(host);
+      expect(main.contains(section)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
## T3.26-15 Minor Release

Merges the latest **stage** work into **main** for production.

### What’s in this release
- **Chrono box** — More reliable deep links and modals when content loads from fragments; cleaner behavior when the schedule changes; a small fix so DOM cleanup only targets nodes outside the block host.
- **RTL** — Removed forced text alignment so right-to-left pages can lay out correctly.
- **Housekeeping** — Dev/stage sync after the recent hotfix, removal of leftover debug logging, and post-hotfix branch-sync guidance for the team.

All items above have already been validated on **stage**.

Made with [Cursor](https://cursor.com)