### PR TITLE
fix(sessions-hub): sort sessions by start time and fix conflict modal close crash

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -175,7 +175,7 @@ function findConflictingSession(newSession, state) {
 }
 
 function normalizeSessions(rawSessions, locationMap, registeredSessionIds, venueId) {
-  return rawSessions.map((session) => {
+  const mapped = rawSessions.map((session) => {
     const sessionTimes = (session.rawTimes || []).map((t) => ({
       sessionTimeId: t.sessionTimeId,
       startTimeMillis: t.startTimeMillis,
@@ -211,6 +211,11 @@ function normalizeSessions(rawSessions, locationMap, registeredSessionIds, venue
       isRegistered: registeredSessionIds.has(session.sessionId),
       expanded: false,
     };
+  });
+  return mapped.sort((a, b) => {
+    const aMin = Math.min(...a.sessionTimes.map((t) => t.startTimeMillis).filter(Boolean));
+    const bMin = Math.min(...b.sessionTimes.map((t) => t.startTimeMillis).filter(Boolean));
+    return (isFinite(aMin) ? aMin : Infinity) - (isFinite(bMin) ? bMin : Infinity);
   });
 }
 
@@ -714,6 +719,7 @@ async function openConflictModal(newSession, conflictingSession) {
   const { getModal, closeModal } = await import(`${miloLibs}/blocks/modal/modal.js`);
   const { content, confirmBtn, optionsEl } = buildConflictModalContent(newSession, conflictingSession);
 
+  let dialogEl;
   return new Promise((resolve) => {
     let confirmed = false;
 
@@ -723,7 +729,7 @@ async function openConflictModal(newSession, conflictingSession) {
       const selectedId = sel?.dataset.sessionId || newSession.sessionId;
 
       if (selectedId === conflictingSession.sessionId) {
-        closeModal();
+        closeModal(dialogEl);
         resolve({ selectedId, finalize: () => {} });
         return;
       }
@@ -733,7 +739,7 @@ async function openConflictModal(newSession, conflictingSession) {
         selectedId,
         finalize: (ok) => {
           if (ok) {
-            closeModal();
+            closeModal(dialogEl);
           } else {
             restoreSwapConflictModalUi(confirmBtn, optionsEl);
           }
@@ -747,7 +753,8 @@ async function openConflictModal(newSession, conflictingSession) {
     };
     window.addEventListener('milo:modal:closed', onClose);
 
-    getModal(null, { id: 'sh-conflict-modal', content, class: 'sh-conflict-modal' });
+    getModal(null, { id: 'sh-conflict-modal', content, class: 'sh-conflict-modal' })
+      .then((modal) => { dialogEl = modal; });
   });
 }
 

--- a/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
+++ b/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
@@ -481,7 +481,6 @@ describe('sessions-hub init', () => {
     setSessionsMeta([makeSession()]);
     const el = document.querySelector('.sessions-hub');
     await init(el);
-    await new Promise((r) => { requestAnimationFrame(() => requestAnimationFrame(r)); });
 
     const listEl = el.querySelector('.sh-session-list');
     const descText = el.querySelector('.sh-card-desh-text');
@@ -500,7 +499,6 @@ describe('sessions-hub init', () => {
     setSessionsMeta([makeSession()]);
     const el = document.querySelector('.sessions-hub');
     await init(el);
-    await new Promise((r) => { requestAnimationFrame(() => requestAnimationFrame(r)); });
 
     const listEl = el.querySelector('.sh-session-list');
     const descText = el.querySelector('.sh-card-desh-text');


### PR DESCRIPTION
## Summary

- **Sort sessions by start time**: \`normalizeSessions()\` now sorts the output array ascending by each session's earliest \`startTimeMillis\`. Sessions with no times are pushed to the end. Previously the order was whatever the API returned.
- **Fix conflict modal close crash**: \`closeModal()\` was called without its required \`modal\` DOM element argument, causing \`TypeError: Cannot read properties of undefined (reading 'id')\` in Milo's \`modal.js\`. The dialog element returned by \`getModal()\` is now captured and passed to both \`closeModal()\` calls.
- **Fix pre-existing test flake**: Two overflow-sync tests timed out in the full suite because \`requestAnimationFrame\` is throttled to ~1fps in background browser tabs (WTR runs 26 tabs in parallel). The double-RAF wait was unnecessary — \`init()\` places all DOM elements synchronously — so it was removed.

## Test plan

- [ ] Register for two overlapping sessions to trigger the conflict modal; confirm choosing either option closes the modal without a console error
- [ ] Verify sessions render in ascending start-time order in the sessions hub
- [ ] \`npm test\` passes all 465 tests with 0 failures
- [ ] \`npm run lint\` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)