### PR TITLE
fix(profile-cards): align modal specs with Figma design

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -6,7 +6,7 @@
   margin: auto;
 }
 
-.profile-cards h2 {
+.profile-cards > div:first-child h2 {
   text-align: center;
 }
 
@@ -131,10 +131,10 @@
 .profile-cards .card-desc {
   color: #2C2C2C;
   font-family: var(--body-font-family);
-  font-size: var(--type-body-xs-size);
+  font-size: var(--type-body-l-size);
   font-style: normal;
   font-weight: 400;
-  line-height: 21px;
+  line-height: var(--type-body-l-lh);
   margin-top: 0;
 }
 
@@ -188,12 +188,16 @@
 .profile-cards-modal .profile-cards-modal-text .card-desc {
   color: #2C2C2C;
   font-family: var(--body-font-family);
-  font-size: var(--type-body-xs-size);
+  font-size: var(--type-body-l-size);
   font-style: normal;
   font-weight: 400;
-  line-height: 21px;
+  line-height: var(--type-body-l-lh);
   margin-top: 0;
   margin-bottom: 24px;
+}
+
+.profile-cards-modal .card-name:focus {
+  outline: none;
 }
 
 .profile-cards-modal .profile-cards-modal-text .card-social-icons {
@@ -247,7 +251,7 @@
 
 /* Desktop and up */
 @media screen and (min-width: 900px) {
-  .profile-cards h2 {
+  .profile-cards > div:first-child h2 {
     margin-top: 13px;
     text-align: center;
     font-size: var(--type-heading-xl-size);

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -162,7 +162,7 @@ function decorateContent(cardContainer, data) {
 
   const textContainer = createTag('div', { class: 'card-text-container' });
   const title = createTag('p', { class: 'card-title' }, data.title);
-  const name = createTag('h3', { class: 'card-name' }, `${data.firstName} ${data.lastName}`);
+  const name = createTag('h2', { class: 'card-name' }, `${data.firstName} ${data.lastName}`);
 
   textContainer.append(title, name);
 
@@ -191,7 +191,7 @@ function decorateContentSimple(cardContainer, data) {
   const contentContainer = createTag('div', { class: 'card-content' });
   const textContainer = createTag('div', { class: 'card-text-container' });
   const title = createTag('p', { class: 'card-title' }, data.title);
-  const name = createTag('h3', { class: 'card-name' }, `${data.firstName} ${data.lastName}`);
+  const name = createTag('h2', { class: 'card-name' }, `${data.firstName} ${data.lastName}`);
 
   textContainer.append(title, name);
   contentContainer.append(textContainer);
@@ -247,7 +247,7 @@ async function buildModalContent(profileData) {
   const imageContainer = createTag('div', { class: 'profile-cards-modal-image' });
   const fullName = getProfileName(profileData);
   const title = createTag('p', { class: 'card-title' }, profileData?.title || '');
-  const name = createTag('h3', { class: 'card-name' }, fullName);
+  const name = createTag('h2', { class: 'card-name' }, fullName);
 
   textContainer.append(title, name);
   appendBio(textContainer, profileData?.bio);


### PR DESCRIPTION
## Summary
- **h3 → h2**: Card name heading changed from `h3` to `h2` across all render paths (`decorateContent`, `decorateContentSimple`, `buildModalContent`). Section heading `h2` selectors scoped to `.profile-cards > div:first-child h2` to prevent style bleed.
- **Body font 14px → 18px**: Card description `.card-desc` font updated from `--type-body-xs-size` (14px/21px) to `--type-body-l-size`/`--type-body-l-lh` (18px/27px) matching the Figma `Body/L` spec — both card view and modal.
- **Modal focus border removed**: Added `.profile-cards-modal .card-name:focus { outline: none; }` to suppress the browser default focus outline on the heading when the modal overlay opens.

Figma reference: [Tier 2 Events Templates Speakers Final — node 255:58754](https://www.figma.com/design/nkt77LckJkvgmTJ96vFLGZ/Tier-2-Events-Templates-Speakers-Final?node-id=255-58754&m=dev)

## Test plan
- [ ] `npx wtr test/unit/blocks/profile-cards/profile-cards.test.js --node-resolve --port=2000` — all 9 tests pass
- [ ] `npm run lint` — modified files pass cleanly
- [ ] Visual: load a page with `profile-cards modal` variant, verify card name renders as `<h2>`, description text is 18px, no focus ring on modal open

🤖 Generated with [Claude Code](https://claude.com/claude-code)