### PR TITLE
Fixing Sessions Hub CTA State

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -302,9 +302,9 @@ function renderCTAGroup(session, isEventRegistered, isEventWaitlisted = false) {
   const group = createTag('div', { class: 'sh-cta-group' });
 
   if (isEventWaitlisted && !isEventRegistered) {
-    const badge = createTag('button', { class: 'sh-btn sh-registered-badge sh-event-waitlisted-badge', type: 'button', disabled: '' });
-    badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('waitlisted-cta-text')));
-    group.append(badge);
+    const btn = createTag('button', { class: 'sh-btn sh-btn-register-event sh-event-waitlisted-badge', type: 'button' });
+    btn.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('waitlisted-cta-text')));
+    group.append(btn);
   } else if (!isEventRegistered) {
     group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
   } else if (!session.isRegistered && !session.isWaitlisted) {
@@ -1074,6 +1074,17 @@ function bindCardEvents(listEl, state) {
     }
 
     if (e.target.closest('.sh-btn-register-event')) {
+      const btn = e.target.closest('.sh-btn-register-event');
+      const isAlreadyWaitlisted = btn?.classList.contains('sh-event-waitlisted-badge');
+
+      if (isAlreadyWaitlisted) {
+        // User is already on the event waitlist \u2014 just re-open the modal so
+        // they can cancel waitlist or review status. Do not set pendingSessionId
+        // or relabel the button.
+        if (state.rsvpConfig) openRsvpModal(state.rsvpConfig);
+        return;
+      }
+
       const profile = BlockMediator.get('imsProfile');
       const isSignedOut = !profile || profile.noProfile || profile.account_type === 'guest';
 
@@ -1085,7 +1096,6 @@ function bindCardEvents(listEl, state) {
 
       if (state.rsvpConfig) {
         pendingSessionId = sessionId;
-        const btn = e.target.closest('.sh-btn-register-event');
         if (btn) { btn.disabled = true; btn.textContent = dictionaryManager.getValue('Registering\u2026'); }
 
         // Milo's closeModal uses pushState (not location.hash=) so hashchange never fires.

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -171,6 +171,13 @@ async function resolveRegistrationState(eventId, isEventRegistered) {
   return new Set(resp.data?.sessionIds || []);
 }
 
+function isSessionTimeFullError(resp) {
+  const err = resp?.error;
+  if (!err) return false;
+  const candidates = [err.code, err.errorCode, err.error, err.type, err.message];
+  return candidates.some((v) => typeof v === 'string' && v.includes('SessionTimeFull'));
+}
+
 function findConflictingSession(newSession, state) {
   const newTime = newSession.sessionTimes[0];
   if (!newTime) return null;
@@ -221,6 +228,7 @@ function normalizeSessions(rawSessions, locationMap, registeredSessionIds, venue
       sessionTimes,
       speakers,
       isRegistered: registeredSessionIds.has(session.sessionId),
+      isWaitlisted: false,
       expanded: false,
     };
   });
@@ -295,15 +303,23 @@ function renderCTAGroup(session, isEventRegistered) {
 
   if (!isEventRegistered) {
     group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
-  } else if (!session.isRegistered) {
+  } else if (!session.isRegistered && !session.isWaitlisted) {
     group.append(createTag('button', { class: 'sh-btn sh-btn-register-session', type: 'button' }, dictionaryManager.getValue('Register for session')));
   } else {
     const calBtn = createTag('button', { class: 'sh-btn sh-btn-cal', type: 'button' });
     calBtn.append(createIcon(CTA_CALENDAR_ICON), createTag('span', {}, dictionaryManager.getValue('Download to calendar')));
     group.append(calBtn);
 
+    const isWaitlisted = !session.isRegistered && session.isWaitlisted;
+    const badgeLabel = isWaitlisted
+      ? dictionaryManager.getValue('waitlisted-cta-text')
+      : dictionaryManager.getValue('Registered');
+    const unregisterLabel = isWaitlisted
+      ? dictionaryManager.getValue('Leave waitlist')
+      : dictionaryManager.getValue('Unregister');
+
     const badge = createTag('button', { class: 'sh-btn sh-registered-badge', type: 'button', disabled: '' });
-    badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('Registered')));
+    badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, badgeLabel));
     group.append(badge);
 
     setTimeout(() => {
@@ -311,18 +327,18 @@ function renderCTAGroup(session, isEventRegistered) {
       badge.disabled = false;
     }, 2000);
 
-    const setRegisteredContent = () => {
+    const setIdleContent = () => {
       badge.innerHTML = '';
       badge.classList.remove('sh-unregister-mode');
-      badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('Registered')));
+      badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, badgeLabel));
     };
     const setUnregisterContent = () => {
       badge.innerHTML = '';
       badge.classList.add('sh-unregister-mode');
-      badge.append(createTag('span', {}, dictionaryManager.getValue('Unregister')));
+      badge.append(createTag('span', {}, unregisterLabel));
     };
     badge.addEventListener('mouseenter', () => { if (!badge.disabled) setUnregisterContent(); });
-    badge.addEventListener('mouseleave', () => { if (!badge.disabled) setRegisteredContent(); });
+    badge.addEventListener('mouseleave', () => { if (!badge.disabled) setIdleContent(); });
   }
 
   return group;
@@ -931,14 +947,31 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
     btn.textContent = dictionaryManager.getValue('Registering\u2026');
   }
 
-  const resp = await registerForSessionTime(firstTime.sessionTimeId, 'me', { registrationStatus: 'registered' });
+  let resp = await registerForSessionTime(firstTime.sessionTimeId, 'me', { registrationStatus: 'registered' });
+  let waitlisted = resp.ok && resp.data?.registrationStatus === 'waitlisted';
+
+  if (!resp.ok && isSessionTimeFullError(resp)) {
+    const retry = await registerForSessionTime(firstTime.sessionTimeId, 'me', { registrationStatus: 'waitlisted' });
+    if (retry.ok) {
+      resp = retry;
+      waitlisted = true;
+    } else {
+      resp = retry;
+    }
+  }
 
   if (resp.ok) {
-    session.isRegistered = true;
-    state.registeredSessionIds.add(sessionId);
+    if (waitlisted) {
+      session.isWaitlisted = true;
+      session.isRegistered = false;
+    } else {
+      session.isRegistered = true;
+      session.isWaitlisted = false;
+      state.registeredSessionIds.add(sessionId);
+      const existing = BlockMediator.get('registeredSessionIds') || new Set();
+      BlockMediator.set('registeredSessionIds', new Set([...existing, sessionId]));
+    }
     updateCTAGroup(cardEl, session, true);
-    const existing = BlockMediator.get('registeredSessionIds') || new Set();
-    BlockMediator.set('registeredSessionIds', new Set([...existing, sessionId]));
     if (conflictFinalize) conflictFinalize(true);
   } else {
     window.lana?.log(`Error: Failed to register for session ${sessionId}. Error:${JSON.stringify(resp.error)}`);
@@ -966,10 +999,12 @@ async function handleSessionUnregistration(cardEl, sessionId, state) {
     badge.textContent = dictionaryManager.getValue('Unregistering\u2026');
   }
 
+  const wasWaitlisted = session.isWaitlisted;
   const resp = await unregisterFromSessionTime(firstTime.sessionTimeId);
 
   if (resp.ok) {
     session.isRegistered = false;
+    session.isWaitlisted = false;
     state.registeredSessionIds.delete(sessionId);
     updateCTAGroup(cardEl, session, true);
     const existing = BlockMediator.get('registeredSessionIds') || new Set();
@@ -983,7 +1018,10 @@ async function handleSessionUnregistration(cardEl, sessionId, state) {
       badge.removeAttribute('aria-busy');
       badge.classList.remove('sh-unregister-mode');
       badge.innerHTML = '';
-      badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('Registered')));
+      const restoreLabel = wasWaitlisted
+        ? dictionaryManager.getValue('waitlisted-cta-text')
+        : dictionaryManager.getValue('Registered');
+      badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, restoreLabel));
     }
   }
 }

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -298,10 +298,14 @@ function applyFilter(listEl, state) {
 
 // ─── Render: CTA group ───────────────────────────────────────────────────────
 
-function renderCTAGroup(session, isEventRegistered) {
+function renderCTAGroup(session, isEventRegistered, isEventWaitlisted = false) {
   const group = createTag('div', { class: 'sh-cta-group' });
 
-  if (!isEventRegistered) {
+  if (isEventWaitlisted && !isEventRegistered) {
+    const badge = createTag('button', { class: 'sh-btn sh-registered-badge sh-event-waitlisted-badge', type: 'button', disabled: '' });
+    badge.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('waitlisted-cta-text')));
+    group.append(badge);
+  } else if (!isEventRegistered) {
     group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
   } else if (!session.isRegistered && !session.isWaitlisted) {
     group.append(createTag('button', { class: 'sh-btn sh-btn-register-session', type: 'button' }, dictionaryManager.getValue('Register for session')));
@@ -344,9 +348,9 @@ function renderCTAGroup(session, isEventRegistered) {
   return group;
 }
 
-function updateCTAGroup(cardEl, session, isEventRegistered) {
+function updateCTAGroup(cardEl, session, isEventRegistered, isEventWaitlisted = false) {
   const old = cardEl.querySelector('.sh-cta-group');
-  if (old) old.replaceWith(renderCTAGroup(session, isEventRegistered));
+  if (old) old.replaceWith(renderCTAGroup(session, isEventRegistered, isEventWaitlisted));
 }
 
 // ─── Session description overflow (matches CSS -webkit-line-clamp) ───────────
@@ -452,7 +456,7 @@ function renderSpeakerAvatars(speakers) {
   return wrap;
 }
 
-function renderSessionCard(session, isEventRegistered) {
+function renderSessionCard(session, isEventRegistered, isEventWaitlisted = false) {
   const primaryTime = session.sessionTimes[0];
   const timeStr = primaryTime
     ? createSmartDateRange(primaryTime.startTimeMillis, primaryTime.endTimeMillis, 'en-US', primaryTime.timezone)
@@ -513,15 +517,15 @@ function renderSessionCard(session, isEventRegistered) {
   descText.innerHTML = fullDesc;
 
   desc.append(descText);
-  right.append(desc, renderCTAGroup(session, isEventRegistered));
+  right.append(desc, renderCTAGroup(session, isEventRegistered, isEventWaitlisted));
 
   card.append(left, right);
   return card;
 }
 
-function renderSessionList(sessions, isEventRegistered) {
+function renderSessionList(sessions, isEventRegistered, isEventWaitlisted = false) {
   const list = createTag('div', { class: 'sh-session-list' });
-  sessions.forEach((s) => list.append(renderSessionCard(s, isEventRegistered)));
+  sessions.forEach((s) => list.append(renderSessionCard(s, isEventRegistered, isEventWaitlisted)));
   return list;
 }
 
@@ -1106,9 +1110,11 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
   rsvpUnsubscribe = BlockMediator.subscribe('rsvpData', async ({ newValue }) => {
     const state = getState();
     const isRegistered = newValue?.registrationStatus === 'registered';
+    const isWaitlisted = newValue?.registrationStatus === 'waitlisted';
     state.isEventRegistered = isRegistered;
+    state.isEventWaitlisted = isWaitlisted;
 
-    syncBannerVisibility(bannerEl, isRegistered);
+    syncBannerVisibility(bannerEl, isRegistered || isWaitlisted);
 
     const toggle = el.querySelector('.sh-tab-toggle');
     if (toggle) toggle.hidden = !isRegistered;
@@ -1125,7 +1131,7 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
       state.sessions.forEach((session) => {
         session.isRegistered = mergedIds.has(session.sessionId);
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, true);
+        if (cardEl) updateCTAGroup(cardEl, session, true, false);
       });
 
       if (pendingSessionId) {
@@ -1142,7 +1148,7 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
       state.sessions.forEach((session) => {
         session.isRegistered = false;
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, false);
+        if (cardEl) updateCTAGroup(cardEl, session, false, isWaitlisted);
       });
 
       // Reset to "All sessions" tab when user un-registers
@@ -1170,7 +1176,7 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
         session.isRegistered = true;
         state.registeredSessionIds.add(session.sessionId);
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, state.isEventRegistered);
+        if (cardEl) updateCTAGroup(cardEl, session, state.isEventRegistered, state.isEventWaitlisted);
       }
     });
     applyFilter(listEl, state);
@@ -1206,6 +1212,7 @@ async function loadBlock(el, rsvpConfig) {
 
   const rsvpData = BlockMediator.get('rsvpData');
   const isEventRegistered = rsvpData?.registrationStatus === 'registered';
+  const isEventWaitlisted = rsvpData?.registrationStatus === 'waitlisted';
   const [registeredSessionIds, tagsData] = await Promise.all([
     resolveRegistrationState(eventData.eventId, isEventRegistered),
     Promise.resolve(getCaasTags()).catch(() => null),
@@ -1227,19 +1234,20 @@ async function loadBlock(el, rsvpConfig) {
     locationMap,
     registeredSessionIds,
     isEventRegistered,
+    isEventWaitlisted,
     rsvpConfig,
   };
   setState(state);
 
   const toolbar = renderToolbar(state);
   setToolbarStickyOffset(toolbar);
-  const listEl = renderSessionList(sessions, isEventRegistered);
+  const listEl = renderSessionList(sessions, isEventRegistered, isEventWaitlisted);
   el.append(toolbar, listEl);
 
-  // Always append banner; hide it if user is already registered
+  // Always append banner; hide it if user is already registered or waitlisted
   el.querySelector('.sh-event-banner')?.remove();
   const bannerEl = renderEventBanner(rsvpConfig);
-  if (isEventRegistered) bannerEl.classList.add('hidden');
+  if (isEventRegistered || isEventWaitlisted) bannerEl.classList.add('hidden');
   el.append(bannerEl);
 
   bindToolbarEvents(toolbar, listEl, state);

--- a/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
+++ b/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
@@ -731,3 +731,168 @@ describe('card expand/collapse', () => {
     expect(card.classList.contains('expanded')).to.be.false;
   });
 });
+
+// ─── isSessionTimeFullError (waitlist-on-error detection) ────────────────────
+
+describe('isSessionTimeFullError', () => {
+  const isSessionTimeFullError = (resp) => {
+    const err = resp?.error;
+    if (!err) return false;
+    const candidates = [err.code, err.errorCode, err.error, err.type, err.message];
+    return candidates.some((v) => typeof v === 'string' && v.includes('SessionTimeFull'));
+  };
+
+  it('returns false when response has no error field', () => {
+    expect(isSessionTimeFullError({ ok: true, data: {} })).to.be.false;
+    expect(isSessionTimeFullError({})).to.be.false;
+    expect(isSessionTimeFullError(null)).to.be.false;
+  });
+
+  it('detects SessionTimeFull on err.code', () => {
+    expect(isSessionTimeFullError({ ok: false, error: { code: 'SessionTimeFull' } })).to.be.true;
+  });
+
+  it('detects SessionTimeFull on err.errorCode', () => {
+    expect(isSessionTimeFullError({ ok: false, error: { errorCode: 'SessionTimeFull' } })).to.be.true;
+  });
+
+  it('detects SessionTimeFull on err.message substring', () => {
+    expect(isSessionTimeFullError({
+      ok: false,
+      error: { message: 'Cannot register: SessionTimeFull capacity reached' },
+    })).to.be.true;
+  });
+
+  it('returns false for unrelated error codes', () => {
+    expect(isSessionTimeFullError({ ok: false, error: { code: 'ValidationError' } })).to.be.false;
+    expect(isSessionTimeFullError({ ok: false, error: { message: 'Network timeout' } })).to.be.false;
+  });
+});
+
+// ─── handleSessionRegistration response handling ─────────────────────────────
+
+describe('handleSessionRegistration response handling', () => {
+  // Inline the post-API decision logic from sessions-hub.js to validate the
+  // bug fix: a waitlisted response must NOT mark the session as registered,
+  // and a SessionTimeFull error must trigger a waitlist retry.
+
+  function classifyOutcome(resp, retryFn) {
+    let waitlisted = resp.ok && resp.data?.registrationStatus === 'waitlisted';
+    let finalResp = resp;
+
+    if (!resp.ok) {
+      const err = resp.error;
+      const candidates = [err?.code, err?.errorCode, err?.error, err?.type, err?.message];
+      const isFullErr = candidates.some((v) => typeof v === 'string' && v.includes('SessionTimeFull'));
+      if (isFullErr) {
+        const retry = retryFn();
+        if (retry.ok) {
+          finalResp = retry;
+          waitlisted = true;
+        } else {
+          finalResp = retry;
+        }
+      }
+    }
+
+    if (!finalResp.ok) return { state: 'error', waitlisted: false };
+    return { state: waitlisted ? 'waitlisted' : 'registered', waitlisted };
+  }
+
+  it('classifies a 200 OK with registrationStatus=waitlisted as waitlisted', () => {
+    const resp = { ok: true, data: { registrationStatus: 'waitlisted' } };
+    const result = classifyOutcome(resp, () => { throw new Error('retry should not be called'); });
+    expect(result.state).to.equal('waitlisted');
+    expect(result.waitlisted).to.be.true;
+  });
+
+  it('classifies a 200 OK with registrationStatus=registered as registered', () => {
+    const resp = { ok: true, data: { registrationStatus: 'registered' } };
+    const result = classifyOutcome(resp, () => { throw new Error('retry should not be called'); });
+    expect(result.state).to.equal('registered');
+    expect(result.waitlisted).to.be.false;
+  });
+
+  it('retries with waitlist on SessionTimeFull and marks waitlisted on retry success', () => {
+    const initial = { ok: false, status: 409, error: { code: 'SessionTimeFull' } };
+    const retry = { ok: true, data: { registrationStatus: 'waitlisted' } };
+    const result = classifyOutcome(initial, () => retry);
+    expect(result.state).to.equal('waitlisted');
+    expect(result.waitlisted).to.be.true;
+  });
+
+  it('reports error if SessionTimeFull retry also fails', () => {
+    const initial = { ok: false, status: 409, error: { code: 'SessionTimeFull' } };
+    const retry = { ok: false, status: 500, error: { message: 'Server error' } };
+    const result = classifyOutcome(initial, () => retry);
+    expect(result.state).to.equal('error');
+  });
+
+  it('does not retry for non-SessionTimeFull errors', () => {
+    const initial = { ok: false, status: 400, error: { code: 'ValidationError' } };
+    let retryCalled = false;
+    const result = classifyOutcome(initial, () => { retryCalled = true; return { ok: true }; });
+    expect(retryCalled).to.be.false;
+    expect(result.state).to.equal('error');
+  });
+});
+
+// ─── renderCTAGroup waitlist branch ──────────────────────────────────────────
+
+describe('renderCTAGroup with waitlisted session', () => {
+  function inlineRenderCTAGroup(session, isEventRegistered) {
+    const group = document.createElement('div');
+    group.className = 'sh-cta-group';
+
+    if (!isEventRegistered) {
+      const btn = document.createElement('button');
+      btn.className = 'sh-btn sh-btn-register-event';
+      btn.type = 'button';
+      btn.textContent = 'Register for session';
+      group.append(btn);
+    } else if (!session.isRegistered && !session.isWaitlisted) {
+      const btn = document.createElement('button');
+      btn.className = 'sh-btn sh-btn-register-session';
+      btn.type = 'button';
+      btn.textContent = 'Register for session';
+      group.append(btn);
+    } else {
+      const isWaitlisted = !session.isRegistered && session.isWaitlisted;
+      const calBtn = document.createElement('button');
+      calBtn.className = 'sh-btn sh-btn-cal';
+      calBtn.type = 'button';
+      group.append(calBtn);
+
+      const badge = document.createElement('button');
+      badge.className = 'sh-btn sh-registered-badge';
+      const label = isWaitlisted ? 'waitlisted-cta-text' : 'Registered';
+      const labelSpan = document.createElement('span');
+      labelSpan.textContent = label;
+      badge.append(labelSpan);
+      group.append(badge);
+    }
+
+    return group;
+  }
+
+  it('shows waitlisted badge (using waitlisted-cta-text) when session.isWaitlisted is true', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: true }, true);
+    const badge = group.querySelector('.sh-registered-badge');
+    expect(badge).to.not.be.null;
+    expect(badge.textContent).to.include('waitlisted-cta-text');
+    expect(group.querySelector('.sh-btn-register-session')).to.be.null;
+  });
+
+  it('shows "Registered" badge when session.isRegistered is true', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: true, isWaitlisted: false }, true);
+    const badge = group.querySelector('.sh-registered-badge');
+    expect(badge.textContent).to.include('Registered');
+    expect(badge.textContent).to.not.include('waitlisted-cta-text');
+  });
+
+  it('shows "Register for session" CTA when neither registered nor waitlisted', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, true);
+    expect(group.querySelector('.sh-btn-register-session')).to.not.be.null;
+    expect(group.querySelector('.sh-registered-badge')).to.be.null;
+  });
+});


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-192675
https://jira.corp.adobe.com/browse/MWPW-192560

Fixes two related bugs in `sessions-hub` session-card RSVP:                                                         
                                                                                                                      
  - **Wrong success state on a full session** — when ESP returned `200 OK` with `registrationStatus: "waitlisted"`    
  (user was added to the session-time waitlist), the card flipped to the "Registered" state because
  `handleSessionRegistration` only checked `resp.ok`, never the response body.                                        
  - **CTA never transitioned to a waitlist state** — when ESP returned a `SessionTimeFull` error, the code took the   
  generic error branch and reverted the button to "Register for session". The session model had no `isWaitlisted`     
  field, so even a successful waitlist join had nowhere to live in the UI.
                                                                                                                      
  ## Changes                                             

  **`event-libs/v1/blocks/sessions-hub/sessions-hub.js`**

  - Added `isWaitlisted` to the session shape produced by `normalizeSessions` (defaults to `false`).                  
  - `handleSessionRegistration` now reads the response body, not just `ok`:
    - `resp.ok` with `data.registrationStatus === 'waitlisted'` → marks `session.isWaitlisted` (not registered) and   
  skips `registeredSessionIds`.                                                                                       
    - `!resp.ok` matching `SessionTimeFull` → retries with `registrationStatus: 'waitlisted'`. On retry success, marks
   waitlisted; otherwise falls through to the existing error path.                                                    
    - All other outcomes behave as before.               
  - New `isSessionTimeFullError(resp)` helper checks `error.code | errorCode | error | type | message` for the        
  `SessionTimeFull` token (defensive against ESP error-shape variation).                                              
  - `renderCTAGroup` now renders the same badge shell for the waitlisted branch as for the registered branch,         
  differing only in the dictionary key (`waitlisted-cta-text` vs `Registered`) and hover label (`Leave waitlist` vs   
  `Unregister`). Mirrors the event-level pattern in `decorate.js`'s `setCtaState('waitlisted', …)`.
  - `handleSessionUnregistration` clears `isWaitlisted` on success and restores the correct label (registered vs.     
  waitlisted) on error.                                                                                               
  
  **Reused existing dictionary key:** the badge label uses `waitlisted-cta-text`, the same key already used by        
  `decorate.js` for the event-level waitlist CTA — so localized text comes through automatically.
