### PR TITLE
[MWPW-194898] : Fix updateImgTag to preserve section-metadata pictures and drop unresolved placeholders

### DIFF
--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -607,7 +607,7 @@ export function updatePictureElement(imageUrl, parentPic, altText) {
   });
 }
 
-function updateImgTag(child, matchCallback) {
+function updateImgTag(child, matchCallback, parentElement) {
   const parentPic = child.closest('picture');
   const originalAlt = child.alt;
   const photoMeta = originalAlt.replace(META_REG, (_match, p1) => matchCallback(_match, p1, child));
@@ -622,11 +622,16 @@ function updateImgTag(child, matchCallback) {
 
     if (imgUrl && parentPic && imgUrl !== originalAlt) {
       updatePictureElement(imgUrl, parentPic, altText);
-    } else if (originalAlt.match(META_REG)) {
-      // Placeholder didn't resolve — keep the authored <picture> as a fallback
-      // (e.g. section-metadata backgrounds) and just strip the [[...]] from alt
-      // so it doesn't leak to the UI.
+      return;
+    }
+
+    if (!originalAlt.match(META_REG)) return;
+
+    // Keep section-metadata pictures (authored fallbacks); drop other unresolved placeholders.
+    if (parentPic?.parentElement?.closest('.section-metadata')) {
       child.alt = altText || '';
+    } else {
+      parentElement.remove();
     }
   } catch (e) {
     window.lana?.log(`Error while attempting to update image:\n${JSON.stringify(e, null, 2)}`);
@@ -962,7 +967,7 @@ function processTemplateInAllNodes(parent, extraData) {
     if (element.childNodes.length) {
       element.childNodes.forEach((n) => {
         if (isImage(n)) {
-          updateImgTag(n, getImgData);
+          updateImgTag(n, getImgData, element);
         }
 
         if (isPlainTextNode(n)) {

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -607,7 +607,7 @@ export function updatePictureElement(imageUrl, parentPic, altText) {
   });
 }
 
-function updateImgTag(child, matchCallback, parentElement) {
+function updateImgTag(child, matchCallback) {
   const parentPic = child.closest('picture');
   const originalAlt = child.alt;
   const photoMeta = originalAlt.replace(META_REG, (_match, p1) => matchCallback(_match, p1, child));
@@ -623,7 +623,10 @@ function updateImgTag(child, matchCallback, parentElement) {
     if (imgUrl && parentPic && imgUrl !== originalAlt) {
       updatePictureElement(imgUrl, parentPic, altText);
     } else if (originalAlt.match(META_REG)) {
-      parentElement.remove();
+      // Placeholder didn't resolve — keep the authored <picture> as a fallback
+      // (e.g. section-metadata backgrounds) and just strip the [[...]] from alt
+      // so it doesn't leak to the UI.
+      child.alt = altText || '';
     }
   } catch (e) {
     window.lana?.log(`Error while attempting to update image:\n${JSON.stringify(e, null, 2)}`);
@@ -959,7 +962,7 @@ function processTemplateInAllNodes(parent, extraData) {
     if (element.childNodes.length) {
       element.childNodes.forEach((n) => {
         if (isImage(n)) {
-          updateImgTag(n, getImgData, element);
+          updateImgTag(n, getImgData);
         }
 
         if (isPlainTextNode(n)) {


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-194898

## What

Updates the `updateImgTag` function in `decorate.js` to correctly distinguish between unresolved placeholder images that should be removed vs. authored fallback images inside `.section-metadata` that should be preserved.

Previously, any image whose `alt` matched `META_REG` (an unresolved placeholder) would always trigger `parentElement.remove()`, which incorrectly removed authored fallback images in section-metadata containers.

The fix:
- Returns early once a picture element has been successfully updated (no further checks needed)
- For remaining `META_REG` matches, preserves the picture if it lives inside `.section-metadata` (sets `alt` to the resolved text or empty string)
- Removes the `parentElement` only for unresolved placeholders outside section-metadata

## Why

Authored fallback images inside section-metadata fragments were being wiped out when their `alt` text happened to match the placeholder pattern, causing missing images in rendered event pages.

## Test plan

- `npm test` — all 548 tests pass
- Verify section-metadata images render correctly on event pages when the hero image is not added in EMC

Before: https://main--da-bacom--adobecom.aem.page/de/drafts/robertw-test/bacom-webinar-training/test-event-creation/2026-05-28?timing=1779926399990&espenv=stage&martech=off
After: https://main--da-bacom--adobecom.aem.page/de/drafts/robertw-test/bacom-webinar-training/test-event-creation/2026-05-28?timing=1779926399990&espenv=stage&eventlibs=debug-img-fragment&martech=off
