### PR TITLE
chore(test): fix ESLint in promotional-content fragment mock

### DIFF
--- a/test/unit/blocks/promotional-content/mocks/libs/blocks/fragment/fragment.js
+++ b/test/unit/blocks/promotional-content/mocks/libs/blocks/fragment/fragment.js
@@ -1,5 +1,5 @@
 // Mock fragment loader
-export default async function loadFragment(fragmentLink) {
+export default async function loadFragment() {
   // Mock implementation - just resolve immediately
   return Promise.resolve();
 }


### PR DESCRIPTION
## Summary
Fixes `no-unused-vars` in `test/unit/blocks/promotional-content/mocks/libs/blocks/fragment/fragment.js` by dropping the unused `loadFragment` parameter (the mock does not use the URL).

## Why a separate PR
Unblocks `npm run lint` without mixing test-harness cleanup into feature work.

Made with [Cursor](https://cursor.com)