### PR TITLE
[chore] Fix bento-cards and event-map unit test failures

### DIFF
--- a/test/unit/blocks/bento-cards/bento-cards.test.js
+++ b/test/unit/blocks/bento-cards/bento-cards.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
+import { setEventConfig } from '../../../../event-libs/v1/utils/utils.js';
 import init from '../../../../event-libs/v1/blocks/bento-cards/bento-cards.js';
 
 const body = await readFile({ path: './mocks/default.html' });
@@ -9,6 +10,7 @@ describe('Bento Cards Module', () => {
   describe('init', () => {
     beforeEach(() => {
       document.head.innerHTML = '';
+      setEventConfig({}, { miloLibs: '/test/unit/blocks/bento-cards/mocks/libs' });
     });
 
     it('should add specific classes to cards and move elements into content container', async () => {

--- a/test/unit/blocks/bento-cards/mocks/libs/utils/decorate.js
+++ b/test/unit/blocks/bento-cards/mocks/libs/utils/decorate.js
@@ -1,0 +1,1 @@
+export function decorateButtons() {}

--- a/test/unit/blocks/event-map/event-map.test.js
+++ b/test/unit/blocks/event-map/event-map.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
+import { setMetadata, setEventConfig } from '../../../../event-libs/v1/utils/utils.js';
 
 const { default: init } = await import('../../../../event-libs/v1/blocks/event-map/event-map.js');
 const body = await readFile({ path: './mocks/default.html' });
@@ -12,6 +12,7 @@ describe('Event Map', () => {
     delete document.body.dataset.eventState;
     document.head.innerHTML = '';
     window.isTestEnv = true;
+    setEventConfig({ cmsType: 'SP' }, { miloLibs: '/test/unit/blocks/event-map/mocks/libs' });
     setMetadata('venue', JSON.stringify({
       venueName: 'Morgan MF',
       address: '401 North Morgan Street',

--- a/test/unit/blocks/event-map/mocks/libs/utils/decorate.js
+++ b/test/unit/blocks/event-map/mocks/libs/utils/decorate.js
@@ -1,0 +1,1 @@
+export function decorateButtons() {}

--- a/test/unit/blocks/event-map/mocks/libs/utils/utils.js
+++ b/test/unit/blocks/event-map/mocks/libs/utils/utils.js
@@ -1,0 +1,21 @@
+export function createTag(tag, attributes, html, options = {}) {
+  const el = document.createElement(tag);
+  if (html) {
+    if (html instanceof HTMLElement
+      || html instanceof SVGElement
+      || html instanceof DocumentFragment) {
+      el.append(html);
+    } else if (Array.isArray(html)) {
+      el.append(...html);
+    } else {
+      el.insertAdjacentHTML('beforeend', html);
+    }
+  }
+  if (attributes) {
+    Object.entries(attributes).forEach(([key, val]) => {
+      el.setAttribute(key, val);
+    });
+  }
+  options.parent?.append(el);
+  return el;
+}


### PR DESCRIPTION
## Summary
- Fixed `bento-cards` and `event-map` unit tests that failed due to dynamic imports resolving to an external Milo URL (`http://main--milo--adobecom.aem.live/libs/...`) unreachable in the test environment
- Added local mock modules for Milo's `decorateButtons` and `createTag`, and redirected `miloLibs` via `setEventConfig` in each test's `beforeEach`
- All 412 tests now pass consistently (previously 2 persistent + 8 intermittent failures)

## Test plan
- [x] `npx wtr test/unit/blocks/bento-cards/bento-cards.test.js` — 2/2 pass
- [x] `npx wtr test/unit/blocks/event-map/event-map.test.js` — 8/8 pass
- [x] `npm test` — 412/412 pass, verified stable across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)