### PR TITLE
Cherry-pick: Fix CP codes in release.yml (dev → stage)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.ref == 'refs/heads/stage'
     uses: ./.github/workflows/clear-cache.yml
     with:
-      cpCode: 1318533
+      cpCode: 1892084
       network: production
       command: delete
     secrets: inherit
@@ -20,7 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/clear-cache.yml
     with:
-      cpCode: 1318762
+      cpCode: 1897648
       network: production
       command: delete
 


### PR DESCRIPTION
## Summary
- Fixes the CP codes in `.github/workflows/release.yml` to use the correct event-libs values:
  - Stage: `1318533` → `1892084`
  - Main: `1318762` → `1897648`

## Merge order
1. Merge **this PR** (→ stage) first
2. Then merge the companion PR targeting `main` (#138 or next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)