### PR TITLE
[MWPW-195082] Fixed typo for window reload

### DIFF
--- a/event-libs/scripts/scripts.js
+++ b/event-libs/scripts/scripts.js
@@ -51,7 +51,7 @@ const CONFIG = {
     enableGuestBotDetection: false,
     api_parameters: { check_token: { guest_allowed: true } },
     onTokenExpired: () => {
-      window.locaton.reload();
+      window.location.reload();
     },
   },
 };


### PR DESCRIPTION
 ### Summary
  
  - Fix typo in scripts.js: window.locaton.reload() → window.location.reload()

  The misspelling caused a silent TypeError on IMS token expiry — window.locaton is undefined, so .reload() would throw instead of refreshing the page. This means expired
  sessions were never recovered via page reload.

  ### Test Plan

  - Manual: Sign in to an event page, let the IMS token expire (or simulate expiry by calling window.adobeIMS.signOut() then triggering onTokenExpired), and confirm the page
  reloads instead of throwing a console error
  - Smoke: Load an event page on stage with a valid IMS session and verify normal login/logout flow is unaffected
  - npm run lint passes (no new lint errors)
  - npm test passes

Resolves: [MWPW-195082](https://jira.corp.adobe.com/browse/MWPW-195082)

Test URLs:
- Before: https://dev--event-libs--adobecom.aem.live/?martech=off
- After: https://MWPW-195082--event-libs--adobecom.aem.live/?martech=off
