### PR TITLE
[MWPW-194073] : Reduced the max size of image as per figma

### DIFF
--- a/event-libs/v1/blocks/image-links/image-links.css
+++ b/event-libs/v1/blocks/image-links/image-links.css
@@ -72,7 +72,7 @@
   }
 
   .image-links .image-links-item {
-    max-width: 306px;
-    max-height: 181px;
+    max-width: 208px;
+    max-height: 135px;
   }
 }


### PR DESCRIPTION
The image sizes previously took the max sizes from the event-sponsor block. Reduced it to align with Figma

Resolves: [MWPW-194073](https://jira.corp.adobe.com/browse/MWPW-194073)

Test URLs:
- Before: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/stage-adobe-summit-london-2026/las-vegas/nv/us/2026-07-07
- After: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/stage-adobe-summit-london-2026/las-vegas/nv/us/2026-07-07?eventlibs=MWPW-194073
