### PR TITLE
MWPW-194614: Load RSVP form inputs from the new EMC config

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -858,6 +858,9 @@ function getRsvpConfigFromMeta() {
       const field = lowercaseKeys(f);
       if (typeof field.field === 'string') field.field = field.field.trim();
       field.required = field.required === true ? 'x' : '';
+      if (Array.isArray(field.options)) {
+        field.options = field.options.map((o) => (typeof o === 'object' ? o.value : o)).join(';');
+      }
       return field;
     });
 

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -911,25 +911,26 @@ async function createForm(bp, formData) {
 
   await dictionaryManager.initialize();
 
-  if (rsvpConfigData) {
-  } else if (rsvpFieldsData) {
-    const { required, visible } = rsvpFieldsData;
-    json.data = json.data
-      .map((obj) => {
-        const lowkey = lowercaseKeys(obj);
-        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
-        if (required.includes(lowkey.field)) lowkey.required = 'x';
-        return lowkey;
-      })
-      .filter((f) => visible.includes(f.field) || ['clear', 'submit'].includes(f.field));
-  } else {
-    json.data = json.data
-      .map((obj) => {
-        const lowkey = lowercaseKeys(obj);
-        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
-        return lowkey;
-      })
-      .filter((f) => ['clear', 'submit'].includes(f.field));
+  if (!rsvpConfigData) {
+    if (rsvpFieldsData) {
+      const { required, visible } = rsvpFieldsData;
+      json.data = json.data
+        .map((obj) => {
+          const lowkey = lowercaseKeys(obj);
+          if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
+          if (required.includes(lowkey.field)) lowkey.required = 'x';
+          return lowkey;
+        })
+        .filter((f) => visible.includes(f.field) || ['clear', 'submit'].includes(f.field));
+    } else {
+      json.data = json.data
+        .map((obj) => {
+          const lowkey = lowercaseKeys(obj);
+          if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
+          return lowkey;
+        })
+        .filter((f) => ['clear', 'submit'].includes(f.field));
+    }
   }
 
   const formEl = createTag('form');

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -3,7 +3,7 @@ import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
 import { dictionaryManager, getInviteOnlyNoCampaignMessage } from '../../utils/dictionary-manager.js';
 import { getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl } from '../../utils/utils.js';
-import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN } from '../../utils/constances.js';
+import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN, PHONE_FIELD_RE, PHONE_PATTERN  } from '../../utils/constances.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
 
 const eventConfig = getEventConfig();
@@ -16,9 +16,6 @@ const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attri
 const { default: loadFragment } = await import(`${miloLibs}/blocks/fragment/fragment.js`);
 
 const VALID_REGISTRATION_STATUS = ['registered', 'waitlisted'];
-
-const PHONE_FIELD_RE = /phone/i;
-const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
 
 const RULE_OPERATORS = {
   equal: '=',
@@ -849,27 +846,53 @@ function addTerms(form, terms) {
   submitWrapper.before(termsWrapper);
 }
 
+function getRsvpConfigFromMeta() {
+  const raw = getMetadata('rsvp-config');
+  if (!raw) return null;
+
+  try {
+    const config = JSON.parse(raw);
+    if (!config.rsvpFormFields?.length) return null;
+
+    const data = config.rsvpFormFields.map((f) => {
+      const field = lowercaseKeys(f);
+      if (typeof field.field === 'string') field.field = field.field.trim();
+      field.required = field.required === true ? 'x' : '';
+      return field;
+    });
+
+    return { data };
+  } catch (error) {
+    window.lana?.log(`Failed to parse rsvp-config metadata: ${JSON.stringify(error)}`);
+    return null;
+  }
+}
+
 async function createForm(bp, formData) {
   const { form, terms } = bp;
 
-  let rsvpFieldsData;
+  const rsvpConfigData = getRsvpConfigFromMeta();
 
-  try {
-    rsvpFieldsData = JSON.parse(getMetadata('rsvp-form-fields'));
-  } catch (error) {
-    window.lana?.log(`Failed to parse partners metadata:\n${JSON.stringify(error, null, 2)}`);
+  let rsvpFieldsData;
+  if (!rsvpConfigData) {
+    try {
+      rsvpFieldsData = JSON.parse(getMetadata('rsvp-form-fields'));
+    } catch (error) {
+      window.lana?.log(`Failed to parse partners metadata:\n${JSON.stringify(error, null, 2)}`);
+    }
   }
 
-  let json = formData;
+  let json = rsvpConfigData || formData;
   /* c8 ignore next 4 */
-  if (!formData) {
+  if (!json) {
     const resp = await fetch(form.href);
     json = await resp.json();
   }
 
   await dictionaryManager.initialize();
 
-  if (rsvpFieldsData) {
+  if (rsvpConfigData) {
+  } else if (rsvpFieldsData) {
     const { required, visible } = rsvpFieldsData;
     json.data = json.data
       .map((obj) => {
@@ -891,8 +914,10 @@ async function createForm(bp, formData) {
 
   const formEl = createTag('form');
   const rules = [];
-  const [action] = new URL(form.href).pathname.split('.json');
-  formEl.dataset.action = action;
+  if (form.href) {
+    const [action] = new URL(form.href).pathname.split('.json');
+    formEl.dataset.action = action;
+  }
 
   const typeToElement = {
     'multi-select': { fn: createSelect, params: [], label: true, classes: [] },
@@ -1156,16 +1181,18 @@ function getFormLink(block, bp) {
   const legacyLink = block.querySelector(':scope > div:nth-of-type(2) a[href$=".json"]');
   const form = createTag('a');
 
-  try {
-    form.href = getRsvpConfigUrl();
-  } catch (error) {
-    window.lana?.log(`Error getting RSVP config URL: ${JSON.stringify(error)}`);
-    throw error;
-  }
+  if (!getRsvpConfigFromMeta()) {
+    try {
+      form.href = getRsvpConfigUrl();
+    } catch (error) {
+      window.lana?.log(`Error getting RSVP config URL: ${JSON.stringify(error)}`);
+      throw error;
+    }
 
-  if (legacyLink) {
-    legacyLink.href = form.href;
-    return legacyLink;
+    if (legacyLink) {
+      legacyLink.href = form.href;
+      return legacyLink;
+    }
   }
 
   bp.formContainer.append(form);

--- a/event-libs/v1/utils/constances.js
+++ b/event-libs/v1/utils/constances.js
@@ -150,3 +150,5 @@ export const FALLBACK_LOCALES = {
   za: { ietf: 'en-GB', tk: 'hah7vzn.css' },
 };
 export const LATEST_VERSION = 'v1';
+export const PHONE_FIELD_RE = /phone/i;
+export const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';


### PR DESCRIPTION
Resolves: [MWPW-194614](https://jira.corp.adobe.com/browse/MWPW-194614)

### Summary         
                                                                                                                             
  - Adds getRsvpConfigFromMeta() to read RSVP form field definitions directly from the rsvp-config page metadata key (JSON), 
  eliminating the need for a separate .json spreadsheet endpoint in metadata-driven configurations.                          
  - When rsvp-config metadata is present, createForm() uses it as the authoritative source and skips the old rsvp-form-fields
   / spreadsheet fetch path entirely; the existing paths are preserved as fallback for backwards compatibility.              
  - Normalizes the parsed config: lowercases all field keys, converts required: true booleans to 'x' (matching sheet format),
   and joins options arrays as ;-separated strings (matching the current sheet column convention).                           
  - Moves PHONE_FIELD_RE and PHONE_PATTERN from module-local constants in events-form.js into the shared constances.js, where
   they can be reused across blocks.                                                                                         
  - Guards formEl.dataset.action assignment behind a form.href check — form.href is intentionally unset in the meta-only
  path, so this prevents a TypeError on new URL(undefined).  

### Test URLs

- Before: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/sharmee-test-scope-config/new-york/ny/us/2026-07-10?martech=off
- After: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/sharmee-test-scope-config/new-york/ny/us/2026-07-10?eventlibs=MWPW-194614&martech=off                                                                
                  
### Test plan                                                                                                                  
                  
  - Meta path (happy path): Add rsvp-config metadata to a test page with a valid JSON payload containing rsvpFormFields.     
  Confirm the form renders with the correct fields, required markers, and options (;-joined).
  - Required boolean normalization: Set required: true on a field in the JSON config; verify the rendered field is marked    
  required. Set required: false; verify it is not.                                                                           
  - Options array normalization: Provide options as an array of objects ({ value: "..." }) and as plain strings; confirm both
   render correctly in a <select> or multi-select element.                                                                   
  - Fallback — rsvp-form-fields meta: Remove rsvp-config, add only rsvp-form-fields JSON metadata. Confirm the old
  filter/visibility logic still applies.                                                                                     
  - Fallback — spreadsheet fetch: Remove both metadata keys. Confirm the form still fetches and renders from the .json link
  in the block.                                                                                                              
  - Malformed JSON in rsvp-config: Set rsvp-config to invalid JSON; confirm lana.log is called, the function returns null,
  and the page falls back gracefully rather than throwing.                                                                   
  - Empty rsvpFormFields: Set rsvp-config to { "rsvpFormFields": [] }; confirm getRsvpConfigFromMeta() returns null and the
  fallback path runs.                                                                                                        
  - Phone field: Confirm phone fields still render with the correct pattern attribute after the constant move to
  constances.js.                                                                                                             
  - No regression on form submission action: For a non-meta form, verify formEl.dataset.action is still set correctly from the .json URL

