### PR TITLE
fix(timing-framework): respect toggleTime when avoidStreamEndFlag is set

### DIFF
--- a/event-libs/v1/features/timing-framework/README.md
+++ b/event-libs/v1/features/timing-framework/README.md
@@ -335,7 +335,7 @@ This would simulate the page as if "now" is the specified timestamp, but time co
 
 ##### 3. `avoidStreamEndFlag` - Mobile Rider Stream Testing
 
-The `avoidStreamEndFlag` parameter treats all Mobile Rider streams as having already ended, allowing the schedule to progress past any Mobile Rider sessions.
+The `avoidStreamEndFlag` parameter treats all Mobile Rider streams as inactive for **blocking** purposes (no overrun hold on an active stream), so time-based schedule positioning can proceed. It does **not** skip `toggleTime` windows or fast-forward to later fragments; only natural stream-end underrun advances before `toggleTime`.
 
 **Example Usage:**
 ```

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -335,24 +335,26 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended
-        const shouldTreatAsActive = this.testingManager.shouldAvoidStreamEnd() ? false : isActive;
+        const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+        const shouldTreatAsActive = avoidingStreamEnd ? false : isActive;
         if (shouldTreatAsActive) {
           return false;
         }
-        liveStreamEnd = true;
+        if (!avoidingStreamEnd && !isActive) {
+          liveStreamEnd = true;
+        }
       }
     }
 
-    // Check if current item has mobileRider that's ended (underrun)
+    // Check if next item has mobileRider that's ended early (underrun)
     if (scheduleItem.mobileRider) {
       const mobileRiderStore = this.plugins.get('mobileRider');
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended (skip forward)
-        const shouldTreatAsEnded = this.testingManager.shouldAvoidStreamEnd() ? true : !isActive;
-        if (shouldTreatAsEnded) return true;
+        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
+          return true;
+        }
       }
     }
 

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -330,17 +330,18 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended
-        const shouldTreatAsActive = this.testingManager.shouldAvoidStreamEnd() ? false : isActive;
+        const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+        const shouldTreatAsActive = avoidingStreamEnd ? false : isActive;
         if (shouldTreatAsActive) {
           return false; // Wait for session to end
         }
-        liveStreamEnd = true;
+        if (!avoidingStreamEnd && !isActive) {
+          liveStreamEnd = true;
+        }
       }
     }
 
     if (scheduleItem.mobileRider) {
-      // Check if toggleTime has passed before checking mobileRider status
       const timePassed = await this.hasToggleTimePassed(scheduleItem);
       if (!timePassed) return false;
 
@@ -348,10 +349,7 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended (skip forward)
-        const shouldTreatAsEnded = this.testingManager.shouldAvoidStreamEnd() ? true : !isActive;
-        if (shouldTreatAsEnded) {
-          this.nextScheduleItem = scheduleItem.next;
+        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
           return true;
         }
       }

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -224,6 +224,63 @@ describe('TimingWorker', () => {
       const result = await worker.shouldTriggerNextSchedule(nextItem);
       expect(result).to.be.true;
     });
+
+    it('should not trigger future MR slot when avoidStreamEndFlag is set', async () => {
+      const now = Date.now();
+      const nextItem = {
+        toggleTime: now + 600000,
+        pathToFragment: '/future-session',
+        mobileRider: { sessionId: 'session2' },
+      };
+
+      worker.testingManager.init({ avoidStreamEndFlag: true });
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current-session',
+      };
+      worker.plugins.set('mobileRider', new Map([
+        ['session1', true],
+        ['session2', true],
+      ]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.false;
+    });
+
+    it('should trigger next item when prior MR stream ended naturally and toggleTime is in future', async () => {
+      const nextItem = {
+        toggleTime: Date.now() + 600000,
+        pathToFragment: '/next',
+      };
+
+      worker.testingManager.init(null);
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current-session',
+      };
+      worker.plugins.set('mobileRider', new Map([['session1', false]]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.true;
+    });
+
+    it('should not set liveStreamEnd when avoidStreamEndFlag is set on current MR item', async () => {
+      const now = Date.now();
+      const nextItem = {
+        toggleTime: now + 600000,
+        pathToFragment: '/future',
+      };
+
+      worker.testingManager.init({ avoidStreamEndFlag: true });
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current',
+      };
+      worker.plugins.set('mobileRider', new Map([['session1', true]]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.false;
+    });
   });
 
   describe('handleMessage', () => {


### PR DESCRIPTION
## Summary

- Fixes `?avoidStreamEndFlag=true` so the chrono-box schedule shows the timed fragment for the **current** period instead of fast-forwarding to the last slot.
- `avoidStreamEndFlag` now only disables Mobile Rider **blocking** (overrun hold on active streams); it no longer reuses underrun/`liveStreamEnd` early-advance paths meant for streams that naturally ended.
- Aligns `worker-traditional.js` (production path via chrono-box) and `worker.js`; removes erroneous `nextScheduleItem` mutation in the module worker.

## Test plan

- [x] `npx wtr test/unit/features/timing-framework/worker.test.js --node-resolve --port=2000` (45 passed)
- [x] ESLint on changed JS files
- [ ] Manual: event page with multiple MR timed fragments + `?avoidStreamEndFlag=true` shows current-period fragment
- [ ] Manual: `?serverTime=<ms>&avoidStreamEndFlag=true` at a known schedule window
- [ ] Manual: without flag, active MR session still holds slot past `toggleTime` (overrun unchanged)


Made with [Cursor](https://cursor.com)