### PR TITLE
feat(rsvp): submit requiresSxswTicket with event-attendee payload

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -890,6 +890,7 @@ async function createForm(bp, formData) {
 
   if (rsvpFieldsData) {
     const { required, visible } = rsvpFieldsData;
+    // Sheet-backed fields (e.g. requiresSxswTicket) must appear in `visible` or they are dropped before render.
     json.data = json.data
       .map((obj) => {
         const lowkey = lowercaseKeys(obj);

--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -13,6 +13,7 @@ export const EVENT_ATTENDEE_DATA_FILTER = {
   registrationStatus: { type: 'string', submittable: true },
   invitedBy: { type: 'string', submittable: true },
   shareInfoWithPartners: { type: 'boolean', submittable: true },
+  requiresSxswTicket: { type: 'boolean', submittable: true },
   ccSentiment: { type: 'string', submittable: true },
   campaignId: { type: 'string', submittable: true },
 };

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -1,0 +1,38 @@
+import { expect } from '@esm-bundle/chai';
+
+import { getEventAttendeePayload } from '../../../event-libs/v1/utils/data-utils.js';
+
+describe('data-utils', () => {
+  describe('getEventAttendeePayload', () => {
+    it('includes requiresSxswTicket when true', () => {
+      const out = getEventAttendeePayload({
+        email: 'a@b.com',
+        requiresSxswTicket: true,
+        unknownCustomFlag: true,
+      });
+      expect(out.requiresSxswTicket).to.be.true;
+      expect(out).to.not.have.property('unknownCustomFlag');
+    });
+
+    it('includes requiresSxswTicket when false', () => {
+      const out = getEventAttendeePayload({
+        requiresSxswTicket: false,
+      });
+      expect(out.requiresSxswTicket).to.be.false;
+    });
+
+    it('drops unknown keys', () => {
+      const out = getEventAttendeePayload({
+        firstName: 'Ada',
+        totallyMadeUpField: 'x',
+      });
+      expect(out.firstName).to.equal('Ada');
+      expect(out).to.not.have.property('totallyMadeUpField');
+    });
+
+    it('returns argument unchanged when falsy', () => {
+      expect(getEventAttendeePayload(null)).to.equal(null);
+      expect(getEventAttendeePayload(undefined)).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

- Add `requiresSxswTicket` to `EVENT_ATTENDEE_DATA_FILTER` so checkbox responses are sent with the event-attendee payload to ESL (`addAttendeeToEvent`), matching `shareInfoWithPartners`.
- Add `test/unit/utils/data-utils.test.js` coverage for `getEventAttendeePayload` (`requiresSxswTicket` true/false, unknown keys stripped).
- Inline note in `events-form` when `rsvp-form-fields` metadata gates fields: new sheet fields must be listed in `visible`.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--event-libs--adobecom.aem.live/?martech=off
- After: https://cursor-rsvp-requires-sxsw-ticket-filter--event-libs--adobecom.aem.live/?martech=off

Made with [Cursor](https://cursor.com)