### PR TITLE
fix(profile-cards): focus modal heading on open to prevent social icon outline

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -214,6 +214,10 @@
   color: var(--color-black);
 }
 
+.profile-cards-modal .card-social-icon a:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .profile-cards-modal .profile-cards-modal-image .card-image-container {
   width: 100%;
   max-width: 385px;

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -214,10 +214,6 @@
   color: var(--color-black);
 }
 
-.profile-cards-modal .card-social-icon a:focus:not(:focus-visible) {
-  outline: none;
-}
-
 .profile-cards-modal .profile-cards-modal-image .card-image-container {
   width: 100%;
   max-width: 385px;

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -254,7 +254,7 @@ export async function buildModalContent(profileData) {
   const imageContainer = createTag('div', { class: 'profile-cards-modal-image' });
   const fullName = getProfileName(profileData);
   const title = createTag('p', { class: 'card-title' }, profileData?.title || '');
-  const name = createTag('h2', { class: 'card-name' }, fullName);
+  const name = createTag('h2', { class: 'card-name', tabindex: '0' }, fullName);
 
   textContainer.append(title, name);
   appendBio(textContainer, profileData?.bio);


### PR DESCRIPTION
## Summary
- When the profile cards modal opens, Milo's `getModal` focuses the first element matching its `FOCUSABLES` selector using `.focus({ focusVisible: true })` — the `focusVisible: true` flag explicitly forces `:focus-visible` to match, so CSS rules using `:focus:not(:focus-visible)` cannot suppress it
- The first FOCUSABLE in the modal was the first social media `<a>` link, causing a visible `:focus-visible` outline ring on modal open
- Fix: add `tabindex="0"` to the `card-name` h2 in `buildModalContent` — the heading now precedes the social links in Milo's DOM query, so it receives initial focus instead; the existing `.card-name:focus { outline: none; }` CSS rule already suppresses the ring on the heading
- Also reverts the ineffective `:focus:not(:focus-visible)` CSS rule added in a prior commit

## Test plan
- [ ] Open a profile cards page with the modal variant
- [ ] Click a card — confirm no outline appears on any element when the modal opens
- [ ] Tab through the open modal — confirm social icon links still show a focus ring when reached via keyboard
- [ ] `npm run lint` — clean
- [ ] Profile-cards tests — 11 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)