### PR TITLE
[MWPW-195781] chore: upgrade Node.js from 18 to 24 in CI workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Kodiak throws warning for older Node version in Github Action workflow on dev
Upgraded to Node 24

Resolves: [MWPW-195781](https://jira.corp.adobe.com/browse/MWPW-195781)

