### PR TITLE
Cherry-pick: Update clear-cache.yml CP codes (stage → main)

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -19,10 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       cpCode:
-        description: 'CP Code: Prod - 1318762 / Stage - 1318533'
+        description: 'CP Code: Prod - 1897648 / Stage - 1892084'
         type: string
         required: true
-        default: '1318762'
+        default: '1897648'
       network:
         description: 'Network'
         type: choice


### PR DESCRIPTION
## Summary
- Cherry-picks ef6630f onto `main` — fixes the CP codes in `.github/workflows/clear-cache.yml` to use the correct event-libs values.
- This is a targeted promotion of a CI/CD fix; no product code changes.

## Merge order
1. Merge the companion PR to `stage` (#136) first
2. Then merge **this PR** (→ main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)