### PR TITLE
T3-26.23 Stage Release

### DIFF
--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -1,0 +1,45 @@
+Create a pull request targeting the `dev` branch.
+
+## 1. Pre-flight checks
+
+Run lint and tests in parallel:
+
+```bash
+npm run lint
+npm test
+```
+
+If lint fails, run `npm run lint:fix`, show what changed, then re-run to confirm clean.
+If any test fails, identify the cause and ask the user whether to fix it before continuing.
+
+## 2. Collect changes
+
+```bash
+git diff dev...HEAD --name-only
+git log dev...HEAD --oneline
+```
+
+Flag any commits with vague messages ("fix", "wip", "update", "changes") and ask the user to amend them before opening the PR.
+
+## 3. Push branch
+
+```bash
+git push -u origin HEAD
+```
+
+## 4. Create the PR
+
+```bash
+gh pr create --base dev
+```
+
+PR format:
+- **Title**: imperative mood, under 70 chars (e.g. "Add guest token support to RSVP block")
+- **Body**:
+  - **What**: one-paragraph description of the change
+  - **Why**: motivation or Jira/ticket reference
+  - **Test plan**: manual steps or `npm test` confirmation
+
+## 5. Output
+
+Print the PR URL when created.

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/event-libs/scripts/scripts.js
+++ b/event-libs/scripts/scripts.js
@@ -12,6 +12,7 @@
 
 import { LIBS } from '../v1/utils/utils.js';
 import decorateArea from '../v1/utils/decorate.js';
+import { EVENT_BLOCKS } from '../v1/libs.js';
 
 const {
   loadArea,
@@ -33,6 +34,9 @@ const CONFIG = {
   imsClientId: 'events-milo',
   miloLibs: LIBS,
   prodDomains,
+  externalLibs: [
+    { base: '/event-libs/v1', blocks: EVENT_BLOCKS },
+  ],
   htmlExclude: [
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,

--- a/event-libs/scripts/scripts.js
+++ b/event-libs/scripts/scripts.js
@@ -51,7 +51,7 @@ const CONFIG = {
     enableGuestBotDetection: false,
     api_parameters: { check_token: { guest_allowed: true } },
     onTokenExpired: () => {
-      window.locaton.reload();
+      window.location.reload();
     },
   },
 };

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -858,6 +858,9 @@ function getRsvpConfigFromMeta() {
       const field = lowercaseKeys(f);
       if (typeof field.field === 'string') field.field = field.field.trim();
       field.required = field.required === true ? 'x' : '';
+      if (Array.isArray(field.options)) {
+        field.options = field.options.map((o) => (typeof o === 'object' ? o.value : o)).join(';');
+      }
       return field;
     });
 

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -911,25 +911,26 @@ async function createForm(bp, formData) {
 
   await dictionaryManager.initialize();
 
-  if (rsvpConfigData) {
-  } else if (rsvpFieldsData) {
-    const { required, visible } = rsvpFieldsData;
-    json.data = json.data
-      .map((obj) => {
-        const lowkey = lowercaseKeys(obj);
-        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
-        if (required.includes(lowkey.field)) lowkey.required = 'x';
-        return lowkey;
-      })
-      .filter((f) => visible.includes(f.field) || ['clear', 'submit'].includes(f.field));
-  } else {
-    json.data = json.data
-      .map((obj) => {
-        const lowkey = lowercaseKeys(obj);
-        if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
-        return lowkey;
-      })
-      .filter((f) => ['clear', 'submit'].includes(f.field));
+  if (!rsvpConfigData) {
+    if (rsvpFieldsData) {
+      const { required, visible } = rsvpFieldsData;
+      json.data = json.data
+        .map((obj) => {
+          const lowkey = lowercaseKeys(obj);
+          if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
+          if (required.includes(lowkey.field)) lowkey.required = 'x';
+          return lowkey;
+        })
+        .filter((f) => visible.includes(f.field) || ['clear', 'submit'].includes(f.field));
+    } else {
+      json.data = json.data
+        .map((obj) => {
+          const lowkey = lowercaseKeys(obj);
+          if (typeof lowkey.field === 'string') lowkey.field = lowkey.field.trim();
+          return lowkey;
+        })
+        .filter((f) => ['clear', 'submit'].includes(f.field));
+    }
   }
 
   const formEl = createTag('form');

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -3,7 +3,7 @@ import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
 import { dictionaryManager, getInviteOnlyNoCampaignMessage } from '../../utils/dictionary-manager.js';
 import { getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl } from '../../utils/utils.js';
-import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN } from '../../utils/constances.js';
+import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN, PHONE_FIELD_RE, PHONE_PATTERN  } from '../../utils/constances.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
 
 const eventConfig = getEventConfig();
@@ -16,9 +16,6 @@ const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attri
 const { default: loadFragment } = await import(`${miloLibs}/blocks/fragment/fragment.js`);
 
 const VALID_REGISTRATION_STATUS = ['registered', 'waitlisted'];
-
-const PHONE_FIELD_RE = /phone/i;
-const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
 
 const RULE_OPERATORS = {
   equal: '=',
@@ -849,27 +846,53 @@ function addTerms(form, terms) {
   submitWrapper.before(termsWrapper);
 }
 
+function getRsvpConfigFromMeta() {
+  const raw = getMetadata('rsvp-config');
+  if (!raw) return null;
+
+  try {
+    const config = JSON.parse(raw);
+    if (!config.rsvpFormFields?.length) return null;
+
+    const data = config.rsvpFormFields.map((f) => {
+      const field = lowercaseKeys(f);
+      if (typeof field.field === 'string') field.field = field.field.trim();
+      field.required = field.required === true ? 'x' : '';
+      return field;
+    });
+
+    return { data };
+  } catch (error) {
+    window.lana?.log(`Failed to parse rsvp-config metadata: ${JSON.stringify(error)}`);
+    return null;
+  }
+}
+
 async function createForm(bp, formData) {
   const { form, terms } = bp;
 
-  let rsvpFieldsData;
+  const rsvpConfigData = getRsvpConfigFromMeta();
 
-  try {
-    rsvpFieldsData = JSON.parse(getMetadata('rsvp-form-fields'));
-  } catch (error) {
-    window.lana?.log(`Failed to parse partners metadata:\n${JSON.stringify(error, null, 2)}`);
+  let rsvpFieldsData;
+  if (!rsvpConfigData) {
+    try {
+      rsvpFieldsData = JSON.parse(getMetadata('rsvp-form-fields'));
+    } catch (error) {
+      window.lana?.log(`Failed to parse partners metadata:\n${JSON.stringify(error, null, 2)}`);
+    }
   }
 
-  let json = formData;
+  let json = rsvpConfigData || formData;
   /* c8 ignore next 4 */
-  if (!formData) {
+  if (!json) {
     const resp = await fetch(form.href);
     json = await resp.json();
   }
 
   await dictionaryManager.initialize();
 
-  if (rsvpFieldsData) {
+  if (rsvpConfigData) {
+  } else if (rsvpFieldsData) {
     const { required, visible } = rsvpFieldsData;
     json.data = json.data
       .map((obj) => {
@@ -891,8 +914,10 @@ async function createForm(bp, formData) {
 
   const formEl = createTag('form');
   const rules = [];
-  const [action] = new URL(form.href).pathname.split('.json');
-  formEl.dataset.action = action;
+  if (form.href) {
+    const [action] = new URL(form.href).pathname.split('.json');
+    formEl.dataset.action = action;
+  }
 
   const typeToElement = {
     'multi-select': { fn: createSelect, params: [], label: true, classes: [] },
@@ -1156,16 +1181,18 @@ function getFormLink(block, bp) {
   const legacyLink = block.querySelector(':scope > div:nth-of-type(2) a[href$=".json"]');
   const form = createTag('a');
 
-  try {
-    form.href = getRsvpConfigUrl();
-  } catch (error) {
-    window.lana?.log(`Error getting RSVP config URL: ${JSON.stringify(error)}`);
-    throw error;
-  }
+  if (!getRsvpConfigFromMeta()) {
+    try {
+      form.href = getRsvpConfigUrl();
+    } catch (error) {
+      window.lana?.log(`Error getting RSVP config URL: ${JSON.stringify(error)}`);
+      throw error;
+    }
 
-  if (legacyLink) {
-    legacyLink.href = form.href;
-    return legacyLink;
+    if (legacyLink) {
+      legacyLink.href = form.href;
+      return legacyLink;
+    }
   }
 
   bp.formContainer.append(form);

--- a/event-libs/v1/utils/constances.js
+++ b/event-libs/v1/utils/constances.js
@@ -150,3 +150,5 @@ export const FALLBACK_LOCALES = {
   za: { ietf: 'en-GB', tk: 'hah7vzn.css' },
 };
 export const LATEST_VERSION = 'v1';
+export const PHONE_FIELD_RE = /phone/i;
+export const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -607,7 +607,7 @@ export function updatePictureElement(imageUrl, parentPic, altText) {
   });
 }
 
-function updateImgTag(child, matchCallback) {
+function updateImgTag(child, matchCallback, parentElement) {
   const parentPic = child.closest('picture');
   const originalAlt = child.alt;
   const photoMeta = originalAlt.replace(META_REG, (_match, p1) => matchCallback(_match, p1, child));
@@ -622,11 +622,16 @@ function updateImgTag(child, matchCallback) {
 
     if (imgUrl && parentPic && imgUrl !== originalAlt) {
       updatePictureElement(imgUrl, parentPic, altText);
-    } else if (originalAlt.match(META_REG)) {
-      // Placeholder didn't resolve — keep the authored <picture> as a fallback
-      // (e.g. section-metadata backgrounds) and just strip the [[...]] from alt
-      // so it doesn't leak to the UI.
+      return;
+    }
+
+    if (!originalAlt.match(META_REG)) return;
+
+    // Keep section-metadata pictures (authored fallbacks); drop other unresolved placeholders.
+    if (parentPic?.parentElement?.closest('.section-metadata')) {
       child.alt = altText || '';
+    } else {
+      parentElement.remove();
     }
   } catch (e) {
     window.lana?.log(`Error while attempting to update image:\n${JSON.stringify(e, null, 2)}`);
@@ -962,7 +967,7 @@ function processTemplateInAllNodes(parent, extraData) {
     if (element.childNodes.length) {
       element.childNodes.forEach((n) => {
         if (isImage(n)) {
-          updateImgTag(n, getImgData);
+          updateImgTag(n, getImgData, element);
         }
 
         if (isPlainTextNode(n)) {

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -607,7 +607,7 @@ export function updatePictureElement(imageUrl, parentPic, altText) {
   });
 }
 
-function updateImgTag(child, matchCallback, parentElement) {
+function updateImgTag(child, matchCallback) {
   const parentPic = child.closest('picture');
   const originalAlt = child.alt;
   const photoMeta = originalAlt.replace(META_REG, (_match, p1) => matchCallback(_match, p1, child));
@@ -623,7 +623,10 @@ function updateImgTag(child, matchCallback, parentElement) {
     if (imgUrl && parentPic && imgUrl !== originalAlt) {
       updatePictureElement(imgUrl, parentPic, altText);
     } else if (originalAlt.match(META_REG)) {
-      parentElement.remove();
+      // Placeholder didn't resolve — keep the authored <picture> as a fallback
+      // (e.g. section-metadata backgrounds) and just strip the [[...]] from alt
+      // so it doesn't leak to the UI.
+      child.alt = altText || '';
     }
   } catch (e) {
     window.lana?.log(`Error while attempting to update image:\n${JSON.stringify(e, null, 2)}`);
@@ -959,7 +962,7 @@ function processTemplateInAllNodes(parent, extraData) {
     if (element.childNodes.length) {
       element.childNodes.forEach((n) => {
         if (isImage(n)) {
-          updateImgTag(n, getImgData, element);
+          updateImgTag(n, getImgData);
         }
 
         if (isPlainTextNode(n)) {


### PR DESCRIPTION
## T3-26.23 Stage Release

Promotes `dev` → `stage` for staging validation ahead of the **T3-26.23** production release.

### Release notes

**RSVP & registration**
- Load RSVP form field definitions from the new EMC scope config via `rsvp-config` page metadata (MWPW-194614) (#134). When present, metadata is the authoritative source; legacy spreadsheet / `rsvp-form-fields` paths remain as fallback.
- Normalize meta config: lowercase field keys, map `required: true` to `x`, join options as `;`-separated strings to match sheet conventions.
- Guard `formEl.dataset.action` behind `form.href` check to prevent TypeError on meta-only path.

**Images & fragments**
- Fix `updateImgTag` to preserve authored fallback images inside `.section-metadata` while still removing unresolved placeholders elsewhere (MWPW-194898) (#144).

**IMS / session recovery**
- Fix typo `window.locaton.reload()` → `window.location.reload()` so expired IMS tokens trigger a page reload instead of a silent TypeError (MWPW-195082) (#142).

**Standalone / local dev**
- Load event blocks from `/event-libs/v1` in standalone mode to match da-events loader wiring (#148).

**Tooling & CI**
- Upgrade Node.js from 18 to 24 in CI workflow (MWPW-195781) (#149).
- Add `/open-pr` Claude slash command for standardized PR workflow (#143).

---

### Included merges

| PR | Theme |
|----|-------|
| #134 | RSVP config from EMC scope metadata |
| #142 | IMS token expiry reload fix |
| #143 | Claude `/open-pr` command |
| #144 | Section-metadata image preservation |
| #148 | Standalone block loader path |
| #149 | Node 24 CI upgrade |

**Promotion path:** `dev` is **17** commits ahead of `stage` at PR open.

### Verification

- [ ] Smoke-test RSVP form rendering with metadata-driven config on stage
- [ ] Verify section-metadata fallback images on event pages without EMC hero image
- [ ] Confirm IMS session expiry triggers page reload
- [ ] Confirm stage deploy / cache-clear workflow after merge

_Post-merge: merge the companion **T3-26.23 Production Release** PR (`stage` → `main`) after stage validation._

Made with [Cursor](https://cursor.com)