### PR TITLE
[MWPW-194078] : Add validation for RSVP phone fields

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -17,6 +17,9 @@ const { default: loadFragment } = await import(`${miloLibs}/blocks/fragment/frag
 
 const VALID_REGISTRATION_STATUS = ['registered', 'waitlisted'];
 
+const PHONE_FIELD_RE = /phone/i;
+const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
+
 const RULE_OPERATORS = {
   equal: '=',
   notEqual: '!=',
@@ -437,8 +440,14 @@ function createHeading({ label }, el) {
 
 function createInput({ type, field, placeholder, required, defval, pattern, title }) {
   const placeholderText = placeholder ? dictionaryManager.getValue(placeholder, 'rsvp-fields') : '';
-  const attrs = { type, id: field, placeholder: placeholderText, value: defval };
-  if (pattern) attrs.pattern = pattern;
+  const isPhoneField = type === 'tel' || type === 'phone' || (typeof field === 'string' && PHONE_FIELD_RE.test(field));
+  const attrs = { type: isPhoneField ? 'tel' : type, id: field, placeholder: placeholderText, value: defval };
+  if (isPhoneField) {
+    attrs.inputmode = 'tel';
+    attrs.autocomplete = 'tel';
+  }
+  const resolvedPattern = pattern || (isPhoneField ? PHONE_PATTERN : null);
+  if (resolvedPattern) attrs.pattern = resolvedPattern;
   if (title) attrs.title = title;
   const input = createTag('input', attrs);
   if (required === 'x') input.setAttribute('required', 'required');

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -300,6 +300,74 @@ describe('Events Form', () => {
     });
   });
 
+  describe('createInput - phone field defaults', () => {
+    const PHONE_FIELD_RE = /phone/i;
+    const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
+
+    function simulateCreatePhoneAwareInput({ type, field, pattern, title }) {
+      const isPhoneField = type === 'tel' || type === 'phone' || (typeof field === 'string' && PHONE_FIELD_RE.test(field));
+      const attrs = { type: isPhoneField ? 'tel' : type, id: field };
+      if (isPhoneField) {
+        attrs.inputmode = 'tel';
+        attrs.autocomplete = 'tel';
+      }
+      const resolvedPattern = pattern || (isPhoneField ? PHONE_PATTERN : null);
+      if (resolvedPattern) attrs.pattern = resolvedPattern;
+      if (title) attrs.title = title;
+      const input = document.createElement('input');
+      Object.entries(attrs).forEach(([k, v]) => input.setAttribute(k, v));
+      return input;
+    }
+
+    it('applies tel type, pattern, inputmode for businessPhone field', () => {
+      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'businessPhone' });
+      expect(input.getAttribute('type')).to.equal('tel');
+      expect(input.getAttribute('inputmode')).to.equal('tel');
+      expect(input.getAttribute('autocomplete')).to.equal('tel');
+      expect(input.getAttribute('pattern')).to.equal(PHONE_PATTERN);
+      expect(input.hasAttribute('title')).to.be.false;
+    });
+
+    it('applies same defaults for mobilePhone field', () => {
+      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'mobilePhone' });
+      expect(input.getAttribute('type')).to.equal('tel');
+      expect(input.getAttribute('pattern')).to.equal(PHONE_PATTERN);
+    });
+
+    it('does not apply phone defaults for non-phone fields', () => {
+      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'firstName' });
+      expect(input.getAttribute('type')).to.equal('text');
+      expect(input.hasAttribute('pattern')).to.be.false;
+      expect(input.hasAttribute('inputmode')).to.be.false;
+    });
+
+    it('keeps explicit pattern and title from field config when provided', () => {
+      const input = simulateCreatePhoneAwareInput({
+        type: 'text',
+        field: 'businessPhone',
+        pattern: '^[0-9]+$',
+        title: 'Digits only',
+      });
+      expect(input.getAttribute('pattern')).to.equal('^[0-9]+$');
+      expect(input.getAttribute('title')).to.equal('Digits only');
+    });
+
+    it('phone pattern rejects letters and stray symbols (bug repro)', () => {
+      const regex = new RegExp(`^(?:${PHONE_PATTERN})$`);
+      expect(regex.test('Testing 123!@#')).to.be.false;
+      expect(regex.test('abc')).to.be.false;
+      expect(regex.test('555$$$')).to.be.false;
+    });
+
+    it('phone pattern accepts common phone formats', () => {
+      const regex = new RegExp(`^(?:${PHONE_PATTERN})$`);
+      expect(regex.test('+1 (555) 123-4567')).to.be.true;
+      expect(regex.test('555-123-4567')).to.be.true;
+      expect(regex.test('+15551234567')).to.be.true;
+      expect(regex.test('5551234567')).to.be.true;
+    });
+  });
+
   describe('Events Form - constructPayload', () => {
     describe('single-option checkbox boolean conversion', () => {
       it('should convert single-option checkbox to boolean when checked', () => {


### PR DESCRIPTION
Added a phone validation for the businessPhone and mobilePhone field in RSVP form block.
Since https://da.live/sheet#/adobecom/event-libs/event-libs/assets/configs/rsvp/experiencecloud and https://da.live/sheet#/adobecom/event-libs/event-libs/assets/configs/rsvp/creativecloud is used across environments , added a safer way to default validation with pattern before making a change to this sheet.

Once this code is merged, will update the sheet and test. And then remove the default logic in a separate PR

Resolves: [MWPW-194078](https://jira.corp.adobe.com/browse/MWPW-194078)

Test URLs:
- Before: http://localhost:8080/.snapshots/esp-stage/automationtestdxda/test-dx-in-person-event-waitlist-qe/san-jose/ca/us/2027-09-27?timing=1822076099990&espenv=stage#rsvp-form-1
- After: https://main--da-events--adobecom.aem.live/.snapshots/esp-stage/automationtestdxda/test-dx-in-person-event-waitlist-qe/san-jose/ca/us/2027-09-27?eventlibs=MWPW-194078&timing=1822076099990&espenv=stage#rsvp-form-1&martech=off
