### PR TITLE
feat(sessions-hub): refine session search keys and empty state

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -240,12 +240,28 @@
 
 /* ─── Session list ───────────────────────────────────────────────────────── */
 
+.sessions-hub .sh-session-area {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.sessions-hub .sh-no-results {
+  padding: 48px 24px 100px;
+  text-align: center;
+}
+
+.sessions-hub .sh-no-results p {
+  font-family: var(--body-font-family, sans-serif);
+  font-size: 16px;
+  line-height: 1.5;
+  color: #505050;
+  margin: 0;
+}
+
 .sessions-hub .sh-session-list {
   display: flex;
   flex-direction: column;
   gap: 32px;
-  max-width: 1200px;
-  margin: 0 auto;
   padding: 24px 24px 100px;
 }
 

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -262,6 +262,35 @@ function normalizeSessions(rawSessions, locationMap, registeredSessionIds, venue
 
 // ─── Filter / search ─────────────────────────────────────────────────────────
 
+const DEFAULT_SEARCH_CONFIG = { includeDescription: false };
+
+function parseSearchConfig(blockEl) {
+  return {
+    includeDescription: Boolean(blockEl?.classList?.contains('search-include-description')),
+  };
+}
+
+function getEffectiveSearchQuery(rawQuery) {
+  const t = (rawQuery || '').trim().toLowerCase();
+  return t.length >= 2 ? t : '';
+}
+
+function speakerMatchesQuery(sp, q) {
+  const fn = (sp.firstName || '').toLowerCase();
+  const ln = (sp.lastName || '').toLowerCase();
+  const full = `${fn} ${ln}`.trim();
+  return fn.includes(q) || ln.includes(q) || full.includes(q);
+}
+
+function sessionMatchesTextSearch(s, q, searchConfig) {
+  const cfg = searchConfig || DEFAULT_SEARCH_CONFIG;
+  if ((s.title || '').toLowerCase().includes(q)) return true;
+  if (s.speakers.some((sp) => speakerMatchesQuery(sp, q))) return true;
+  if (s.tags.some((t) => t.label && t.label.toLowerCase().includes(q))) return true;
+  if (cfg.includeDescription && (s.description || '').toLowerCase().includes(q)) return true;
+  return false;
+}
+
 function collectFilterGroups(sessions) {
   const groups = new Map();
   sessions.forEach((s) => s.tags.forEach(({ label, group }) => {
@@ -277,8 +306,14 @@ function collectFilterGroups(sessions) {
   return sorted;
 }
 
-function filterSessions(sessions, { query, activeTags, activeTab, registeredSessionIds }) {
-  const q = query.toLowerCase();
+export function filterSessions(sessions, {
+  query,
+  activeTags,
+  activeTab,
+  registeredSessionIds,
+  searchConfig = DEFAULT_SEARCH_CONFIG,
+}) {
+  const q = getEffectiveSearchQuery(query);
   return sessions.filter((s) => {
     if (activeTab === 'my' && !registeredSessionIds.has(s.sessionId)) return false;
 
@@ -288,33 +323,44 @@ function filterSessions(sessions, { query, activeTags, activeTab, registeredSess
       }
     }
 
-    if (q) {
-      const hay = [
-        s.title,
-        s.description,
-        ...s.speakers.map((sp) => `${sp.firstName} ${sp.lastName}`),
-      ].join(' ').toLowerCase();
-      if (!hay.includes(q)) return false;
-    }
+    if (q && !sessionMatchesTextSearch(s, q, searchConfig)) return false;
 
     return true;
   });
 }
 
-function applyFilter(listEl, state) {
+function getSessionListRoot(sessionAreaOrList) {
+  if (sessionAreaOrList?.classList?.contains('sh-session-area')) {
+    return sessionAreaOrList.querySelector('.sh-session-list') || sessionAreaOrList;
+  }
+  return sessionAreaOrList;
+}
+
+function applyFilter(sessionAreaEl, state) {
   const fs = getFilterState();
   const filtered = filterSessions(state.sessions, {
     query: fs.query,
     activeTags: fs.activeTags,
     activeTab: fs.activeTab,
     registeredSessionIds: state.registeredSessionIds,
+    searchConfig: state.searchConfig || DEFAULT_SEARCH_CONFIG,
   });
   const filteredIds = new Set(filtered.map((s) => s.sessionId));
+  const effectiveQuery = getEffectiveSearchQuery(fs.query);
 
-  listEl.querySelectorAll('.sh-card').forEach((card) => {
+  const listRoot = getSessionListRoot(sessionAreaEl);
+  listRoot.querySelectorAll('.sh-card').forEach((card) => {
     card.hidden = !filteredIds.has(card.dataset.sessionId);
   });
-  scheduleSyncSessionDescriptionsOverflow(listEl);
+
+  const emptyEl = sessionAreaEl.querySelector('.sh-no-results');
+  if (emptyEl) {
+    const showEmpty = effectiveQuery.length >= 2 && filtered.length === 0;
+    emptyEl.hidden = !showEmpty;
+    listRoot.hidden = showEmpty;
+  }
+
+  scheduleSyncSessionDescriptionsOverflow(sessionAreaEl);
 }
 
 // ─── Render: CTA group ───────────────────────────────────────────────────────
@@ -422,9 +468,9 @@ function syncSessionCardDescriptionOverflow(card) {
   }
 }
 
-export function syncSessionDescriptionsOverflow(listEl) {
-  if (!listEl) return;
-  listEl.querySelectorAll('.sh-card').forEach((card) => {
+export function syncSessionDescriptionsOverflow(sessionAreaOrList) {
+  if (!sessionAreaOrList) return;
+  sessionAreaOrList.querySelectorAll('.sh-card').forEach((card) => {
     syncSessionCardDescriptionOverflow(card);
   });
 }
@@ -437,16 +483,17 @@ function scheduleSyncSessionDescriptionsOverflow(listEl) {
   });
 }
 
-function connectSessionDescriptionsOverflowObserver(listEl) {
+function connectSessionDescriptionsOverflowObserver(sessionAreaEl) {
   if (typeof ResizeObserver === 'undefined') return;
   disconnectSessionDescriptionsOverflow();
+  const observeEl = getSessionListRoot(sessionAreaEl);
   const debouncedSync = debounce(() => {
-    syncSessionDescriptionsOverflow(listEl);
+    syncSessionDescriptionsOverflow(sessionAreaEl);
   }, 100);
   const ro = new ResizeObserver(() => {
     debouncedSync();
   });
-  ro.observe(listEl);
+  ro.observe(observeEl);
   disconnectDescOverflowObserver = () => {
     ro.disconnect();
     disconnectDescOverflowObserver = null;
@@ -560,9 +607,19 @@ function renderSessionCard(session, opts = {}) {
 }
 
 function renderSessionList(sessions, opts = {}) {
+  const area = createTag('div', { class: 'sh-session-area' });
   const list = createTag('div', { class: 'sh-session-list' });
+  const empty = createTag('div', {
+    class: 'sh-no-results',
+    hidden: '',
+    role: 'status',
+    'aria-live': 'polite',
+    'aria-atomic': 'true',
+  });
+  empty.append(createTag('p', {}, dictionaryManager.getValue('No matching sessions')));
   sessions.forEach((s) => list.append(renderSessionCard(s, opts)));
-  return list;
+  area.append(list, empty);
+  return area;
 }
 
 // ─── Render: toolbar ────────────────────────────────────────────────────────
@@ -1297,6 +1354,8 @@ function bindMediatorSubscriptions(el, listEl) {
 // ─── init ────────────────────────────────────────────────────────────────────
 
 async function loadBlock(el, rsvpConfig) {
+  const searchConfig = parseSearchConfig(el);
+
   const eventData = await resolveEventData();
   if (!eventData?.eventId) {
     el.remove();
@@ -1364,6 +1423,7 @@ async function loadBlock(el, rsvpConfig) {
     inviteOnlyBlocked,
     inviteOnlyMessage,
     waitlistBannerMessage,
+    searchConfig,
   };
   setState(state);
 

--- a/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
+++ b/test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init, { syncSessionDescriptionsOverflow } from '../../../../event-libs/v1/blocks/sessions-hub/sessions-hub.js';
+import init, { filterSessions, syncSessionDescriptionsOverflow } from '../../../../event-libs/v1/blocks/sessions-hub/sessions-hub.js';
 import BlockMediator from '../../../../event-libs/v1/deps/block-mediator.min.js';
 import { DictionaryManager, dictionaryManager } from '../../../../event-libs/v1/utils/dictionary-manager.js';
 
@@ -46,7 +46,6 @@ function makeEventData(overrides = {}) {
 let resolveTagWithGroup;
 let resolveTagObjects;
 let generateICS;
-let filterSessions;
 let normalizeSessions;
 
 const mockTagsData = {
@@ -128,27 +127,6 @@ before(async () => {
     if (locationName) lines.push(`LOCATION:${locationName.replace(/\n/g, '\\n')}`);
     lines.push('END:VEVENT', 'END:VCALENDAR');
     return lines.join('\r\n');
-  };
-
-  filterSessions = (sessions, { query, activeTags, activeTab, registeredSessionIds }) => {
-    const q = query.toLowerCase();
-    return sessions.filter((s) => {
-      if (activeTab === 'my' && !registeredSessionIds.has(s.sessionId)) return false;
-      if (activeTags.size > 0) {
-        for (const [, groupSet] of activeTags) {
-          if (groupSet.size > 0 && !s.tags.some((t) => groupSet.has(t.label))) return false;
-        }
-      }
-      if (q) {
-        const hay = [
-          s.title,
-          s.description,
-          ...s.speakers.map((sp) => `${sp.firstName} ${sp.lastName}`),
-        ].join(' ').toLowerCase();
-        if (!hay.includes(q)) return false;
-      }
-      return true;
-    });
   };
 
   normalizeSessions = (rawSessions, speakerMap, locationMap, registeredSessionIds, venueId, tagsData) => rawSessions.map((session) => {
@@ -350,6 +328,21 @@ describe('filterSessions', () => {
     expect(result).to.have.lengthOf(3);
   });
 
+  it('does not apply text search for whitespace-only query', () => {
+    const result = filterSessions(sessions, {
+      query: '   ', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result).to.have.lengthOf(3);
+  });
+
+  it('applies text search for two-character query', () => {
+    const result = filterSessions(sessions, {
+      query: 'ph', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].sessionId).to.equal('s1');
+  });
+
   it('filters by title substring (case-insensitive)', () => {
     const result = filterSessions(sessions, {
       query: 'photoshop', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
@@ -358,12 +351,53 @@ describe('filterSessions', () => {
     expect(result[0].sessionId).to.equal('s1');
   });
 
-  it('filters by description substring', () => {
+  it('does not match description-only text by default', () => {
     const result = filterSessions(sessions, {
       query: 'power users', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
     });
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it('matches description when searchConfig.includeDescription is true', () => {
+    const result = filterSessions(sessions, {
+      query: 'power users',
+      activeTags: new Map(),
+      activeTab: 'all',
+      registeredSessionIds: new Set(),
+      searchConfig: { includeDescription: true },
+    });
     expect(result).to.have.lengthOf(1);
     expect(result[0].sessionId).to.equal('s2');
+  });
+
+  it('does not apply text search for a single-character query', () => {
+    const result = filterSessions(sessions, {
+      query: 'p', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result).to.have.lengthOf(3);
+  });
+
+  it('filters by tag label substring', () => {
+    const result = filterSessions(sessions, {
+      query: 'work', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result.map((s) => s.sessionId).sort()).to.deep.equal(['s1', 's3']);
+  });
+
+  it('filters by speaker last name substring', () => {
+    const result = filterSessions(sessions, {
+      query: 'smith', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].sessionId).to.equal('s1');
+  });
+
+  it('filters by full speaker name phrase', () => {
+    const result = filterSessions(sessions, {
+      query: 'alice smith', activeTags: new Map(), activeTab: 'all', registeredSessionIds: new Set(),
+    });
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].sessionId).to.equal('s1');
   });
 
   it('filters by speaker name', () => {
@@ -605,6 +639,39 @@ describe('sessions-hub init', () => {
     await init(el);
     const cards = el.querySelectorAll('.sh-card');
     expect(cards.length).to.equal(2);
+  });
+
+  it('shows no-results state when search matches no sessions', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([makeSession()]);
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+    const search = el.querySelector('.sh-search');
+    search.value = 'zzznomatch';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 250));
+    const empty = el.querySelector('.sh-no-results');
+    const list = el.querySelector('.sh-session-list');
+    expect(empty.hidden).to.be.false;
+    expect(list.hidden).to.be.true;
+  });
+
+  it('restores session list when search is cleared after no matches', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([makeSession()]);
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+    const search = el.querySelector('.sh-search');
+    search.value = 'zzznomatch';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 250));
+    search.value = '';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 250));
+    const empty = el.querySelector('.sh-no-results');
+    const list = el.querySelector('.sh-session-list');
+    expect(empty.hidden).to.be.true;
+    expect(list.hidden).to.be.false;
   });
 
   it('renders sticky event banner when user is not event-registered', async () => {


### PR DESCRIPTION
## Summary
- Restrict Sessions Hub text search to **title**, **speaker names** (first, last, or full-name substring), and **tag labels**; **exclude session descriptions** by default.
- Require **trimmed query length ≥ 2** before applying text search (1 character or whitespace-only leaves all sessions visible subject to tab/tag filters).
- Optional block class **`search-include-description`** restores description matching for marketers who need legacy behavior.
- Add **no-results** UI (`role="status"`, `aria-live="polite"`) when a qualifying search returns zero sessions; hide the session grid in that state.
- Export **`filterSessions`** for unit tests; extend **`sessions-catalogue`** tests.

## Fit criteria mapping
- [x] 1-char query does not filter by text
- [x] ≥2 chars filter by title / speaker / tags (OR), case-insensitive partial match
- [x] Description-only match excluded unless `search-include-description`
- [x] Zero matches shows empty state; clearing search restores grid

## Test plan
- `npx eslint event-libs/v1/blocks/sessions-hub/sessions-hub.js test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js`
- `npx stylelint event-libs/v1/blocks/sessions-hub/sessions-hub.css`
- `npx wtr test/unit/blocks/sessions-catalogue/sessions-catalogue.test.js --node-resolve --port=2000`

Made with [Cursor](https://cursor.com)