### PR TITLE
Load event blocks from /event-libs/v1 in standalone mode

### DIFF
--- a/event-libs/scripts/scripts.js
+++ b/event-libs/scripts/scripts.js
@@ -12,6 +12,7 @@
 
 import { LIBS } from '../v1/utils/utils.js';
 import decorateArea from '../v1/utils/decorate.js';
+import { EVENT_BLOCKS } from '../v1/libs.js';
 
 const {
   loadArea,
@@ -33,6 +34,9 @@ const CONFIG = {
   imsClientId: 'events-milo',
   miloLibs: LIBS,
   prodDomains,
+  externalLibs: [
+    { base: '/event-libs/v1', blocks: EVENT_BLOCKS },
+  ],
   htmlExclude: [
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,


### PR DESCRIPTION
Without an externalLibs entry, Milo's loader requests blocks at <codeRoot>/blocks/<name>/<name>.js (= /event-libs/blocks/<name>...), but the files live under /event-libs/v1/blocks/. Match how da-events wires the same loader so standalone aem-up in event-libs can render blocks.