### PR TITLE
Updated logic for sessions registration

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -692,7 +692,8 @@
   background: #fff;
 }
 
-.sh-event-banner .sh-banner-invite-only-msg {
+.sh-event-banner .sh-banner-invite-only-msg,
+.sh-event-banner .sh-banner-waitlist-msg {
   font-size: 16px;
   line-height: 1.4;
   max-width: 420px;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -8,7 +8,7 @@ import {
   loadStyle,
   getValidCampaignIdFromUrl,
 } from '../../utils/utils.js';
-import { dictionaryManager, getInviteOnlyNoCampaignMessage } from '../../utils/dictionary-manager.js';
+import { dictionaryManager, getInviteOnlyNoCampaignMessage, getEventWaitlistBannerMessage } from '../../utils/dictionary-manager.js';
 import { signIn } from '../../utils/decorate.js';
 import { buildModalContent } from '../profile-cards/profile-cards.js';
 import { createSmartDateRange } from '../../utils/date-time-helper.js';
@@ -186,6 +186,19 @@ function isSessionTimeFullError(resp) {
   return candidates.some((v) => typeof v === 'string' && v.includes('SessionTimeFull'));
 }
 
+function computeIsEventClosed(eventData) {
+  if (!eventData?.isFull) return false;
+  // ESP returns allowWaitlisting as either boolean `true` or string `'true'` depending on source.
+  // Match both — anything truthy that isn't the literal string 'false' counts as enabled.
+  const waitlistEnabled = eventData.allowWaitlisting === true
+    || eventData.allowWaitlisting === 'true';
+  return !waitlistEnabled;
+}
+
+function isSessionRegistrationBlocked({ isEventWaitlisted, isEventClosed, inviteOnlyBlocked }) {
+  return Boolean(isEventWaitlisted || isEventClosed || inviteOnlyBlocked);
+}
+
 function findConflictingSession(newSession, state) {
   const newTime = newSession.sessionTimes[0];
   if (!newTime) return null;
@@ -306,22 +319,11 @@ function applyFilter(listEl, state) {
 
 // ─── Render: CTA group ───────────────────────────────────────────────────────
 
-function renderCTAGroup(session, isEventRegistered, inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted = false) {
+function renderCTAGroup(session, { isEventRegistered = false, isBlocked = false } = {}) {
   const group = createTag('div', { class: 'sh-cta-group' });
 
-  if (isEventWaitlisted && !isEventRegistered) {
-    const btn = createTag('button', { class: 'sh-btn sh-btn-register-event sh-event-waitlisted-badge', type: 'button' });
-    btn.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('waitlisted-cta-text')));
-    group.append(btn);
-  } else if (!isEventRegistered) {
-    if (inviteOnlyBlocked) {
-      group.append(createTag('p', { class: 'sh-invite-only-msg', role: 'status' }, inviteOnlyMessage));
-    } else {
-      group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
-    }
-  } else if (!session.isRegistered && !session.isWaitlisted) {
-    group.append(createTag('button', { class: 'sh-btn sh-btn-register-session', type: 'button' }, dictionaryManager.getValue('Register for session')));
-  } else {
+  // State 1: registered or waitlisted for THIS session — badge with hover-to-unregister
+  if (isEventRegistered && (session.isRegistered || session.isWaitlisted)) {
     const calBtn = createTag('button', { class: 'sh-btn sh-btn-cal', type: 'button' });
     calBtn.append(createIcon(CTA_CALENDAR_ICON), createTag('span', {}, dictionaryManager.getValue('Download to calendar')));
     group.append(calBtn);
@@ -355,22 +357,36 @@ function renderCTAGroup(session, isEventRegistered, inviteOnlyBlocked, inviteOnl
     };
     badge.addEventListener('mouseenter', () => { if (!badge.disabled) setUnregisterContent(); });
     badge.addEventListener('mouseleave', () => { if (!badge.disabled) setIdleContent(); });
+    return group;
   }
 
+  // State 3: blocked — disabled button (event-waitlisted, event-closed, or invite-only without campaign)
+  if (isBlocked) {
+    const btn = createTag('button', {
+      class: 'sh-btn sh-btn-blocked',
+      type: 'button',
+      disabled: '',
+      'aria-disabled': 'true',
+    }, dictionaryManager.getValue('Registration unavailable'));
+    group.append(btn);
+    return group;
+  }
+
+  // State 2: able to register — direct-API button (no modal)
+  if (isEventRegistered) {
+    group.append(createTag('button', { class: 'sh-btn sh-btn-register-session', type: 'button' }, dictionaryManager.getValue('Register for session')));
+    return group;
+  }
+
+  // Default: not yet event-registered, not blocked — opens RSVP modal
+  group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
   return group;
 }
 
-function updateCTAGroup(cardEl, session, isEventRegistered, isEventWaitlisted = false) {
-  const state = getState();
+function updateCTAGroup(cardEl, session, opts = {}) {
   const old = cardEl.querySelector('.sh-cta-group');
   if (!old) return;
-  old.replaceWith(renderCTAGroup(
-    session,
-    isEventRegistered,
-    state?.inviteOnlyBlocked ?? false,
-    state?.inviteOnlyMessage ?? '',
-    isEventWaitlisted,
-  ));
+  old.replaceWith(renderCTAGroup(session, opts));
 }
 
 // ─── Session description overflow (matches CSS -webkit-line-clamp) ───────────
@@ -476,7 +492,7 @@ function renderSpeakerAvatars(speakers) {
   return wrap;
 }
 
-function renderSessionCard(session, isEventRegistered, inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted = false) {
+function renderSessionCard(session, opts = {}) {
   const primaryTime = session.sessionTimes[0];
   const timeStr = primaryTime
     ? createSmartDateRange(primaryTime.startTimeMillis, primaryTime.endTimeMillis, 'en-US', primaryTime.timezone)
@@ -537,21 +553,15 @@ function renderSessionCard(session, isEventRegistered, inviteOnlyBlocked, invite
   descText.innerHTML = fullDesc;
 
   desc.append(descText);
-  right.append(desc, renderCTAGroup(session, isEventRegistered, inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted));
+  right.append(desc, renderCTAGroup(session, opts));
 
   card.append(left, right);
   return card;
 }
 
-function renderSessionList(sessions, isEventRegistered, inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted = false) {
+function renderSessionList(sessions, opts = {}) {
   const list = createTag('div', { class: 'sh-session-list' });
-  sessions.forEach((s) => list.append(renderSessionCard(
-    s,
-    isEventRegistered,
-    inviteOnlyBlocked,
-    inviteOnlyMessage,
-    isEventWaitlisted,
-  )));
+  sessions.forEach((s) => list.append(renderSessionCard(s, opts)));
   return list;
 }
 
@@ -655,7 +665,7 @@ function buildBannerDateString() {
   return createSmartDateRange(startMillis, endMillis, 'en-US', timezone);
 }
 
-function renderEventBanner(rsvpConfig, inviteOnlyBlocked, inviteOnlyMessage) {
+function renderEventBanner(rsvpConfig, { inviteOnlyBlocked = false, inviteOnlyMessage = '', isEventWaitlisted = false, waitlistBannerMessage = '' } = {}) {
   const banner = createTag('aside', { class: 'sh-event-banner', 'aria-label': dictionaryManager.getValue('Event registration') });
   const inner = createTag('div', { class: 'sh-banner-inner' });
   const info = createTag('div', { class: 'sh-banner-info' });
@@ -680,7 +690,13 @@ function renderEventBanner(rsvpConfig, inviteOnlyBlocked, inviteOnlyMessage) {
       createTag('p', { class: 'sh-banner-invite-only-msg', role: 'status' }, inviteOnlyMessage),
     );
   } else {
-    const btn = createTag('button', { class: 'sh-btn sh-btn-event-register', type: 'button' }, dictionaryManager.getValue('Register'));
+    const btn = createTag('button', { class: 'sh-btn sh-btn-event-register', type: 'button' });
+    if (isEventWaitlisted) {
+      btn.classList.add('sh-event-register-waitlisted');
+      btn.append(createIcon(CHECKMARK_ICON), createTag('span', {}, dictionaryManager.getValue('waitlisted-cta-text')));
+    } else {
+      btn.append(createTag('span', {}, dictionaryManager.getValue('Register')));
+    }
     btn.addEventListener('click', () => {
       const profile = BlockMediator.get('imsProfile');
       const isSignedOut = !profile || profile.noProfile || profile.account_type === 'guest';
@@ -691,7 +707,13 @@ function renderEventBanner(rsvpConfig, inviteOnlyBlocked, inviteOnlyMessage) {
         openRsvpModal(rsvpConfig);
       }
     });
-    inner.append(info, btn);
+
+    if (isEventWaitlisted) {
+      const msg = createTag('p', { class: 'sh-banner-waitlist-msg', role: 'status' }, waitlistBannerMessage);
+      inner.append(info, msg, btn);
+    } else {
+      inner.append(info, btn);
+    }
   }
 
   banner.append(inner);
@@ -944,6 +966,15 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
   const firstTime = session.sessionTimes[0];
   if (!firstTime) return;
 
+  // Defensive: never attempt session registration when blocked at the event level.
+  // The disabled CTA prevents clicks, but an auto-fired flow (e.g. pendingSessionId)
+  // could still reach this point.
+  if (isSessionRegistrationBlocked({
+    isEventWaitlisted: state.isEventWaitlisted,
+    isEventClosed: state.isEventClosed,
+    inviteOnlyBlocked: state.inviteOnlyBlocked,
+  })) return;
+
   // ── Conflict detection ────────────────────────────────────────────────────
   const conflictingSession = findConflictingSession(session, state);
   let conflictFinalize = null;
@@ -969,7 +1000,7 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
       state.registeredSessionIds.delete(conflictingSession.sessionId);
       const conflictCard = cardEl.closest('.sh-session-list')
         ?.querySelector(`[data-session-id="${conflictingSession.sessionId}"]`);
-      if (conflictCard) updateCTAGroup(conflictCard, conflictingSession, true, state.isEventWaitlisted);
+      if (conflictCard) updateCTAGroup(conflictCard, conflictingSession, { isEventRegistered: true, isBlocked: false });
       const existing = BlockMediator.get('registeredSessionIds') || new Set();
       const updated = new Set([...existing]);
       updated.delete(conflictingSession.sessionId);
@@ -1008,7 +1039,7 @@ async function handleSessionRegistration(cardEl, sessionId, state) {
       const existing = BlockMediator.get('registeredSessionIds') || new Set();
       BlockMediator.set('registeredSessionIds', new Set([...existing, sessionId]));
     }
-    updateCTAGroup(cardEl, session, true, state.isEventWaitlisted);
+    updateCTAGroup(cardEl, session, { isEventRegistered: true, isBlocked: false });
     if (conflictFinalize) conflictFinalize(true);
   } else {
     window.lana?.log(`Error: Failed to register for session ${sessionId}. Error:${JSON.stringify(resp.error)}`);
@@ -1043,7 +1074,7 @@ async function handleSessionUnregistration(cardEl, sessionId, state) {
     session.isRegistered = false;
     session.isWaitlisted = false;
     state.registeredSessionIds.delete(sessionId);
-    updateCTAGroup(cardEl, session, true, state.isEventWaitlisted);
+    updateCTAGroup(cardEl, session, { isEventRegistered: true, isBlocked: false });
     const existing = BlockMediator.get('registeredSessionIds') || new Set();
     const updated = new Set([...existing]);
     updated.delete(sessionId);
@@ -1108,17 +1139,8 @@ function bindCardEvents(listEl, state) {
 
     if (e.target.closest('.sh-btn-register-event')) {
       const btn = e.target.closest('.sh-btn-register-event');
-      const isAlreadyWaitlisted = btn?.classList.contains('sh-event-waitlisted-badge');
 
       if (state.inviteOnlyBlocked) return;
-
-      if (isAlreadyWaitlisted) {
-        // User is already on the event waitlist \u2014 just re-open the modal so
-        // they can cancel waitlist or review status. Do not set pendingSessionId
-        // or relabel the button.
-        if (state.rsvpConfig) openRsvpModal(state.rsvpConfig);
-        return;
-      }
 
       const profile = BlockMediator.get('imsProfile');
       const isSignedOut = !profile || profile.noProfile || profile.account_type === 'guest';
@@ -1151,15 +1173,32 @@ function bindCardEvents(listEl, state) {
   });
 }
 
-function bindMediatorSubscriptions(el, bannerEl, listEl) {
-  rsvpUnsubscribe = BlockMediator.subscribe('rsvpData', async ({ newValue }) => {
+function refreshEventBanner(el, rsvpConfig, opts) {
+  const current = el.querySelector('.sh-event-banner');
+  const wasHidden = current?.classList.contains('hidden') ?? false;
+  const fresh = renderEventBanner(rsvpConfig, opts);
+  if (wasHidden) fresh.classList.add('hidden');
+  if (current) current.replaceWith(fresh);
+  else el.append(fresh);
+  return fresh;
+}
+
+function bindMediatorSubscriptions(el, listEl) {
+  const handleRsvpDataChange = async (newValue) => {
     const state = getState();
     const isRegistered = newValue?.registrationStatus === 'registered';
     const isWaitlisted = newValue?.registrationStatus === 'waitlisted';
     state.isEventRegistered = isRegistered;
     state.isEventWaitlisted = isWaitlisted;
 
-    syncBannerVisibility(bannerEl, isRegistered || isWaitlisted);
+    // Re-render banner so its button reflects waitlist state, then apply visibility
+    const newBanner = refreshEventBanner(el, state.rsvpConfig, {
+      inviteOnlyBlocked: state.inviteOnlyBlocked,
+      inviteOnlyMessage: state.inviteOnlyMessage,
+      isEventWaitlisted: isWaitlisted,
+      waitlistBannerMessage: state.waitlistBannerMessage,
+    });
+    syncBannerVisibility(newBanner, isRegistered);
 
     const toggle = el.querySelector('.sh-tab-toggle');
     if (toggle) toggle.hidden = !isRegistered;
@@ -1167,6 +1206,12 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
     const cardMap = new Map(
       [...el.querySelectorAll('.sh-card')].map((c) => [c.dataset.sessionId, c]),
     );
+
+    const isBlocked = isSessionRegistrationBlocked({
+      isEventWaitlisted: isWaitlisted,
+      isEventClosed: state.isEventClosed,
+      inviteOnlyBlocked: state.inviteOnlyBlocked,
+    });
 
     if (isRegistered) {
       const ids = await resolveRegistrationState(state.eventData.eventId, true);
@@ -1176,7 +1221,7 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
       state.sessions.forEach((session) => {
         session.isRegistered = mergedIds.has(session.sessionId);
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, true, false);
+        if (cardEl) updateCTAGroup(cardEl, session, { isEventRegistered: true, isBlocked: false });
       });
 
       if (pendingSessionId) {
@@ -1193,7 +1238,7 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
       state.sessions.forEach((session) => {
         session.isRegistered = false;
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, false, isWaitlisted);
+        if (cardEl) updateCTAGroup(cardEl, session, { isEventRegistered: false, isBlocked });
       });
 
       // Reset to "All sessions" tab when user un-registers
@@ -1208,7 +1253,23 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
     }
 
     applyFilter(listEl, state);
-  });
+  };
+
+  rsvpUnsubscribe = BlockMediator.subscribe('rsvpData', ({ newValue }) => handleRsvpDataChange(newValue));
+
+  // Reconcile against the current rsvpData snapshot in case captureProfile
+  // (in profile.js) or the events-form modal set it BETWEEN the initial
+  // loadBlock read and this subscription registration. BlockMediator does not
+  // replay current values to new subscribers, so we manually apply them once.
+  const state = getState();
+  const currentRsvp = BlockMediator.get('rsvpData');
+  const currentStatus = currentRsvp?.registrationStatus;
+  const renderedStatus = state.isEventRegistered
+    ? 'registered'
+    : (state.isEventWaitlisted ? 'waitlisted' : null);
+  if (currentStatus !== renderedStatus) {
+    handleRsvpDataChange(currentRsvp);
+  }
 
   BlockMediator.subscribe('registeredSessionIds', ({ newValue }) => {
     const state = getState();
@@ -1216,12 +1277,17 @@ function bindMediatorSubscriptions(el, bannerEl, listEl) {
     const cardMap = new Map(
       [...el.querySelectorAll('.sh-card')].map((c) => [c.dataset.sessionId, c]),
     );
+    const isBlocked = isSessionRegistrationBlocked({
+      isEventWaitlisted: state.isEventWaitlisted,
+      isEventClosed: state.isEventClosed,
+      inviteOnlyBlocked: state.inviteOnlyBlocked,
+    });
     state.sessions.forEach((session) => {
       if (newValue.has(session.sessionId) && !session.isRegistered) {
         session.isRegistered = true;
         state.registeredSessionIds.add(session.sessionId);
         const cardEl = cardMap.get(session.sessionId);
-        if (cardEl) updateCTAGroup(cardEl, session, state.isEventRegistered, state.isEventWaitlisted);
+        if (cardEl) updateCTAGroup(cardEl, session, { isEventRegistered: state.isEventRegistered, isBlocked });
       }
     });
     applyFilter(listEl, state);
@@ -1245,6 +1311,9 @@ async function loadBlock(el, rsvpConfig) {
 
   const inviteOnlyBlocked = Boolean(eventData.inviteOnly && !getValidCampaignIdFromUrl());
   const inviteOnlyMessage = getInviteOnlyNoCampaignMessage(dictionaryManager);
+  const waitlistBannerMessage = getEventWaitlistBannerMessage(dictionaryManager, {
+    eventTitle: getMetadata('event-title') || '',
+  });
 
   let rawSessions;
   try {
@@ -1267,6 +1336,7 @@ async function loadBlock(el, rsvpConfig) {
   const rsvpData = BlockMediator.get('rsvpData');
   const isEventRegistered = rsvpData?.registrationStatus === 'registered';
   const isEventWaitlisted = rsvpData?.registrationStatus === 'waitlisted';
+  const isEventClosed = computeIsEventClosed(eventData);
   const [registeredSessionIds, tagsData] = await Promise.all([
     resolveRegistrationState(eventData.eventId, isEventRegistered),
     Promise.resolve(getCaasTags()).catch(() => null),
@@ -1289,26 +1359,31 @@ async function loadBlock(el, rsvpConfig) {
     registeredSessionIds,
     isEventRegistered,
     isEventWaitlisted,
+    isEventClosed,
     rsvpConfig,
     inviteOnlyBlocked,
     inviteOnlyMessage,
+    waitlistBannerMessage,
   };
   setState(state);
 
+  const isBlocked = isSessionRegistrationBlocked({ isEventWaitlisted, isEventClosed, inviteOnlyBlocked });
+
   const toolbar = renderToolbar(state);
   setToolbarStickyOffset(toolbar);
-  const listEl = renderSessionList(sessions, isEventRegistered, inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted);
+  const listEl = renderSessionList(sessions, { isEventRegistered, isBlocked });
   el.append(toolbar, listEl);
 
-  // Always append banner; hide it if user is already registered or waitlisted
+  // Always append banner; hide it only if user is already event-registered.
+  // (Waitlisted users keep the banner visible so they can manage their waitlist.)
   el.querySelector('.sh-event-banner')?.remove();
-  const bannerEl = renderEventBanner(rsvpConfig, inviteOnlyBlocked, inviteOnlyMessage);
-  if (isEventRegistered || isEventWaitlisted) bannerEl.classList.add('hidden');
+  const bannerEl = renderEventBanner(rsvpConfig, { inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted, waitlistBannerMessage });
+  if (isEventRegistered) bannerEl.classList.add('hidden');
   el.append(bannerEl);
 
   bindToolbarEvents(toolbar, listEl, state);
   bindCardEvents(listEl, state);
-  bindMediatorSubscriptions(el, bannerEl, listEl);
+  bindMediatorSubscriptions(el, listEl);
 
   try {
     await document.fonts?.ready;

--- a/event-libs/v1/utils/dictionary-manager.js
+++ b/event-libs/v1/utils/dictionary-manager.js
@@ -180,3 +180,22 @@ export function getInviteOnlyNoCampaignMessage(manager) {
     ? 'Registration is only available through a valid invitation link.'
     : text;
 }
+
+export const EVENT_WAITLIST_BANNER_MESSAGE_KEY = 'event-waitlist-banner-msg';
+
+/**
+ * Localized banner message shown when the user is on the event-level waitlist.
+ * Supports optional `{eventTitle}` token substitution to mirror the events-form
+ * waitlist success modal copy ("You've been added to the waitlist for {eventTitle}").
+ * @param {DictionaryManager} manager - Initialized dictionary manager instance
+ * @param {Object} [tokens] - Tokens to interpolate into the dictionary value
+ * @param {string} [tokens.eventTitle] - Event title to substitute for `{eventTitle}`
+ * @returns {string}
+ */
+export function getEventWaitlistBannerMessage(manager, { eventTitle = '' } = {}) {
+  const raw = manager.getValue(EVENT_WAITLIST_BANNER_MESSAGE_KEY);
+  const text = raw === EVENT_WAITLIST_BANNER_MESSAGE_KEY
+    ? "You're on the event waitlist. Session registration will be available if a spot opens up."
+    : raw;
+  return text.replace(/\{eventTitle\}/g, eventTitle);
+}

--- a/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
+++ b/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
@@ -846,62 +846,189 @@ describe('handleSessionRegistration response handling', () => {
   });
 });
 
-// ─── renderCTAGroup waitlist branch ──────────────────────────────────────────
+// ─── isSessionRegistrationBlocked predicate ─────────────────────────────────
 
-describe('renderCTAGroup with waitlisted session', () => {
-  function inlineRenderCTAGroup(session, isEventRegistered) {
+describe('isSessionRegistrationBlocked', () => {
+  const isSessionRegistrationBlocked = ({ isEventWaitlisted, isEventClosed, inviteOnlyBlocked }) => Boolean(
+    isEventWaitlisted || isEventClosed || inviteOnlyBlocked,
+  );
+
+  it('returns false when no gating flag is set', () => {
+    expect(isSessionRegistrationBlocked({})).to.be.false;
+    expect(isSessionRegistrationBlocked({ isEventWaitlisted: false, isEventClosed: false, inviteOnlyBlocked: false })).to.be.false;
+  });
+
+  it('returns true when event is waitlisted', () => {
+    expect(isSessionRegistrationBlocked({ isEventWaitlisted: true })).to.be.true;
+  });
+
+  it('returns true when event is closed', () => {
+    expect(isSessionRegistrationBlocked({ isEventClosed: true })).to.be.true;
+  });
+
+  it('returns true when invite-only is blocked', () => {
+    expect(isSessionRegistrationBlocked({ inviteOnlyBlocked: true })).to.be.true;
+  });
+
+  it('returns true when any combination of flags is set', () => {
+    expect(isSessionRegistrationBlocked({ isEventWaitlisted: true, isEventClosed: true })).to.be.true;
+    expect(isSessionRegistrationBlocked({ isEventClosed: true, inviteOnlyBlocked: true })).to.be.true;
+  });
+});
+
+// ─── computeIsEventClosed ───────────────────────────────────────────────────
+
+describe('computeIsEventClosed', () => {
+  const computeIsEventClosed = (eventData) => {
+    if (!eventData?.isFull) return false;
+    const waitlistEnabled = eventData.allowWaitlisting === true
+      || eventData.allowWaitlisting === 'true';
+    return !waitlistEnabled;
+  };
+
+  it('returns false for missing eventData', () => {
+    expect(computeIsEventClosed(null)).to.be.false;
+    expect(computeIsEventClosed(undefined)).to.be.false;
+  });
+
+  it('returns false when not full', () => {
+    expect(computeIsEventClosed({ isFull: false, allowWaitlisting: 'false' })).to.be.false;
+  });
+
+  it('returns false when full but waitlist is enabled (string "true")', () => {
+    expect(computeIsEventClosed({ isFull: true, allowWaitlisting: 'true' })).to.be.false;
+  });
+
+  it('returns false when full but waitlist is enabled (boolean true)', () => {
+    expect(computeIsEventClosed({ isFull: true, allowWaitlisting: true })).to.be.false;
+  });
+
+  it('returns true when full and waitlist is not enabled (string "false")', () => {
+    expect(computeIsEventClosed({ isFull: true, allowWaitlisting: 'false' })).to.be.true;
+  });
+
+  it('returns true when full and waitlist is missing/falsy', () => {
+    expect(computeIsEventClosed({ isFull: true })).to.be.true;
+    expect(computeIsEventClosed({ isFull: true, allowWaitlisting: false })).to.be.true;
+    expect(computeIsEventClosed({ isFull: true, allowWaitlisting: null })).to.be.true;
+  });
+});
+
+// ─── renderCTAGroup 3-state design ──────────────────────────────────────────
+
+describe('renderCTAGroup three-state design', () => {
+  // Inline reproduction of the 3-state branch in renderCTAGroup so we can
+  // exercise it in isolation without bootstrapping the full block.
+  function inlineRenderCTAGroup(session, { isEventRegistered = false, isBlocked = false } = {}) {
     const group = document.createElement('div');
     group.className = 'sh-cta-group';
 
-    if (!isEventRegistered) {
-      const btn = document.createElement('button');
-      btn.className = 'sh-btn sh-btn-register-event';
-      btn.type = 'button';
-      btn.textContent = 'Register for session';
-      group.append(btn);
-    } else if (!session.isRegistered && !session.isWaitlisted) {
-      const btn = document.createElement('button');
-      btn.className = 'sh-btn sh-btn-register-session';
-      btn.type = 'button';
-      btn.textContent = 'Register for session';
-      group.append(btn);
-    } else {
-      const isWaitlisted = !session.isRegistered && session.isWaitlisted;
+    // State 1: registered or waitlisted for THIS session — badge
+    if (isEventRegistered && (session.isRegistered || session.isWaitlisted)) {
       const calBtn = document.createElement('button');
       calBtn.className = 'sh-btn sh-btn-cal';
-      calBtn.type = 'button';
       group.append(calBtn);
 
+      const isWaitlisted = !session.isRegistered && session.isWaitlisted;
       const badge = document.createElement('button');
       badge.className = 'sh-btn sh-registered-badge';
+      badge.disabled = true;
       const label = isWaitlisted ? 'waitlisted-cta-text' : 'Registered';
       const labelSpan = document.createElement('span');
       labelSpan.textContent = label;
       badge.append(labelSpan);
       group.append(badge);
+      return group;
     }
 
+    // State 3: blocked — disabled button
+    if (isBlocked) {
+      const btn = document.createElement('button');
+      btn.className = 'sh-btn sh-btn-blocked';
+      btn.type = 'button';
+      btn.disabled = true;
+      btn.setAttribute('aria-disabled', 'true');
+      btn.textContent = 'Registration unavailable';
+      group.append(btn);
+      return group;
+    }
+
+    // State 2: able to register — direct-API button
+    if (isEventRegistered) {
+      const btn = document.createElement('button');
+      btn.className = 'sh-btn sh-btn-register-session';
+      btn.type = 'button';
+      btn.textContent = 'Register for session';
+      group.append(btn);
+      return group;
+    }
+
+    // Default: not yet event-registered, not blocked
+    const btn = document.createElement('button');
+    btn.className = 'sh-btn sh-btn-register-event';
+    btn.type = 'button';
+    btn.textContent = 'Register for session';
+    group.append(btn);
     return group;
   }
 
-  it('shows waitlisted badge (using waitlisted-cta-text) when session.isWaitlisted is true', () => {
-    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: true }, true);
-    const badge = group.querySelector('.sh-registered-badge');
-    expect(badge).to.not.be.null;
-    expect(badge.textContent).to.include('waitlisted-cta-text');
+  it('renders disabled blocked button when isBlocked is true (event-waitlisted)', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, { isEventRegistered: false, isBlocked: true });
+    const blocked = group.querySelector('.sh-btn-blocked');
+    expect(blocked).to.not.be.null;
+    expect(blocked.disabled).to.be.true;
+    expect(blocked.getAttribute('aria-disabled')).to.equal('true');
+    expect(blocked.textContent).to.include('Registration unavailable');
+    expect(group.querySelector('.sh-btn-register-session')).to.be.null;
+    expect(group.querySelector('.sh-btn-register-event')).to.be.null;
+  });
+
+  it('renders blocked button when event-registered but blocked (defensive case)', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, { isEventRegistered: true, isBlocked: true });
+    expect(group.querySelector('.sh-btn-blocked')).to.not.be.null;
     expect(group.querySelector('.sh-btn-register-session')).to.be.null;
   });
 
-  it('shows "Registered" badge when session.isRegistered is true', () => {
-    const group = inlineRenderCTAGroup({ isRegistered: true, isWaitlisted: false }, true);
+  it('renders direct-API "Register for session" when event-registered and able to register', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, { isEventRegistered: true, isBlocked: false });
+    expect(group.querySelector('.sh-btn-register-session')).to.not.be.null;
+    expect(group.querySelector('.sh-btn-blocked')).to.be.null;
+    expect(group.querySelector('.sh-btn-register-event')).to.be.null;
+  });
+
+  it('renders modal-opening "Register for session" when not event-registered and not blocked', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, { isEventRegistered: false, isBlocked: false });
+    expect(group.querySelector('.sh-btn-register-event')).to.not.be.null;
+    expect(group.querySelector('.sh-btn-register-session')).to.be.null;
+    expect(group.querySelector('.sh-btn-blocked')).to.be.null;
+  });
+
+  it('renders Registered badge when session.isRegistered (event-registered)', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: true, isWaitlisted: false }, { isEventRegistered: true, isBlocked: false });
     const badge = group.querySelector('.sh-registered-badge');
+    expect(badge).to.not.be.null;
     expect(badge.textContent).to.include('Registered');
     expect(badge.textContent).to.not.include('waitlisted-cta-text');
   });
 
-  it('shows "Register for session" CTA when neither registered nor waitlisted', () => {
-    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, true);
-    expect(group.querySelector('.sh-btn-register-session')).to.not.be.null;
-    expect(group.querySelector('.sh-registered-badge')).to.be.null;
+  it('renders waitlisted badge when session.isWaitlisted (event-registered)', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: true }, { isEventRegistered: true, isBlocked: false });
+    const badge = group.querySelector('.sh-registered-badge');
+    expect(badge).to.not.be.null;
+    expect(badge.textContent).to.include('waitlisted-cta-text');
+  });
+
+  it('blocked takes precedence over the "able to register" path', () => {
+    const group = inlineRenderCTAGroup({ isRegistered: false, isWaitlisted: false }, { isEventRegistered: true, isBlocked: true });
+    expect(group.querySelector('.sh-btn-blocked')).to.not.be.null;
+    expect(group.querySelector('.sh-btn-register-session')).to.be.null;
+  });
+
+  it('registered-for-session badge takes precedence over blocked', () => {
+    // A user who already registered for a session before the event went into
+    // a blocked state should still see their badge, not a sudden "blocked" button.
+    const group = inlineRenderCTAGroup({ isRegistered: true, isWaitlisted: false }, { isEventRegistered: true, isBlocked: true });
+    expect(group.querySelector('.sh-registered-badge')).to.not.be.null;
+    expect(group.querySelector('.sh-btn-blocked')).to.be.null;
   });
 });

--- a/test/unit/blocks/sessions-hub/sessions-hub.test.js
+++ b/test/unit/blocks/sessions-hub/sessions-hub.test.js
@@ -107,7 +107,7 @@ describe('sessions-hub invite-only RSVP gate', () => {
     window.history.replaceState({}, '', `${window.location.pathname}`);
   });
 
-  it('shows invite-only message on banner and cards when event is invite-only and URL has no campaign', async () => {
+  it('shows invite-only message on banner and disabled "blocked" CTA on cards when event is invite-only and URL has no campaign', async () => {
     stubDefaultFetch({ inviteOnly: true });
     setSessionsMeta([makeSession()]);
     const el = document.querySelector('.sessions-hub');
@@ -119,10 +119,13 @@ describe('sessions-hub invite-only RSVP gate', () => {
     expect(bannerMsg).to.not.be.null;
     expect(bannerMsg.textContent).to.equal(INVITE_FALLBACK);
 
-    const cardMsg = el.querySelector('.sh-card .sh-invite-only-msg');
-    expect(cardMsg).to.not.be.null;
-    expect(cardMsg.textContent).to.equal(INVITE_FALLBACK);
-    expect(el.querySelector('.sh-btn-register-event')).to.be.null;
+    // Cards now share the unified blocked state with event-waitlisted/event-closed:
+    // a disabled `.sh-btn-blocked` button labeled "Registration unavailable".
+    const blockedBtn = el.querySelector('.sh-card .sh-btn-blocked');
+    expect(blockedBtn).to.not.be.null;
+    expect(blockedBtn.disabled).to.be.true;
+    expect(el.querySelector('.sh-card .sh-btn-register-event')).to.be.null;
+    expect(el.querySelector('.sh-card .sh-btn-register-session')).to.be.null;
   });
 
   it('shows Register UI when event is invite-only but URL has a valid campaign param', async () => {


### PR DESCRIPTION
                                                                                                                     
  ## Summary                                                                                                          
                                                                                                                      
  Refactors the `sessions-hub` block CTA to a clear three-state model and adds explicit handling for event-level      
  waitlist and event-closed states. Fixes two bugs where the per-card button misrepresented the user's actual ability 
  to register.                                                                                                        
                                                         
  ## Background

  Two bugs surfaced during testing:

  1. When ESP returned `SessionTimeFull` for a per-session-time RSVP, the frontend treated any 2xx as a registration  
  and showed the "Registered" badge — even when the user had actually been moved to a session-time waitlist.
  2. When the user landed on the event-level waitlist via the events-form modal, every session card kept its "Register
   for session" CTA. Clicking it just re-opened the same modal, with no clear indication of why the user couldn't     
  register.
                                                                                                                      
  The deeper issue: the per-card CTA had too many entry points and didn't model "you can't act on this right now" at  
  all.
                                                                                                                      
  ## Changes                                             

  ### Three-state CTA model (`event-libs/v1/blocks/sessions-hub/sessions-hub.js`)                                     
   
  The session-card CTA now has exactly three states:                                                                  
                                                         
  | State | Visual | Click behavior |                                                                                 
  |---|---|---|                                          
  | **Registered** for the session | Blue `.sh-registered-badge` with checkmark + "Registered" / "Waitlisted"
  (waitlist-cta-text) | Hover swaps to "Unregister" / "Leave waitlist"; click triggers `unregisterFromSessionTime` |  
  | **Able to register** | `.sh-btn-register-session` clickable button | Direct `registerForSessionTime` API call —
  **no modal** |                                                                                                      
  | **Blocked** | Disabled `.sh-btn-blocked` button labeled "Registration unavailable" (`Registration unavailable`
  dictionary key) | Not clickable |                                                                                   
                                                         
  Plus a default "Register for session" → modal entry for users who haven't yet RSVPed for the event.                 
                                                         
  ### When "blocked" applies                                                                                          
                                                         
  A new pure predicate `isSessionRegistrationBlocked({ isEventWaitlisted, isEventClosed, inviteOnlyBlocked })` returns
   true if **any** of:
                                                                                                                      
  - User is event-waitlisted (`rsvpData.registrationStatus === 'waitlisted'`)                                         
  - Event is closed (`computeIsEventClosed`: `isFull` and waitlist not enabled — accepts both boolean `true` and
  string `'true'` for `allowWaitlisting`)                                                                             
  - Invite-only without a valid campaign (existing `inviteOnlyBlocked` flag)
                                                                                                                      
  ### SessionTimeFull handling                           
                                                                                                                      
  `handleSessionRegistration` now reads the response body, not just `resp.ok`:                                        
  - `200 OK` with `data.registrationStatus === 'waitlisted'` → mark `session.isWaitlisted` (not `isRegistered`).
  - Non-2xx matching `SessionTimeFull` → retry the call with `registrationStatus: 'waitlisted'`. On retry success,    
  mark waitlisted.                                                                                                    
  - New `isSessionTimeFullError(resp)` helper checks `error.code | errorCode | error | type | message` for the token  
  (defensive against ESP error-shape variation).                                                                      
  - Defensive guard at the top of `handleSessionRegistration` bails if any blocked flag is true, so an auto-fired flow
   can't bypass the disabled UI.                                                                                      
  ### Event banner: stays visible for waitlist, gains explanatory copy
                                                                                                                      
  - `syncBannerVisibility` only hides the banner when `isEventRegistered === true`. Waitlisted users keep the banner
  visible so they can manage their waitlist.                                                                          
  - When `isEventWaitlisted`, the banner button reads `waitlisted-cta-text` with a checkmark icon (reuses the same
  dictionary key `decorate.js` already uses for the page-level RSVP CTA).                                             
  - New status paragraph `<p class="sh-banner-waitlist-msg">` renders alongside the button, explaining session        
  registration is unavailable.                                                                                
                                                                                                                      
  ### Templatized banner copy                            
                                                                                                                      
  `event-libs/v1/utils/dictionary-manager.js` exports a new helper that mirrors `getInviteOnlyNoCampaignMessage`:
                                                                                                                      
  ```js
  export const EVENT_WAITLIST_BANNER_MESSAGE_KEY = 'event-waitlist-banner-msg';                                       
  export function getEventWaitlistBannerMessage(manager, { eventTitle = '' } = {}) { ... }
                                                                                                                      
  - Reads from the dictionary, falls back to a sensible inline default.
  - Supports {eventTitle} token interpolation so localized copy can read e.g. "You're on the waitlist for             
  {eventTitle}. We'll email you when a spot opens up." — mirrors the events-form waitlist success modal wording.      
                                                                                                                      
  Race-condition reconciliation                                                                                       
                                                         
  captureProfile (in profile.js) sets rsvpData asynchronously after imsProfile. If it resolves between loadBlock's    
  initial read and bindMediatorSubscriptions's subscribe call, the subscription would never fire (BlockMediator
  doesn't replay current values to new subscribers).                                                                  
                                                         
  Added a one-shot reconciliation: after subscribing, read the current rsvpData snapshot and manually invoke the      
  handler if the rendered status differs from the current status. Closes the race so reloads against an
  event-waitlisted user always show the correct UI.                                                                   
                                                         
  API cleanup                                                                                                         
   
  renderCTAGroup, updateCTAGroup, renderSessionCard, renderSessionList were taking up to 5 positional booleans.       
  Switched to a single options object: { isEventRegistered, isBlocked } (and similarly for the banner: { 
  inviteOnlyBlocked, inviteOnlyMessage, isEventWaitlisted, waitlistBannerMessage }). Easier to read at call sites and 
  easier to extend.                                      

  CSS

  No new visual styling required for the blocked state — reuses the existing .sh-btn:disabled rule (opacity: 0.5;     
  cursor: not-allowed;). Added .sh-banner-waitlist-msg to share styling with the existing .sh-banner-invite-only-msg.
                                                                                                                      
  Test plan                                              

  - npx wtr ./test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js --node-resolve --port=2000 — 78/78       
  passing (added 16 new tests covering isSessionRegistrationBlocked, computeIsEventClosed for both boolean and string
  allowWaitlisting, the 3-state ladder including precedence rules, and SessionTimeFull retry classification).         
  - npx wtr ./test/unit/scripts/esp-controller.test.js --node-resolve --port=2001 — 29/29 passing (no regressions).
  - Manual: event open, no RSVP → "Register for session" → modal.                                                     
  - Manual: event-registered, session not registered → "Register for session" → direct API call (no modal).           
  - Manual: event-registered, session registered → "Registered" badge, hover → "Unregister".                          
  - Manual: event-registered, session-time waitlisted → "Waitlisted" badge.                                           
  - Manual: event full + waitlist enabled, user submits RSVP → modal says "added to waitlist". After dismiss, every   
  card shows disabled "Registration unavailable", banner stays visible with waitlist copy + ✓ Waitlisted button. Click
   banner button → modal reopens with Cancel waitlist available.                                                      
  - Manual: event full, waitlist not enabled → cards show disabled "Registration unavailable"; banner stays as        
  "Register".                                                                                                         
  - Manual: invite-only without campaign → cards disabled, banner shows the existing invite-only message.
  - Manual: hard reload after event-waitlisting → banner still shows waitlist message (verifies the reconciliation    
  fix).        