### PR TITLE
MWPW-189871: Read promotional items for the block from custom attributes

### DIFF
--- a/event-libs/v1/blocks/promotional-content/promotional-content.js
+++ b/event-libs/v1/blocks/promotional-content/promotional-content.js
@@ -21,7 +21,22 @@ async function getPromotionalContentUrl() {
   return `${domain}${prefix}/event-libs/assets/configs/promotional-content.json`;
 }
 
-async function getPromotionalContent() {
+function getPromotionalContent() {
+  const customAttributesMetadata = getMetadata('custom-attributes');
+  if (!customAttributesMetadata) return [];
+
+  try {
+    const customAttributes = JSON.parse(customAttributesMetadata);
+    return customAttributes
+      .filter((attr) => attr.attribute === 'promotionalItems' && attr.value)
+      .map((attr) => attr.value);
+  } catch (error) {
+    window.lana?.log(`Error parsing custom-attributes: ${JSON.stringify(error)}`);
+    return [];
+  }
+}
+
+async function getLegacyPromotionalContent() {
   let promotionalItems = [];
   const eventPromotionalItemsMetadata = getMetadata('promotional-items');
   if (eventPromotionalItemsMetadata) {
@@ -38,20 +53,20 @@ async function getPromotionalContent() {
       return promotionalItems;
     }
   }
-  
+
   // If no promotional items, return early to avoid unnecessary imports and fetch
   if (promotionalItems.length === 0) {
     return [];
   }
-  
+
   try {
     const url = await getPromotionalContentUrl();
     const response = await fetch(url);
-    
+
     if (!response.ok) {
       throw new Error(`Failed to fetch promotional content: ${response.status}`);
     }
-    
+
     const json = await response.json();
     const data = json.data || [];
 
@@ -86,22 +101,24 @@ export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  const promotionalItems = await getPromotionalContent();
-  if (!promotionalItems.length) return;
+  let fragmentUrls = getPromotionalContent();
+
+  if (!fragmentUrls.length) {
+    const legacyItems = await getLegacyPromotionalContent();
+    fragmentUrls = (legacyItems ?? []).map((item) => item?.['fragment-path']).filter(Boolean);
+  }
+
+  if (!fragmentUrls?.length) return;
 
   const [{ default: loadFragment }, { createTag }] = await Promise.all([
     import(`${miloLibs}/blocks/fragment/fragment.js`),
     import(`${miloLibs}/utils/utils.js`),
   ]);
 
-  const fragmentPromotionalItemsPromises = promotionalItems.map(async (item) => {
-    const fragmentPath = item['fragment-path'];
-    if (!fragmentPath) return;
-
+  await Promise.all(fragmentUrls.map(async (fragmentPath) => {
     const fragmentLink = createTag('a', { href: fragmentPath }, '', { parent: el });
     await loadFragment(fragmentLink);
-  });
+  }));
 
-  await Promise.all(fragmentPromotionalItemsPromises);
   addMediaReversedClass(el);
 }

--- a/test/unit/blocks/promotional-content/promotional-content.test.js
+++ b/test/unit/blocks/promotional-content/promotional-content.test.js
@@ -3,118 +3,147 @@ import sinon from 'sinon';
 import { setEventConfig } from '../../../../event-libs/v1/utils/utils.js';
 import init, { addMediaReversedClass } from '../../../../event-libs/v1/blocks/promotional-content/promotional-content.js';
 
+const CUSTOM_ATTRS_WITH_PROMO = JSON.stringify([
+  { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
+  { attributeId: '732fdd75', attribute: 'promotionalItems', value: 'https://example.com/fragments/acrobat' },
+  { attributeId: '50578a75', attribute: 'technicalLevel', value: 'advanced' },
+]);
+
+const CUSTOM_ATTRS_WITHOUT_PROMO = JSON.stringify([
+  { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
+]);
+
+// Bypasses the /libs/utils/utils.js dynamic import (404s in unit tests) so the legacy
+// fetch path can be exercised end-to-end.
+const MOCK_PROMO_CONFIG_URL = '/test/mocks/promotional-content.json';
+
 describe('Promotional Content Block', () => {
   let el;
   let fetchStub;
 
+  function addMeta(name, content) {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  }
+
   beforeEach(async () => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+
     el = document.createElement('div');
     el.className = 'promotional-content';
     document.body.appendChild(el);
 
-    // Mock LIBS and set up event config
     window.LIBS = '/libs';
     setEventConfig({}, { miloLibs: '/libs' });
-    
-    // No need to mock imports since we fixed the code to return early when no promotional items
 
-    // Mock the promotional content JSON response - empty data for this test
-    const mockPromotionalData = {
-      data: [],
-    };
-
-    fetchStub = sinon.stub(window, 'fetch').resolves({ json: () => Promise.resolve(mockPromotionalData) });
+    fetchStub = sinon.stub(window, 'fetch');
   });
 
   afterEach(() => {
-    document.body.removeChild(el);
-    fetchStub.restore();
     sinon.restore();
     delete window.LIBS;
-    
-    // Clean up any metadata that might have been added
-    const metaTags = document.head.querySelectorAll('meta[name="promotional-items"]');
+    const metaTags = document.head.querySelectorAll('meta');
     metaTags.forEach((tag) => tag.remove());
   });
 
-  describe('init', () => {
-    it('should handle empty promotional items gracefully', async () => {
-      // Should not throw an error
+  describe('init — new path via custom-attributes', () => {
+    it('returns early with no fetch when custom-attributes meta is absent', async () => {
       await init(el);
-
-      // Fetch should not be called when there are no promotional items (early return)
       expect(fetchStub.called).to.be.false;
+    });
+
+    it('returns early with no fetch when custom-attributes has no promotionalItems entry', async () => {
+      addMeta('custom-attributes', CUSTOM_ATTRS_WITHOUT_PROMO);
+      await init(el);
+      expect(fetchStub.called).to.be.false;
+    });
+
+    it('does not fetch promotional-content.json when custom-attributes provides a fragment URL', async () => {
+      addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
+      fetchStub.resolves({ ok: true, text: () => Promise.resolve('<div></div>') });
+
+      try {
+        await init(el);
+      } catch (e) {
+        // loadFragment dynamic import is not available in unit test env
+      }
+
+      const configFetched = fetchStub.args.some(([url]) => String(url).includes('promotional-content.json'));
+      expect(configFetched).to.be.false;
+    });
+  });
+
+  describe('init — legacy path via promotional-items', () => {
+    it('returns early with no fetch when promotional-items meta is absent', async () => {
+      await init(el);
+      expect(fetchStub.called).to.be.false;
+    });
+
+    it('returns early with no fetch on invalid promotional-items JSON', async () => {
+      addMeta('promotional-items', 'invalid json');
+      await init(el);
+      expect(fetchStub.called).to.be.false;
+    });
+
+    it('fetches promotional-content.json when valid promotional-items are present', async () => {
+      addMeta('promotional-items', '["Acrobat"]');
+      addMeta('promotional-content-location', MOCK_PROMO_CONFIG_URL);
+      fetchStub.resolves({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ name: 'Acrobat', 'fragment-path': '/fragments/acrobat' }] }),
+      });
+
+      try {
+        await init(el);
+      } catch (e) {
+        // loadFragment dynamic import is not available in unit test env
+      }
+
+      const configFetched = fetchStub.args.some(([url]) => String(url).includes('promotional-content.json'));
+      expect(configFetched).to.be.true;
+    });
+
+    it('returns early when promotional-content.json has no data', async () => {
+      addMeta('promotional-items', '["Acrobat"]');
+      addMeta('promotional-content-location', MOCK_PROMO_CONFIG_URL);
+      fetchStub.resolves({ ok: true, json: () => Promise.resolve({ data: [] }) });
+
+      await init(el);
+      expect(el.children.length).to.equal(0);
     });
   });
 
   describe('addMediaReversedClass', () => {
-    it('should remove media-reverse-mobile class from all media blocks', async () => {
-      // Add media blocks with media-reverse-mobile class
-      const media1 = document.createElement('div');
-      media1.className = 'media media-reverse-mobile';
-      el.appendChild(media1);
-
-      const media2 = document.createElement('div');
-      media2.className = 'media media-reverse-mobile';
-      el.appendChild(media2);
-
-      // Set up mock metadata to ensure the function runs
-      const meta = document.createElement('meta');
-      meta.name = 'promotional-items';
-      meta.content = '["Acrobat"]';
-      document.head.appendChild(meta);
+    it('removes media-reverse-mobile from all media blocks', () => {
+      for (let i = 0; i < 2; i++) {
+        const div = document.createElement('div');
+        div.className = 'media media-reverse-mobile';
+        el.appendChild(div);
+      }
 
       addMediaReversedClass(el);
 
-      const mediaBlocks = el.querySelectorAll('.media');
-      mediaBlocks.forEach((block) => {
+      el.querySelectorAll('.media').forEach((block) => {
         expect(block.classList.contains('media-reverse-mobile')).to.be.false;
       });
     });
 
-    it('should add media-reversed class to odd-indexed media blocks', async () => {
-      // Add media blocks
-      const media1 = document.createElement('div');
-      media1.className = 'media';
-      el.appendChild(media1);
-
-      const media2 = document.createElement('div');
-      media2.className = 'media';
-      el.appendChild(media2);
-
-      const media3 = document.createElement('div');
-      media3.className = 'media';
-      el.appendChild(media3);
-
-      // Set up mock metadata to ensure the function runs
-      const meta = document.createElement('meta');
-      meta.name = 'promotional-items';
-      meta.content = '["Acrobat"]';
-      document.head.appendChild(meta);
+    it('adds media-reversed to odd-indexed media blocks only', () => {
+      for (let i = 0; i < 3; i++) {
+        const div = document.createElement('div');
+        div.className = 'media';
+        el.appendChild(div);
+      }
 
       addMediaReversedClass(el);
 
-      const mediaBlocks = el.querySelectorAll('.media');
-
-      expect(mediaBlocks[0].classList.contains('media-reversed')).to.be.false;
-      expect(mediaBlocks[1].classList.contains('media-reversed')).to.be.true;
-      expect(mediaBlocks[2].classList.contains('media-reversed')).to.be.false;
-    });
-  });
-
-  describe('getPromotionalContent', () => {
-    it('should handle invalid JSON in promotional items metadata', async () => {
-      // Set up invalid metadata
-      const meta = document.createElement('meta');
-      meta.name = 'promotional-items';
-      meta.content = 'invalid json';
-      document.head.appendChild(meta);
-
-      // Should not throw an error
-      await init(el);
-
-      // Fetch should not be called with invalid metadata (early return due to empty promotional items)
-      expect(fetchStub.called).to.be.false;
+      const blocks = el.querySelectorAll('.media');
+      expect(blocks[0].classList.contains('media-reversed')).to.be.false;
+      expect(blocks[1].classList.contains('media-reversed')).to.be.true;
+      expect(blocks[2].classList.contains('media-reversed')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
### Summary                                                                                                                    
         
  - New data source for promotional items: getPromotionalContent() now reads fragment URLs directly from the                 
  custom-attributes meta tag (attribute "promotionalItems"), eliminating the need for a secondary config JSON fetch. This is 
  the new primary path.
  - Legacy path preserved: The old getPromotionalContent() logic (reads promotional-items meta → fetches                     
  promotional-content.json → resolves fragment paths) is renamed to getLegacyPromotionalContent() and used as a fallback when
   custom-attributes is absent or has no promotionalItems entry.
  - Simplified init: Both paths now resolve to a flat array of fragment URLs before loading, so the fragment-loading loop is 
  unified and the nullish-safety guards (?? [], ?.length) ensure no crashes if either path returns nullish.                  
  
  ### Test plan                                                                                                                  
                                                            
  - Verify a page with only custom-attributes (containing a promotionalItems value) loads the promotional fragment without   
  triggering a promotional-content.json fetch
  - Verify a page with only the legacy promotional-items meta still loads fragments correctly via the config JSON lookup     
  - Verify a page with neither meta renders the block with no content and no errors                                          
  - Run unit tests: npx wtr test/unit/blocks/promotional-content/promotional-content.test.js --node-resolve --port=2000 — all
   9 tests pass          

Resolves: [MWPW-189871](https://jira.corp.adobe.com/browse/MWPW-189871)

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/fr/.snapshots/esp-dev/create-now-da-acom/test-event-scope-configs-0421-01/saratoga-springs/ut/us/2026-04-30?timing=1777528799990&espenv=dev&martech=off
- After: https://main--da-events--adobecom.aem.page/fr/.snapshots/esp-dev/create-now-da-acom/test-event-scope-configs-0421-01/saratoga-springs/ut/us/2026-04-30?timing=1777528799990&espenv=dev&eventlibs=MWPW-189871&martech=off

With custom attr: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/sharmee-test-scope-config/new-york/ny/us/2026-07-10?eventlibs=MWPW-189871
Without custom attr: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/sharmee-test-scope-config/new-york/ny/us/2026-07-10
