### PR TITLE
fix(profile-cards): mark member images without alt text as decorative

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -13,14 +13,13 @@ function decorateImage(card, photo) {
   if (!photo) return;
 
   const { altText } = photo;
-  const imgElement = createTag('img', {
+  const attrs = {
     src: getImageSource(photo),
     class: 'card-image',
-  });
-
-  if (altText) {
-    imgElement.setAttribute('alt', altText);
-  }
+    alt: altText || '',
+  };
+  if (!altText) attrs.role = 'presentation';
+  const imgElement = createTag('img', attrs);
 
   const imgContainer = createTag('div', { class: 'card-image-container' });
   imgContainer.append(imgElement);

--- a/test/unit/blocks/profile-cards/mocks/default.html
+++ b/test/unit/blocks/profile-cards/mocks/default.html
@@ -136,4 +136,27 @@
     </div>
   </div>
 </div>
+<div>
+  <div id='static-no-alt-cards' class="profile-cards">
+    <div>
+      <div>
+        <h2 id="no-alt-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture><img src="https://example.com/photo.jpg"></picture>
+        <p>Speaker title</p>
+        <h3>No Alt Speaker</h3>
+        <p>Bio text.</p>
+      </div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
 </body>

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -90,6 +90,28 @@ describe('Profile Cards Module', () => {
       });
     });
 
+    it('should set alt text on profile images from metadata', () => {
+      const el = document.querySelector('#speakers-cards');
+      init(el);
+
+      const images = el.querySelectorAll('.card-image');
+      images.forEach((img) => {
+        expect(img.hasAttribute('alt')).to.be.true;
+        expect(img.getAttribute('alt')).to.not.be.empty;
+        expect(img.hasAttribute('role')).to.be.false;
+      });
+    });
+
+    it('should mark images without alt text as decorative', () => {
+      const el = document.querySelector('#static-no-alt-cards');
+      init(el);
+
+      const img = el.querySelector('.card-image');
+      expect(img).to.not.be.null;
+      expect(img.getAttribute('alt')).to.equal('');
+      expect(img.getAttribute('role')).to.equal('presentation');
+    });
+
     it('should make metadata-driven modal cards interactive', () => {
       const el = document.querySelector('#modal-speakers-cards');
       init(el);


### PR DESCRIPTION
## Summary
- Profile card member images that lack `altText` now get `alt=""` and `role="presentation"`, marking them as decorative for screen readers
- Images with `altText` continue to render their meaningful alt text as before
- Social icons are unaffected (they already have `alt="${platform} logo"`)

## Test plan
- [x] New test: metadata-driven images have non-empty `alt` and no `role`
- [x] New test: images without alt text get `alt=""` and `role="presentation"`
- [x] All 11 profile-cards tests pass
- [ ] Manual screen reader verification (VoiceOver): decorative images are skipped, meaningful alt text is announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)