### PR TITLE
feat(sessions-hub): layout-based truncation and conflict swap flow

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -812,6 +812,11 @@
   gap: 24px;
 }
 
+.sh-conflict-options.sh-conflict-options-pending {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
 .sh-conflict-option {
   position: relative;
   display: flex;
@@ -894,6 +899,17 @@
 
 .sh-conflict-confirm:hover {
   background: #404040;
+}
+
+.sh-conflict-confirm:disabled,
+.sh-conflict-confirm[aria-busy='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sh-conflict-confirm:hover:disabled,
+.sh-conflict-confirm:hover[aria-busy='true'] {
+  background: #292929;
 }
 
 /* ─── Reduced motion ─────────────────────────────────────────────────────── */

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -22,8 +22,6 @@ const FILTER_ICON = '<svg width="26" height="26" viewBox="0 0 26 26" fill="none"
 const SEARCH_ICON = '<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="7.25" stroke="#6e6e6e" stroke-width="2"/><path d="M16.5 16.5L23 23" stroke="#6e6e6e" stroke-width="2" stroke-linecap="round"/></svg>';
 const CHEVRON_DOWN_ICON = '<svg width="14" height="14" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4,7.01a1,1,0,0,1,1.7055-.7055l3.289,3.286,3.289-3.286a1,1,0,0,1,1.437,1.3865l-.0245.0245L9.7,11.7075a1,1,0,0,1-1.4125,0L4.293,7.716A.9945.9945,0,0,1,4,7.01Z" fill="#505050"/></svg>';
 
-const DESC_CHAR_LIMIT = 500;
-
 // ─── Module-level state singleton ──────────────────────────────────────────
 
 const [getState, setState] = (() => {
@@ -33,6 +31,7 @@ const [getState, setState] = (() => {
 
 let rsvpUnsubscribe = null;
 let pendingSessionId = null;
+let disconnectDescOverflowObserver = null;
 
 async function openRsvpModal({ hash, path }) {
   const miloLibs = getEventConfig()?.miloConfig?.miloLibs || LIBS;
@@ -256,6 +255,7 @@ function applyFilter(listEl, state) {
   listEl.querySelectorAll('.sh-card').forEach((card) => {
     card.hidden = !filteredIds.has(card.dataset.sessionId);
   });
+  scheduleSyncSessionDescriptionsOverflow(listEl);
 }
 
 // ─── Render: CTA group ───────────────────────────────────────────────────────
@@ -301,6 +301,76 @@ function renderCTAGroup(session, isEventRegistered) {
 function updateCTAGroup(cardEl, session, isEventRegistered) {
   const old = cardEl.querySelector('.sh-cta-group');
   if (old) old.replaceWith(renderCTAGroup(session, isEventRegistered));
+}
+
+// ─── Session description overflow (matches CSS -webkit-line-clamp) ───────────
+
+function syncSessionCardDescriptionOverflow(card) {
+  const descText = card.querySelector('.sh-card-desh-text');
+  const expandBtn = card.querySelector('.sh-expand-btn');
+  if (!descText || !expandBtn) return;
+
+  if (card.hidden) return;
+
+  if (card.classList.contains('expanded')) {
+    expandBtn.hidden = false;
+    const readMoreEl = card.querySelector('.sh-read-more');
+    if (readMoreEl) readMoreEl.hidden = false;
+    return;
+  }
+
+  const truncated = descText.scrollHeight > descText.clientHeight;
+  expandBtn.hidden = !truncated;
+
+  const desc = card.querySelector('.sh-card-desc');
+  let readMore = card.querySelector('.sh-read-more');
+  if (truncated) {
+    if (!readMore && desc) {
+      readMore = createTag('button', { class: 'sh-read-more', type: 'button' }, dictionaryManager.getValue('Read more'));
+      desc.append(readMore);
+    } else if (readMore) {
+      readMore.hidden = false;
+    }
+  } else if (readMore) {
+    readMore.remove();
+  }
+}
+
+export function syncSessionDescriptionsOverflow(listEl) {
+  if (!listEl) return;
+  listEl.querySelectorAll('.sh-card').forEach((card) => {
+    syncSessionCardDescriptionOverflow(card);
+  });
+}
+
+function scheduleSyncSessionDescriptionsOverflow(listEl) {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      syncSessionDescriptionsOverflow(listEl);
+    });
+  });
+}
+
+function connectSessionDescriptionsOverflowObserver(listEl) {
+  if (typeof ResizeObserver === 'undefined') return;
+  disconnectSessionDescriptionsOverflow();
+  const debouncedSync = debounce(() => {
+    syncSessionDescriptionsOverflow(listEl);
+  }, 100);
+  const ro = new ResizeObserver(() => {
+    debouncedSync();
+  });
+  ro.observe(listEl);
+  disconnectDescOverflowObserver = () => {
+    ro.disconnect();
+    disconnectDescOverflowObserver = null;
+  };
+}
+
+function disconnectSessionDescriptionsOverflow() {
+  if (disconnectDescOverflowObserver) {
+    disconnectDescOverflowObserver();
+  }
 }
 
 // ─── Render: session card ────────────────────────────────────────────────────
@@ -395,14 +465,8 @@ function renderSessionCard(session, isEventRegistered) {
   const descText = createTag('div', { class: 'sh-card-desh-text' });
   const fullDesc = session.description || '';
   descText.innerHTML = fullDesc;
-  const needsTruncation = descText.textContent.length > DESC_CHAR_LIMIT;
 
   desc.append(descText);
-  if (needsTruncation) {
-    desc.append(createTag('button', { class: 'sh-read-more', type: 'button' }, dictionaryManager.getValue('Read more')));
-  }
-
-  expandBtn.hidden = !needsTruncation;
   right.append(desc, renderCTAGroup(session, isEventRegistered));
 
   card.append(left, right);
@@ -625,6 +689,26 @@ function buildConflictModalContent(newSession, conflictingSession) {
   return { content: wrapper, confirmBtn, optionsEl };
 }
 
+function setSwapConflictModalPending(confirmBtn, optionsEl) {
+  confirmBtn.disabled = true;
+  confirmBtn.setAttribute('aria-busy', 'true');
+  confirmBtn.textContent = dictionaryManager.getValue('Registering\u2026');
+  optionsEl.classList.add('sh-conflict-options-pending');
+  optionsEl.querySelectorAll('.sh-conflict-option').forEach((o) => {
+    o.setAttribute('tabindex', '-1');
+  });
+}
+
+function restoreSwapConflictModalUi(confirmBtn, optionsEl) {
+  confirmBtn.disabled = false;
+  confirmBtn.removeAttribute('aria-busy');
+  confirmBtn.textContent = dictionaryManager.getValue('Add session');
+  optionsEl.classList.remove('sh-conflict-options-pending');
+  optionsEl.querySelectorAll('.sh-conflict-option').forEach((o) => {
+    o.setAttribute('tabindex', '0');
+  });
+}
+
 async function openConflictModal(newSession, conflictingSession) {
   const miloLibs = getEventConfig()?.miloConfig?.miloLibs || LIBS;
   const { getModal, closeModal } = await import(`${miloLibs}/blocks/modal/modal.js`);
@@ -636,8 +720,25 @@ async function openConflictModal(newSession, conflictingSession) {
     confirmBtn.addEventListener('click', () => {
       confirmed = true;
       const sel = optionsEl.querySelector('.sh-conflict-option.selected');
-      closeModal();
-      resolve(sel?.dataset.sessionId || newSession.sessionId);
+      const selectedId = sel?.dataset.sessionId || newSession.sessionId;
+
+      if (selectedId === conflictingSession.sessionId) {
+        closeModal();
+        resolve({ selectedId, finalize: () => {} });
+        return;
+      }
+
+      setSwapConflictModalPending(confirmBtn, optionsEl);
+      resolve({
+        selectedId,
+        finalize: (ok) => {
+          if (ok) {
+            closeModal();
+          } else {
+            restoreSwapConflictModalUi(confirmBtn, optionsEl);
+          }
+        },
+      });
     });
 
     const onClose = () => {
@@ -744,10 +845,15 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
 
   // ── Conflict detection ────────────────────────────────────────────────────
   const conflictingSession = findConflictingSession(session, state);
+  let conflictFinalize = null;
+  let isDeferredSwap = false;
   if (conflictingSession) {
-    const selectedId = await openConflictModal(session, conflictingSession);
-    if (!selectedId) return; // dismissed
-    if (selectedId === conflictingSession.sessionId) return; // user kept existing
+    const outcome = await openConflictModal(session, conflictingSession);
+    if (!outcome) return; // dismissed
+    if (outcome.selectedId === conflictingSession.sessionId) return; // user kept existing
+
+    conflictFinalize = outcome.finalize;
+    isDeferredSwap = true;
 
     // User chose new session → unregister from conflicting first
     const conflictTime = conflictingSession.sessionTimes[0];
@@ -755,6 +861,7 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
       const unregResp = await unregisterFromSessionTime(conflictTime.sessionTimeId);
       if (!unregResp.ok) {
         window.lana?.log(`Error: Failed to unregister conflicting session ${conflictingSession.sessionId}`);
+        conflictFinalize(false);
         return;
       }
       conflictingSession.isRegistered = false;
@@ -770,7 +877,7 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
   }
 
   const btn = cardEl.querySelector('.sh-btn-register-session');
-  if (btn) {
+  if (!isDeferredSwap && btn) {
     btn.disabled = true;
     btn.setAttribute('aria-busy', 'true');
     btn.textContent = dictionaryManager.getValue('Registering\u2026');
@@ -784,9 +891,12 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
     updateCTAGroup(cardEl, session, true);
     const existing = BlockMediator.get('registeredSessionIds') || new Set();
     BlockMediator.set('registeredSessionIds', new Set([...existing, sessionId]));
+    if (conflictFinalize) conflictFinalize(true);
   } else {
     window.lana?.log(`Error: Failed to register for session ${sessionId}. Error:${JSON.stringify(resp.error)}`);
-    if (btn) {
+    if (conflictFinalize) {
+      conflictFinalize(false);
+    } else if (btn) {
       btn.disabled = false;
       btn.removeAttribute('aria-busy');
       btn.textContent = dictionaryManager.getValue('Register for session');
@@ -841,6 +951,9 @@ function bindCardEvents(listEl, state) {
       const expandBtn = card.querySelector('.sh-expand-btn');
       expandBtn.innerHTML = isExpanded ? MINUS_CIRCLE_ICON : PLUS_CIRCLE_ICON;
       expandBtn.setAttribute('aria-label', isExpanded ? dictionaryManager.getValue('Collapse session') : dictionaryManager.getValue('Expand session'));
+      if (!isExpanded) {
+        syncSessionCardDescriptionOverflow(card);
+      }
       return;
     }
 
@@ -1044,6 +1157,14 @@ async function loadBlock(el, rsvpConfig) {
   bindCardEvents(listEl, state);
   bindMediatorSubscriptions(el, bannerEl, listEl);
 
+  try {
+    await document.fonts?.ready;
+  } catch {
+    // ignore font loading errors
+  }
+  scheduleSyncSessionDescriptionsOverflow(listEl);
+  connectSessionDescriptionsOverflowObserver(listEl);
+
   const storedPendingId = sessionStorage.getItem('sessions-hub:pendingSessionId');
   const storedEventRsvp = sessionStorage.getItem('sessions-hub:pendingEventRsvp');
   if (storedEventRsvp) sessionStorage.removeItem('sessions-hub:pendingEventRsvp');
@@ -1068,6 +1189,7 @@ async function loadBlock(el, rsvpConfig) {
 
 export default async function init(el) {
   if (rsvpUnsubscribe) { rsvpUnsubscribe(); rsvpUnsubscribe = null; }
+  disconnectSessionDescriptionsOverflow();
   setFilterState({ query: '', activeTags: new Set(), activeTab: 'all' });
 
   let rsvpConfig = null;

--- a/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
+++ b/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init from '../../../../event-libs/v1/blocks/sessions-hub/sessions-hub.js';
+import init, { syncSessionDescriptionsOverflow } from '../../../../event-libs/v1/blocks/sessions-hub/sessions-hub.js';
 import BlockMediator from '../../../../event-libs/v1/deps/block-mediator.min.js';
 
 const body = await readFile({ path: './mocks/default.html' });
@@ -474,6 +474,44 @@ describe('sessions-hub init', () => {
     const banner = document.querySelector('.sh-event-banner');
     expect(banner).to.not.be.null;
     expect(banner.classList.contains('hidden')).to.be.false;
+  });
+
+  it('shows expand and read-more when description scrollHeight exceeds clientHeight', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([makeSession()]);
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+    await new Promise((r) => { requestAnimationFrame(() => requestAnimationFrame(r)); });
+
+    const listEl = el.querySelector('.sh-session-list');
+    const descText = el.querySelector('.sh-card-desh-text');
+    const card = el.querySelector('.sh-card');
+    Object.defineProperty(descText, 'scrollHeight', { configurable: true, get: () => 400 });
+    Object.defineProperty(descText, 'clientHeight', { configurable: true, get: () => 100 });
+
+    syncSessionDescriptionsOverflow(listEl);
+
+    expect(card.querySelector('.sh-expand-btn').hidden).to.be.false;
+    expect(card.querySelector('.sh-read-more')).to.not.be.null;
+  });
+
+  it('hides expand and omits read-more when description fits within clamp', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([makeSession()]);
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+    await new Promise((r) => { requestAnimationFrame(() => requestAnimationFrame(r)); });
+
+    const listEl = el.querySelector('.sh-session-list');
+    const descText = el.querySelector('.sh-card-desh-text');
+    const card = el.querySelector('.sh-card');
+    Object.defineProperty(descText, 'scrollHeight', { configurable: true, get: () => 120 });
+    Object.defineProperty(descText, 'clientHeight', { configurable: true, get: () => 120 });
+
+    syncSessionDescriptionsOverflow(listEl);
+
+    expect(card.querySelector('.sh-expand-btn').hidden).to.be.true;
+    expect(card.querySelector('.sh-read-more')).to.be.null;
   });
 });
 


### PR DESCRIPTION
## Summary

- **Session descriptions:** Detect truncation from layout (`scrollHeight` vs `clientHeight`) instead of a fixed character limit; sync expand/read-more after filter changes, expand/collapse, fonts ready, and list resize via `ResizeObserver`. Export `syncSessionDescriptionsOverflow` for tests.
- **Conflict modal:** Defer closing the modal until registration completes when swapping sessions; show pending state on the confirm button and options; restore UI on failure.
- **Styles:** Disabled / busy state for conflict confirm and pointer-events for pending options.

## Dictionary / localization keys (`dictionary.json`)

Add these **key** strings under the default `data` sheet (values are your localized copy). Keys must match exactly, including Unicode ellipsis (**…**, U+2026) for the two “Registering” / “Unregistering” entries.

- Register for session
- Download to calendar
- Registered
- Unregister
- Tags
- Expand session
- Collapse session
- Session full
- Speakers
- Read more
- All sessions
- My sessions
- Search sessions
- Filter
- Event registration
- Register
- You have conflicting sessions
- Select which session you want to keep.
- Add session
- Registering…
- Unregistering…
