### PR TITLE
feat(events-form): RSVP limit column for maxlength

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -2,9 +2,38 @@ import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEv
 import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
 import { dictionaryManager } from '../../utils/dictionary-manager.js';
-import { getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl } from '../../utils/utils.js';
+import {
+  getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl,
+} from '../../utils/utils.js';
 import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN } from '../../utils/constances.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
+
+/**
+ * Parses the RSVP form `limit` column: max character length only.
+ * Value must be a positive integer — JSON number or string of digits (e.g. `30`).
+ * @param {unknown} raw
+ * @returns {number|undefined} Integer ≥ 1, or undefined when unset/invalid
+ */
+function parseRsvpFieldLimit(raw) {
+  if (raw == null || raw === '') return undefined;
+  if (typeof raw === 'number') {
+    const n = Math.trunc(raw);
+    if (Number.isFinite(n) && n >= 1) return n;
+    window.lana?.log('events-form: limit must be a positive integer');
+    return undefined;
+  }
+  if (typeof raw === 'string') {
+    const s = raw.trim();
+    if (!s) return undefined;
+    if (!/^\d+$/.test(s)) {
+      window.lana?.log('events-form: limit must be a positive integer (digits only)');
+      return undefined;
+    }
+    return parseInt(s, 10);
+  }
+  window.lana?.log('events-form: limit must be a positive integer');
+  return undefined;
+}
 
 const eventConfig = getEventConfig();
 const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
@@ -435,19 +464,24 @@ function createHeading({ label }, el) {
   return createTag(el, {}, dictionaryManager.getValue(label, 'rsvp-fields'));
 }
 
-function createInput({ type, field, placeholder, required, defval, pattern, title }) {
+function createInput({
+  type, field, placeholder, required, defval, pattern, title, limit,
+}) {
   const placeholderText = placeholder ? dictionaryManager.getValue(placeholder, 'rsvp-fields') : '';
   const attrs = { type, id: field, placeholder: placeholderText, value: defval };
   if (pattern) attrs.pattern = pattern;
   if (title) attrs.title = title;
+  if (limit != null) attrs.maxlength = limit;
   const input = createTag('input', attrs);
   if (required === 'x') input.setAttribute('required', 'required');
   return input;
 }
 
-function createTextArea({ field, placeholder, required, defval }) {
+function createTextArea({ field, placeholder, required, defval, limit }) {
   const placeholderText = placeholder ? dictionaryManager.getValue(placeholder, 'rsvp-fields') : '';
-  const input = createTag('textarea', { id: field, placeholder: placeholderText, value: defval });
+  const attrs = { id: field, placeholder: placeholderText, value: defval };
+  if (limit != null) attrs.maxlength = limit;
+  const input = createTag('textarea', attrs);
   if (required === 'x') input.setAttribute('required', 'required');
   return input;
 }
@@ -904,6 +938,7 @@ async function createForm(bp, formData) {
 
   json.data.forEach(async (fd) => {
     fd.type = fd.type || 'text';
+    fd.limit = parseRsvpFieldLimit(fd.limit);
     if (fd.type === 'text') sanitizeList.push(fd.field);
     const style = fd.extra ? ` events-form-${fd.extra}` : '';
     const fieldWrapper = createTag(

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -7,33 +7,7 @@ import {
 } from '../../utils/utils.js';
 import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN } from '../../utils/constances.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
-
-/**
- * Parses the RSVP form `limit` column: max character length only.
- * Value must be a positive integer — JSON number or string of digits (e.g. `30`).
- * @param {unknown} raw
- * @returns {number|undefined} Integer ≥ 1, or undefined when unset/invalid
- */
-function parseRsvpFieldLimit(raw) {
-  if (raw == null || raw === '') return undefined;
-  if (typeof raw === 'number') {
-    const n = Math.trunc(raw);
-    if (Number.isFinite(n) && n >= 1) return n;
-    window.lana?.log('events-form: limit must be a positive integer');
-    return undefined;
-  }
-  if (typeof raw === 'string') {
-    const s = raw.trim();
-    if (!s) return undefined;
-    if (!/^\d+$/.test(s)) {
-      window.lana?.log('events-form: limit must be a positive integer (digits only)');
-      return undefined;
-    }
-    return parseInt(s, 10);
-  }
-  window.lana?.log('events-form: limit must be a positive integer');
-  return undefined;
-}
+import { parseRsvpFieldLimit, stripTags } from '../../utils/sanitize-utils.js';
 
 const eventConfig = getEventConfig();
 const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
@@ -254,7 +228,7 @@ async function submitForm(bp) {
     }
 
     if (sanitizeList.includes(key)) {
-      payload[key] = sanitizeComment(payload[key]);
+      payload[key] = sanitizeComment(stripTags(payload[key]));
     }
 
     return valid;
@@ -939,7 +913,7 @@ async function createForm(bp, formData) {
   json.data.forEach(async (fd) => {
     fd.type = fd.type || 'text';
     fd.limit = parseRsvpFieldLimit(fd.limit);
-    if (fd.type === 'text') sanitizeList.push(fd.field);
+    if (fd.type === 'text' || fd.type === 'text-area') sanitizeList.push(fd.field);
     const style = fd.extra ? ` events-form-${fd.extra}` : '';
     const fieldWrapper = createTag(
       'div',

--- a/event-libs/v1/utils/sanitize-utils.js
+++ b/event-libs/v1/utils/sanitize-utils.js
@@ -1,0 +1,28 @@
+export function parseRsvpFieldLimit(raw) {
+  if (raw == null || raw === '') return undefined;
+  if (typeof raw === 'number') {
+    const n = Math.trunc(raw);
+    if (Number.isFinite(n) && n >= 1) return n;
+    window.lana?.log('events-form: limit must be a positive integer');
+    return undefined;
+  }
+  if (typeof raw === 'string') {
+    const s = raw.trim();
+    if (!s) return undefined;
+    if (!/^\d+$/.test(s)) {
+      window.lana?.log('events-form: limit must be a positive integer (digits only)');
+      return undefined;
+    }
+    return parseInt(s, 10);
+  }
+  window.lana?.log('events-form: limit must be a positive integer');
+  return undefined;
+}
+
+// Uses the browser's HTML parser so malformed/nested tags are handled correctly.
+export function stripTags(value) {
+  if (!value) return value;
+  const div = document.createElement('div');
+  div.innerHTML = value;
+  return div.textContent ?? '';
+}

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { getValidCampaignIdFromUrl } from '../../../../event-libs/v1/utils/utils.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../../../event-libs/v1/utils/data-utils.js';
+import { stripTags } from '../../../../event-libs/v1/utils/sanitize-utils.js';
 
 describe('Events Form', () => {
   let block;
@@ -787,5 +788,32 @@ describe('Events Form', () => {
       expect(errorEl).to.not.be.null;
       expect(errorEl.textContent).to.equal('event-full-no-waitlist-error-msg');
     });
+  });
+});
+
+describe('stripTags', () => {
+  it('removes script tags and keeps inner text', () => {
+    expect(stripTags('<script>alert()</script>')).to.equal('alert()');
+  });
+
+  it('removes inline tags and keeps surrounding text', () => {
+    expect(stripTags('hello <b>world</b>')).to.equal('hello world');
+  });
+
+  it('passes through plain text unchanged', () => {
+    expect(stripTags('no tags here')).to.equal('no tags here');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(stripTags('')).to.equal('');
+  });
+
+  it('returns falsy values unchanged', () => {
+    expect(stripTags(null)).to.equal(null);
+    expect(stripTags(undefined)).to.equal(undefined);
+  });
+
+  it('strips nested tags and event handler attributes', () => {
+    expect(stripTags('<a href="x"><img onerror="y">text</a>')).to.equal('text');
   });
 });


### PR DESCRIPTION
## Summary
Adds support for an optional `limit` field per row in the RSVP form JSON (table export). Authors set a **positive integer** (digits only as a string, or a JSON number). The block applies it as the HTML `maxlength` attribute on **text** inputs and **textareas**.

- **No limit column / empty / invalid:** no `maxlength` (unchanged from today).
- **Invalid values:** omitted and logged via `window.lana` (no thrown errors).

## Regression notes
- Existing configs without `limit` behave as before.
- Only `createInput` / `createTextArea` paths use `limit`; selects, checkboxes, etc. are unchanged.

## Other
- Fixes ESLint `no-unused-vars` in `test/unit/blocks/promotional-content/mocks/libs/blocks/fragment/fragment.js` so `npm run lint` passes.

## Test / lint
- `npm run lint`: clean
- `npm test`: 463 passed; 2 sessions-catalogue tests occasionally time out under full parallel run but pass when that file is run alone (pre-existing flake).

Made with [Cursor](https://cursor.com)