### PR TITLE
fix(chrono-box): stop fallback to first schedule item

### DIFF
--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -295,7 +295,7 @@ class TimingWorker {
       pointer = pointer.next;
     }
 
-    return start || scheduleRoot;
+    return start;
   }
 
   /**
@@ -398,11 +398,6 @@ class TimingWorker {
       // If no items are triggered, send the current schedule item
       // This handles cases where mobileRider is still active or other blocking conditions
       itemToSend = this.currentScheduleItem;
-
-      // If we don't have a current item, fall back to the first item
-      if (!itemToSend) {
-        itemToSend = this.getFirstScheduleItem();
-      }
     }
 
     // Send the item if it's different from what we previously sent
@@ -419,15 +414,6 @@ class TimingWorker {
     if (this.testingManager.isFrozen()) return;
 
     this.timerId = setTimeout(() => this.runTimer(), TimingWorker.getRandomInterval());
-  }
-
-  getFirstScheduleItem() {
-    // Find the first item in the schedule by traversing backwards from current
-    let item = this.currentScheduleItem;
-    while (item?.prev) {
-      item = item.prev;
-    }
-    return item;
   }
 
   handleMessage(event) {
@@ -473,8 +459,9 @@ class TimingWorker {
    * @description Initializes the schedule asynchronously
    */
   async initializeSchedule(schedule) {
-    this.nextScheduleItem = await this.getStartScheduleItemByToggleTime(schedule);
-    this.currentScheduleItem = this.nextScheduleItem?.prev || schedule;
+    const startItem = await this.getStartScheduleItemByToggleTime(schedule);
+    this.nextScheduleItem = startItem || schedule;
+    this.currentScheduleItem = startItem?.prev || null;
     this.previouslySentItem = null;
 
     if (!this.nextScheduleItem) return;

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -256,7 +256,7 @@ class TimingWorker {
       pointer = pointer.next;
     }
 
-    return start || scheduleRoot;
+    return start;
   }
 
   /**
@@ -389,11 +389,6 @@ class TimingWorker {
       // If no items are triggered, send the current schedule item
       // This handles cases where mobileRider is still active or other blocking conditions
       itemToSend = this.currentScheduleItem;
-
-      // If we don't have a current item, fall back to the first item
-      if (!itemToSend) {
-        itemToSend = this.getFirstScheduleItem();
-      }
     }
 
     // Send the item if it's different from what we previously sent
@@ -410,15 +405,6 @@ class TimingWorker {
     if (this.testingManager.isFrozen()) return;
 
     this.timerId = setTimeout(() => this.runTimer(), TimingWorker.getRandomInterval());
-  }
-
-  getFirstScheduleItem() {
-    // Find the first item in the schedule by traversing backwards from current
-    let item = this.currentScheduleItem;
-    while (item?.prev) {
-      item = item.prev;
-    }
-    return item;
   }
 
   handleMessage(event) {
@@ -469,8 +455,9 @@ class TimingWorker {
     const initialTime = this.getFastInitialTime();
     
     // Synchronously determine first schedule item
-    this.nextScheduleItem = this.getStartScheduleItemByToggleTime(schedule, initialTime);
-    this.currentScheduleItem = this.nextScheduleItem?.prev || schedule;
+    const startItem = this.getStartScheduleItemByToggleTime(schedule, initialTime);
+    this.nextScheduleItem = startItem || schedule;
+    this.currentScheduleItem = startItem?.prev || null;
     this.previouslySentItem = null;
 
     if (!this.nextScheduleItem) return;
@@ -500,6 +487,11 @@ class TimingWorker {
     // If we're on the wrong item, correct it on next timer tick
     if (correctItem && correctItem !== this.currentScheduleItem) {
       this.nextScheduleItem = correctItem;
+    } else if (!correctItem && this.currentScheduleItem) {
+      // Authoritative time says nothing qualifies yet — reset
+      this.nextScheduleItem = schedule;
+      this.currentScheduleItem = null;
+      this.previouslySentItem = null;
     }
   }
 

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -40,7 +40,7 @@ describe('TimingWorker', () => {
   });
 
   describe('getStartScheduleItemByToggleTime', () => {
-    it('should return the first item if no toggleTime has passed', () => {
+    it('should return null if no toggleTime has passed', () => {
       const now = Date.now();
       const schedule = {
         toggleTime: now + 1000,
@@ -48,7 +48,7 @@ describe('TimingWorker', () => {
       };
 
       const result = worker.getStartScheduleItemByToggleTime(schedule, now);
-      expect(result).to.equal(schedule);
+      expect(result).to.be.null;
     });
 
     it('should return the last passed item if toggleTime has passed', () => {
@@ -84,23 +84,24 @@ describe('TimingWorker', () => {
       expect(result).to.equal(schedule);
     });
 
-    it('should use testing time when in testing mode - past time', () => {
+    it('should return null when testing time is before all toggleTimes', () => {
       const now = Date.now();
       const schedule = {
-        toggleTime: now - 1000, // Past time
+        toggleTime: now - 1000, // Past time relative to wall clock
         next: {
           toggleTime: now + 1000, // Future time
           next: null,
         },
       };
 
-      // Set up testing mode with a time offset that makes the current time
-      // appear to be in the past
+      // Set up testing mode with a time offset that makes the adjusted time
+      // earlier than all toggleTimes
       worker.testingManager.init({ toggleTime: now - 2000 });
 
       const result = worker.getStartScheduleItemByToggleTime(schedule, now);
-      // Should return the first item because the testing time is in the past
-      expect(result).to.equal(schedule);
+      // Adjusted time (now - 2000) is before first toggleTime (now - 1000),
+      // so nothing qualifies
+      expect(result).to.be.null;
     });
   });
 
@@ -831,6 +832,50 @@ describe('TimingWorker', () => {
 
       // Cache should not be updated for safety
       expect(sharedWorker.cachedApiTime).to.be.null;
+    });
+  });
+
+  describe('No conditions met behavior', () => {
+    it('should not send any message when currentScheduleItem is null', async () => {
+      const clock = sinon.useFakeTimers();
+      const perfStub = sinon.stub(performance, 'now');
+      perfStub.returns(1000);
+
+      worker.testingManager.init(null);
+      worker.nextScheduleItem = {
+        toggleTime: Date.now() + 10000,
+        pathToFragment: '/future-item',
+        next: { toggleTime: Date.now() + 20000, pathToFragment: '/later', next: null },
+      };
+      worker.currentScheduleItem = null;
+      worker.previouslySentItem = null;
+
+      await worker.runTimer();
+
+      expect(mockPostMessage.called).to.be.false;
+      expect(worker.timerId).to.not.be.null;
+
+      clock.restore();
+      perfStub.restore();
+    });
+
+    it('should set currentScheduleItem to null when no toggleTime has passed', () => {
+      const now = Date.now();
+      const schedule = {
+        toggleTime: now + 10000,
+        pathToFragment: '/future',
+        next: null,
+        prev: null,
+      };
+
+      const runTimerStub = sinon.stub(worker, 'runTimer');
+
+      worker.initializeSchedule(schedule);
+
+      expect(worker.nextScheduleItem).to.equal(schedule);
+      expect(worker.currentScheduleItem).to.be.null;
+
+      runTimerStub.restore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Removed the three-point fallback mechanism in the timing framework workers (`worker.js` and `worker-traditional.js`) that always rendered the first schedule item when no item's conditions were satisfied
- `getStartScheduleItemByToggleTime` now returns `null` instead of falling back to the schedule root
- `initializeSchedule` sets `currentScheduleItem` to `null` when nothing qualifies, while keeping `nextScheduleItem` pointed at the first item so the timer continues polling
- `runTimer` no longer falls back to `getFirstScheduleItem()` — if nothing qualifies, nothing is sent
- `validateSchedulePosition` in `worker.js` now handles the case where authoritative time disagrees with the fast-path wall clock
- Updated and added unit tests covering the new no-render behavior

## Test plan
- [x] `npx wtr test/unit/features/timing-framework/worker.test.js` — 41 tests pass
- [x] `npx wtr test/unit/blocks/chrono-box/chrono-box.test.js` — 6 tests pass
- [x] `npm test` — no new failures (10 pre-existing failures in unrelated tests)
- [x] `npm run lint` on changed files — clean
- [ ] Manual: use `?timing=<future-timestamp>` to confirm chrono-box stays empty when all toggleTimes are in the future, then use a past timestamp to confirm rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)