### PR TITLE
fix(timing-framework): avoidStreamEndFlag and traditional worker alignment

### DIFF
--- a/event-libs/v1/blocks/mobile-rider/mobile-rider.js
+++ b/event-libs/v1/blocks/mobile-rider/mobile-rider.js
@@ -185,6 +185,7 @@ class MobileRider {
   }
 
   #attachEndListener(vid) {
+    if (new URLSearchParams(window.location.search).get('avoidStreamEndFlag') === 'true') return;
     // Avoid stacking listeners
     window.__mr_player?.off?.('streamend');
     window.__mr_player?.on?.('streamend', () => {

--- a/event-libs/v1/features/timing-framework/README.md
+++ b/event-libs/v1/features/timing-framework/README.md
@@ -335,7 +335,7 @@ This would simulate the page as if "now" is the specified timestamp, but time co
 
 ##### 3. `avoidStreamEndFlag` - Mobile Rider Stream Testing
 
-The `avoidStreamEndFlag` parameter treats all Mobile Rider streams as having already ended, allowing the schedule to progress past any Mobile Rider sessions.
+The `avoidStreamEndFlag` parameter treats all Mobile Rider streams as inactive for **blocking** purposes (no overrun hold on an active stream), so time-based schedule positioning can proceed. It does **not** skip `toggleTime` windows or fast-forward to later fragments; only natural stream-end underrun advances before `toggleTime`.
 
 **Example Usage:**
 ```

--- a/event-libs/v1/features/timing-framework/README.md
+++ b/event-libs/v1/features/timing-framework/README.md
@@ -639,8 +639,8 @@ timing-framework/
 
 **Usage Guidelines:**
 - Use `worker.js` for same-origin deployments with modern browsers
-- Use `worker-traditional.js` for cross-origin or CSP-restricted environments
-- Both versions provide identical functionality
+- Use `worker-traditional.js` for cross-origin or CSP-restricted environments (chrono-box production path)
+- **Keep both workers behaviorally aligned** — schedule trigger, time cache, and init paths must match; unit tests in `worker.test.js` exercise the module worker as the reference implementation
 - Testing capabilities work in both modes
 
 ### Browser Compatibility

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -268,6 +268,11 @@ class TimingWorker {
 
     while (pointer) {
       const { toggleTime } = pointer;
+      if (!toggleTime) {
+        start = pointer;
+        pointer = pointer.next;
+        continue;
+      }
       const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
       const toggleTimePassed = typeof numericToggleTime !== 'number' || adjustedTime > numericToggleTime;
 

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -335,24 +335,26 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended
-        const shouldTreatAsActive = this.testingManager.shouldAvoidStreamEnd() ? false : isActive;
+        const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+        const shouldTreatAsActive = avoidingStreamEnd ? false : isActive;
         if (shouldTreatAsActive) {
           return false;
         }
-        liveStreamEnd = true;
+        if (!avoidingStreamEnd && !isActive) {
+          liveStreamEnd = true;
+        }
       }
     }
 
-    // Check if current item has mobileRider that's ended (underrun)
+    // Check if next item has mobileRider that's ended early (underrun)
     if (scheduleItem.mobileRider) {
       const mobileRiderStore = this.plugins.get('mobileRider');
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended (skip forward)
-        const shouldTreatAsEnded = this.testingManager.shouldAvoidStreamEnd() ? true : !isActive;
-        if (shouldTreatAsEnded) return true;
+        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
+          return true;
+        }
       }
     }
 

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -265,6 +265,8 @@ class TimingWorker {
 
     let pointer = scheduleRoot;
     let start = null;
+    let lastTimedStart = null;
+    let brokeOnFuture = false;
 
     while (pointer) {
       const { toggleTime } = pointer;
@@ -276,13 +278,21 @@ class TimingWorker {
       const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
       const toggleTimePassed = typeof numericToggleTime !== 'number' || adjustedTime > numericToggleTime;
 
-      if (!toggleTimePassed) break;
+      if (!toggleTimePassed) {
+        brokeOnFuture = true;
+        break;
+      }
 
       start = pointer;
+      lastTimedStart = pointer;
       pointer = pointer.next;
     }
 
-    return start;
+    // When a future-timed item stopped traversal, a null-toggleTime item that appeared
+    // between the last active timed item and the stopping point must not override the
+    // timed item's position (e.g. a transition/catch-all slot interleaved mid-schedule).
+    // When traversal reaches the end naturally, the final item (timed or null) is correct.
+    return brokeOnFuture ? (lastTimedStart || start) : start;
   }
 
   getFastInitialTime() {
@@ -478,7 +488,8 @@ class TimingWorker {
     const authoritativeTime = await this.getAuthoritativeTime();
     const correctItem = this.getStartScheduleItemByToggleTime(schedule, authoritativeTime);
 
-    if (correctItem && correctItem !== this.currentScheduleItem) {
+    const isSamePosition = correctItem?.pathToFragment === this.currentScheduleItem?.pathToFragment;
+    if (correctItem && !isSamePosition) {
       this.nextScheduleItem = correctItem;
     } else if (!correctItem && this.currentScheduleItem) {
       this.nextScheduleItem = schedule;

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -1,4 +1,4 @@
-// Inline TestingManager class (converted from ES6 module)
+// Keep in sync with testing.js (classic worker cannot import ES modules)
 class TestingManager {
   constructor() {
     this.timeOffset = 0;
@@ -82,157 +82,157 @@ class TimingWorker {
     this.previouslySentItem = null;
     this.testingManager = new TestingManager();
 
-    // Time management properties - optimized for scale
+    // Time management — keep aligned with worker.js
     this.cachedApiTime = null;
-    this.lastApiCall = 0;
+    this.lastApiCallPerformance = 0;
     this.apiCallInterval = 300000; // 5 minutes minimum between API calls
-    this.cacheTtl = 600000; // 10 minutes cache TTL (longer for better scaling)
-    this.fallbackToLocal = true;
+    this.cacheTtl = 600000; // 10 minutes cache TTL
     this.consecutiveFailures = 0;
     this.maxFailures = 3;
     this.backoffMultiplier = 2;
     this.maxBackoffInterval = 1800000; // 30 minutes max backoff
+    this.maxAllowedDrift = 60000; // 1 minute max drift before cache invalidation
 
     this.setupMessageHandler();
   }
 
   setupBroadcastChannels(plugins) {
-    // Close any existing channels
     this.channels.forEach((channel) => {
       try {
         if (channel && typeof channel.close === 'function') {
           channel.close();
         }
-      } catch (error) {
-        console.log(`Error closing BroadcastChannel: ${JSON.stringify(error)}`);
+      } catch {
+        // Ignore cleanup errors - non-critical
       }
     });
     this.channels.clear();
 
-    // Only set up channels for enabled plugins
-    if (plugins.has('metadata')) {
+    const createPluginChannel = (channelName, pluginName, messageHandler) => {
       try {
-        const channel = new BroadcastChannel('metadata-store');
+        const channel = new BroadcastChannel(channelName);
         channel.onmessage = (event) => {
-          const { tabId, key, value } = event.data;
-          // Only process messages from this tab
+          const { tabId } = event.data;
           if (tabId === this.tabId) {
-            const metadataStore = this.plugins.get('metadata');
-            if (metadataStore) {
-              metadataStore.set(key, value);
+            const store = this.plugins.get(pluginName);
+            if (store) {
+              messageHandler(event.data, store);
             }
           }
         };
-        this.channels.set('metadata', channel);
-      } catch (error) {
-        console.log(`Error setting up metadata BroadcastChannel: ${JSON.stringify(error)}`);
+        this.channels.set(pluginName, channel);
+      } catch {
+        // BroadcastChannel not supported or failed - cross-tab sync disabled
       }
+    };
+
+    if (plugins.has('metadata')) {
+      createPluginChannel('metadata-store', 'metadata', (data, store) => {
+        store.set(data.key, data.value);
+      });
     }
 
     if (plugins.has('mobileRider')) {
-      try {
-        const channel = new BroadcastChannel('mobile-rider-store');
-        channel.onmessage = (event) => {
-          const { tabId, sessionId, isActive } = event.data;
-          // Only process messages from this tab
-          if (tabId === this.tabId) {
-            const mobileRiderStore = this.plugins.get('mobileRider');
-            if (mobileRiderStore) {
-              mobileRiderStore.set(sessionId, isActive);
-            }
-          }
-        };
-        this.channels.set('mobileRider', channel);
-      } catch (error) {
-        console.log(`Error setting up mobileRider BroadcastChannel: ${JSON.stringify(error)}`);
-      }
+      createPluginChannel('mobile-rider-store', 'mobileRider', (data, store) => {
+        store.set(data.sessionId, data.isActive);
+      });
     }
 
-    // Set up shared time cache channel
     try {
       const timeChannel = new BroadcastChannel('time-cache-store');
       timeChannel.onmessage = (event) => {
         const { type, data } = event.data;
         if (type === 'time-update' && data) {
-          // Update local cache with shared time data
-          this.cachedApiTime = data;
-          this.consecutiveFailures = 0; // Reset failures when we get shared time
+          const now = Date.now();
+          const age = now - data.timestamp;
+
+          if (age < this.cacheTtl && age >= 0) {
+            if (data.performanceTimestamp !== undefined) {
+              this.cachedApiTime = {
+                time: data.time + age,
+                timestamp: now,
+                performanceTimestamp: performance.now(),
+              };
+              this.consecutiveFailures = 0;
+            }
+          }
         }
       };
       this.channels.set('timeCache', timeChannel);
-    } catch (error) {
-      console.log(`Error setting up time cache BroadcastChannel: ${JSON.stringify(error)}`);
+    } catch {
+      // BroadcastChannel not supported or failed - cross-tab time sync disabled
     }
   }
 
-  /**
-   * @returns {number}
-   * @description Returns the current time from the API with caching and rate limiting
-   */
+  getCachedTimeWithElapsed() {
+    const elapsedMs = performance.now() - this.cachedApiTime.performanceTimestamp;
+    return this.cachedApiTime.time + elapsedMs;
+  }
+
+  static parseToggleTime(toggleTime) {
+    return typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
+  }
+
   static async getCurrentTimeFromAPI() {
     try {
       const response = await fetch('https://time.akamai.com/');
       const data = await response.text();
-      const currentTimeInMs = Number.parseInt(data, 10) * 1000;
-      return currentTimeInMs;
-    } catch (error) {
-      console.log(`Error fetching time from API: ${JSON.stringify(error)}`);
+      return Number.parseInt(data, 10) * 1000;
+    } catch {
       return null;
     }
   }
 
-  /**
-   * @returns {Promise<number>}
-   * @description Returns the authoritative current time, using API with fallback to local
-   */
   async getAuthoritativeTime() {
     const now = Date.now();
+    const perfNow = performance.now();
 
-    // If in testing mode, skip API calls and use local time
     if (this.testingManager.isTesting()) {
       return now;
     }
 
-    // If we have a valid cached API time, use it
-    if (this.cachedApiTime && (now - this.cachedApiTime.timestamp) < this.cacheTtl) {
-      const timeSinceCache = now - this.cachedApiTime.timestamp;
-      return this.cachedApiTime.time + timeSinceCache;
+    if (this.cachedApiTime) {
+      const wallClockElapsed = now - this.cachedApiTime.timestamp;
+      const monotonicElapsed = perfNow - this.cachedApiTime.performanceTimestamp;
+      const drift = Math.abs(wallClockElapsed - monotonicElapsed);
+
+      if (drift > this.maxAllowedDrift) {
+        this.cachedApiTime = null;
+      }
     }
 
-    // Calculate backoff interval based on consecutive failures
+    if (this.cachedApiTime && (now - this.cachedApiTime.timestamp) < this.cacheTtl) {
+      return this.getCachedTimeWithElapsed();
+    }
+
     const backoffInterval = Math.min(
       this.apiCallInterval * (this.backoffMultiplier ** this.consecutiveFailures),
       this.maxBackoffInterval,
     );
 
-    // Add jitter to prevent thundering herd (random offset between 0-30% of interval)
     const jitter = Math.random() * 0.3 * backoffInterval;
     const effectiveInterval = backoffInterval + jitter;
 
-    // Check if enough time has passed since last API call (with backoff)
-    if (now - this.lastApiCall < effectiveInterval) {
-      // Use cached time if available, otherwise fall back to local
-      if (this.cachedApiTime) {
-        const timeSinceCache = now - this.cachedApiTime.timestamp;
-        return this.cachedApiTime.time + timeSinceCache;
-      }
-      return now;
+    const timeSinceLastCall = this.lastApiCallPerformance > 0
+      ? perfNow - this.lastApiCallPerformance
+      : Infinity;
+
+    if (timeSinceLastCall < effectiveInterval) {
+      return this.cachedApiTime ? this.getCachedTimeWithElapsed() : now;
     }
 
-    // Try to get fresh time from API
     try {
       const apiTime = await TimingWorker.getCurrentTimeFromAPI();
-      this.lastApiCall = now;
+      this.lastApiCallPerformance = perfNow;
 
       if (apiTime !== null) {
         this.cachedApiTime = {
           time: apiTime,
           timestamp: now,
+          performanceTimestamp: perfNow,
         };
-        // Reset failure count on success
         this.consecutiveFailures = 0;
 
-        // Broadcast the new time to other tabs to reduce API calls
         try {
           const timeChannel = this.channels.get('timeCache');
           if (timeChannel) {
@@ -241,41 +241,24 @@ class TimingWorker {
               data: this.cachedApiTime,
             });
           }
-        } catch (error) {
-          console.log(`Error broadcasting time update: ${JSON.stringify(error)}`);
+        } catch {
+          // Broadcasting failed - not critical
         }
 
         return apiTime;
       }
-      // Increment failure count if API returns null
       this.consecutiveFailures = Math.min(this.consecutiveFailures + 1, this.maxFailures);
-    } catch (error) {
-      console.log(`Error getting authoritative time: ${JSON.stringify(error)}`);
-      // Increment failure count on error
+    } catch {
       this.consecutiveFailures = Math.min(this.consecutiveFailures + 1, this.maxFailures);
     }
 
-    // Fall back to local time if API fails or returns null
-    if (this.fallbackToLocal) {
-      return now;
-    }
-
-    // If fallback is disabled and API failed, use cached time or current time
     if (this.cachedApiTime) {
-      const timeSinceCache = now - this.cachedApiTime.timestamp;
-      return this.cachedApiTime.time + timeSinceCache;
+      return this.getCachedTimeWithElapsed();
     }
-
     return now;
   }
 
-  /**
-   * @param {Object} scheduleRoot - The root of the schedule tree
-   * @returns {Object}
-   * @description Returns the first schedule item that should be shown based on toggleTime
-   */
-  async getStartScheduleItemByToggleTime(scheduleRoot) {
-    const currentTime = await this.getAuthoritativeTime();
+  getStartScheduleItemByToggleTime(scheduleRoot, currentTime) {
     const adjustedTime = this.testingManager.isTesting()
       ? this.testingManager.adjustTime(currentTime)
       : currentTime;
@@ -284,9 +267,8 @@ class TimingWorker {
     let start = null;
 
     while (pointer) {
-      const { toggleTime: t } = pointer;
-      // Convert toggleTime to number if it's a string, like in shouldTriggerNextSchedule
-      const numericToggleTime = typeof t === 'string' ? parseInt(t, 10) : t;
+      const { toggleTime } = pointer;
+      const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
       const toggleTimePassed = typeof numericToggleTime !== 'number' || adjustedTime > numericToggleTime;
 
       if (!toggleTimePassed) break;
@@ -296,6 +278,17 @@ class TimingWorker {
     }
 
     return start;
+  }
+
+  getFastInitialTime() {
+    const hasRecentCache = this.cachedApiTime
+      && (Date.now() - this.cachedApiTime.timestamp) < this.cacheTtl;
+
+    if (hasRecentCache) {
+      return this.getCachedTimeWithElapsed();
+    }
+
+    return Date.now();
   }
 
   /**
@@ -319,6 +312,15 @@ class TimingWorker {
       : currentTime;
 
     return adjustedTime;
+  }
+
+  async hasToggleTimePassed(scheduleItem) {
+    const { toggleTime } = scheduleItem;
+    if (!toggleTime) return true;
+
+    const currentTime = await this.getCurrentTime();
+    const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
+    return currentTime > numericToggleTime;
   }
 
   /**
@@ -346,8 +348,10 @@ class TimingWorker {
       }
     }
 
-    // Check if next item has mobileRider that's ended early (underrun)
     if (scheduleItem.mobileRider) {
+      const timePassed = await this.hasToggleTimePassed(scheduleItem);
+      if (!timePassed) return false;
+
       const mobileRiderStore = this.plugins.get('mobileRider');
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
@@ -377,17 +381,8 @@ class TimingWorker {
       }
     }
     if (liveStreamEnd) return true;
-    // If no plugins are blocking, check toggleTime
-    const { toggleTime } = scheduleItem;
-    if (toggleTime) {
-      const currentTime = await this.getCurrentTime();
-      // Convert toggleTime to number if it's a string
-      const numericToggleTime = typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
-      const timePassed = currentTime > numericToggleTime;
-      return timePassed;
-    }
 
-    return true;
+    return this.hasToggleTimePassed(scheduleItem);
   }
 
   async runTimer() {
@@ -454,17 +449,13 @@ class TimingWorker {
     }
 
     if (schedule) {
-      // Initialize schedule asynchronously since getStartScheduleItemByToggleTime is now async
       this.initializeSchedule(schedule);
     }
   }
 
-  /**
-   * @param {Object} schedule - The schedule to initialize
-   * @description Initializes the schedule asynchronously
-   */
   async initializeSchedule(schedule) {
-    const startItem = await this.getStartScheduleItemByToggleTime(schedule);
+    const initialTime = this.getFastInitialTime();
+    const startItem = this.getStartScheduleItemByToggleTime(schedule, initialTime);
     this.nextScheduleItem = startItem || schedule;
     this.currentScheduleItem = startItem?.prev || null;
     this.previouslySentItem = null;
@@ -472,6 +463,23 @@ class TimingWorker {
     if (!this.nextScheduleItem) return;
 
     this.runTimer();
+
+    this.validateSchedulePosition(schedule).catch(() => {
+      // Validation failed - timer will still run and self-correct on next tick
+    });
+  }
+
+  async validateSchedulePosition(schedule) {
+    const authoritativeTime = await this.getAuthoritativeTime();
+    const correctItem = this.getStartScheduleItemByToggleTime(schedule, authoritativeTime);
+
+    if (correctItem && correctItem !== this.currentScheduleItem) {
+      this.nextScheduleItem = correctItem;
+    } else if (!correctItem && this.currentScheduleItem) {
+      this.nextScheduleItem = schedule;
+      this.currentScheduleItem = null;
+      this.previouslySentItem = null;
+    }
   }
 
   setupMessageHandler() {

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -244,6 +244,8 @@ class TimingWorker {
 
     let pointer = scheduleRoot;
     let start = null;
+    let lastTimedStart = null;
+    let brokeOnFuture = false;
 
     while (pointer) {
       const { toggleTime } = pointer;
@@ -255,13 +257,21 @@ class TimingWorker {
       const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
       const toggleTimePassed = typeof numericToggleTime !== 'number' || adjustedTime > numericToggleTime;
 
-      if (!toggleTimePassed) break;
+      if (!toggleTimePassed) {
+        brokeOnFuture = true;
+        break;
+      }
 
       start = pointer;
+      lastTimedStart = pointer;
       pointer = pointer.next;
     }
 
-    return start;
+    // When a future-timed item stopped traversal, a null-toggleTime item that appeared
+    // between the last active timed item and the stopping point must not override the
+    // timed item's position (e.g. a transition/catch-all slot interleaved mid-schedule).
+    // When traversal reaches the end naturally, the final item (timed or null) is correct.
+    return brokeOnFuture ? (lastTimedStart || start) : start;
   }
 
   /**
@@ -493,8 +503,10 @@ class TimingWorker {
     // Find the correct schedule item based on authoritative time
     const correctItem = this.getStartScheduleItemByToggleTime(schedule, authoritativeTime);
 
-    // If we're on the wrong item, correct it on next timer tick
-    if (correctItem && correctItem !== this.currentScheduleItem) {
+    // If we're on the wrong item, correct it on next timer tick (compare by path, not reference,
+    // because currentScheduleItem is always a spread copy and reference equality is always false)
+    const isSamePosition = correctItem?.pathToFragment === this.currentScheduleItem?.pathToFragment;
+    if (correctItem && !isSamePosition) {
       this.nextScheduleItem = correctItem;
     } else if (!correctItem && this.currentScheduleItem) {
       // Authoritative time says nothing qualifies yet — reset

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -247,6 +247,11 @@ class TimingWorker {
 
     while (pointer) {
       const { toggleTime } = pointer;
+      if (!toggleTime) {
+        start = pointer;
+        pointer = pointer.next;
+        continue;
+      }
       const numericToggleTime = TimingWorker.parseToggleTime(toggleTime);
       const toggleTimePassed = typeof numericToggleTime !== 'number' || adjustedTime > numericToggleTime;
 
@@ -487,7 +492,7 @@ class TimingWorker {
     
     // Find the correct schedule item based on authoritative time
     const correctItem = this.getStartScheduleItemByToggleTime(schedule, authoritativeTime);
-    
+
     // If we're on the wrong item, correct it on next timer tick
     if (correctItem && correctItem !== this.currentScheduleItem) {
       this.nextScheduleItem = correctItem;

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -330,17 +330,18 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended
-        const shouldTreatAsActive = this.testingManager.shouldAvoidStreamEnd() ? false : isActive;
+        const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+        const shouldTreatAsActive = avoidingStreamEnd ? false : isActive;
         if (shouldTreatAsActive) {
           return false; // Wait for session to end
         }
-        liveStreamEnd = true;
+        if (!avoidingStreamEnd && !isActive) {
+          liveStreamEnd = true;
+        }
       }
     }
 
     if (scheduleItem.mobileRider) {
-      // Check if toggleTime has passed before checking mobileRider status
       const timePassed = await this.hasToggleTimePassed(scheduleItem);
       if (!timePassed) return false;
 
@@ -348,10 +349,7 @@ class TimingWorker {
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        // If avoidStreamEndFlag is set, treat all streams as ended (skip forward)
-        const shouldTreatAsEnded = this.testingManager.shouldAvoidStreamEnd() ? true : !isActive;
-        if (shouldTreatAsEnded) {
-          this.nextScheduleItem = scheduleItem.next;
+        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
           return true;
         }
       }

--- a/test/unit/blocks/mobile-rider/mobile-rider.test.js
+++ b/test/unit/blocks/mobile-rider/mobile-rider.test.js
@@ -206,6 +206,18 @@ describe('Mobile Rider Module', () => {
         await new Promise((resolve) => { setTimeout(resolve, 50); });
         expect(player.on.called).to.be.false;
       });
+
+      it('should not attach end listener when avoidStreamEndFlag=true', async () => {
+        window.history.replaceState({}, '', '?avoidStreamEndFlag=true');
+        riderInstance.mainID = 'main-video';
+        riderInstance.store = { get: sinon.stub().returns(true) };
+        riderInstance.injectPlayer('test-video', 'test-skin');
+        const player = { off: sinon.stub(), on: sinon.stub() };
+        globalThis.__mr_player = player;
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+        expect(player.on.calledWith('streamend')).to.be.false;
+        window.history.replaceState({}, '', window.location.pathname);
+      });
     });
 
     describe('setStatus', () => {

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -103,6 +103,25 @@ describe('TimingWorker', () => {
       // so nothing qualifies
       expect(result).to.be.null;
     });
+
+    it('should skip items with no toggleTime and return the last item with a passed toggleTime', () => {
+      const now = Date.now();
+      const item2 = { toggleTime: now + 1000, next: null };
+      const item1 = { toggleTime: now - 1000, next: item2 };
+      const item0 = { next: item1 }; // no toggleTime — represents pre-event state
+
+      const result = worker.getStartScheduleItemByToggleTime(item0, now);
+      expect(result).to.equal(item1);
+    });
+
+    it('should return the no-toggleTime item when no subsequent toggleTime has passed', () => {
+      const now = Date.now();
+      const item1 = { toggleTime: now + 1000, next: null };
+      const item0 = { next: item1 }; // no toggleTime
+
+      const result = worker.getStartScheduleItemByToggleTime(item0, now);
+      expect(result).to.equal(item0);
+    });
   });
 
   describe('shouldTriggerNextSchedule', () => {

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -1084,4 +1084,142 @@ describe('TimingWorker', () => {
       perfStub.restore();
     });
   });
+
+  describe('getStartScheduleItemByToggleTime — null-toggleTime ordering', () => {
+    it('should not let a null-toggleTime item override the last activated timed item when a future timed item stops traversal', () => {
+      const now = Date.now();
+      // [null_pre → T1_past → null_trans → T2_future]
+      // With adjustedTime between T1 and T2, result must be T1_past, not null_trans.
+      const t2Future = { toggleTime: now + 3600000, pathToFragment: '/second-xf', next: null };
+      const nullTrans = { pathToFragment: '/transition', next: t2Future };
+      const t1Past = { toggleTime: now - 3600000, pathToFragment: '/first-xf', next: nullTrans };
+      const nullPre = { pathToFragment: '/pre-event', next: t1Past };
+
+      const result = worker.getStartScheduleItemByToggleTime(nullPre, now);
+      expect(result).to.equal(t1Past);
+    });
+
+    it('should return a post-event null-toggleTime item when it is the last item and all timed items have passed', () => {
+      const now = Date.now();
+      // [null_pre → T1_past → T2_past → null_post] — natural end of list, null_post is correct
+      const nullPost = { pathToFragment: '/post-event', next: null };
+      const t2Past = { toggleTime: now - 1000, pathToFragment: '/second-xf', next: nullPost };
+      const t1Past = { toggleTime: now - 7200000, pathToFragment: '/first-xf', next: t2Past };
+      const nullPre = { pathToFragment: '/pre-event', next: t1Past };
+
+      const result = worker.getStartScheduleItemByToggleTime(nullPre, now);
+      expect(result).to.equal(nullPost);
+    });
+
+    it('should return the pre-event null item when no timed item has activated yet and a null-trans follows', () => {
+      const now = Date.now();
+      // [null_pre → T1_future → null_trans → T2_future]
+      // Nothing has activated — should return null_pre (the only item before the future break)
+      const t2Future = { toggleTime: now + 7200000, pathToFragment: '/second-xf', next: null };
+      const nullTrans = { pathToFragment: '/transition', next: t2Future };
+      const t1Future = { toggleTime: now + 3600000, pathToFragment: '/first-xf', next: nullTrans };
+      const nullPre = { pathToFragment: '/pre-event', next: t1Future };
+
+      const result = worker.getStartScheduleItemByToggleTime(nullPre, now);
+      expect(result).to.equal(nullPre);
+    });
+  });
+
+  describe('validateSchedulePosition — semantic comparison', () => {
+    it('should not reset nextScheduleItem when correctItem has the same path as currentScheduleItem', async () => {
+      const now = Date.now();
+      const item2 = { toggleTime: now + 3600000, pathToFragment: '/second-xf', next: null };
+      const item1 = { toggleTime: now - 3600000, pathToFragment: '/first-xf', next: item2 };
+      const item0 = { pathToFragment: '/pre-event', next: item1 };
+
+      // Simulate: timer already advanced past item1, nextScheduleItem is item2
+      worker.currentScheduleItem = { ...item1 }; // spread copy (as runTimer sets it)
+      worker.nextScheduleItem = item2;
+
+      await worker.validateSchedulePosition(item0);
+
+      // correctItem = item1 (same path as currentScheduleItem) → should NOT reset
+      expect(worker.nextScheduleItem).to.equal(item2);
+    });
+
+    it('should reset nextScheduleItem when correctItem has a different path than currentScheduleItem', async () => {
+      const now = Date.now();
+      const item2 = { toggleTime: now + 3600000, pathToFragment: '/second-xf', next: null };
+      const item1 = { toggleTime: now - 3600000, pathToFragment: '/first-xf', next: item2 };
+
+      // Simulate: timer is incorrectly on item2 but correctItem is item1
+      worker.currentScheduleItem = { ...item2 }; // wrong position
+      worker.nextScheduleItem = item2.next; // null
+
+      await worker.validateSchedulePosition(item1);
+
+      // correctItem = item1, which differs from currentScheduleItem (/second-xf) → reset
+      expect(worker.nextScheduleItem).to.equal(item1);
+    });
+  });
+
+  describe('avoidStreamEndFlag with interleaved null-toggleTime items', () => {
+    it('should show the first timed XF, not an interleaved null item, when avoidStreamEndFlag and serverTime position inside first XF period', async () => {
+      const clock = sinon.useFakeTimers();
+      const perfStub = sinon.stub(performance, 'now').returns(1000);
+
+      // serverTime is 1 hour after T1, 1 hour before T2
+      const t1 = Date.now() - 3600000;
+      const t2 = Date.now() + 3600000;
+      const serverTime = Date.now(); // exactly between T1 and T2
+
+      // Schedule: [null_pre → T1_MR → null_trans → T2_MR]
+      const t2Item = {
+        toggleTime: t2,
+        pathToFragment: '/second-xf',
+        mobileRider: { sessionId: 'session2' },
+        next: null,
+        prev: null,
+      };
+      const nullTrans = {
+        pathToFragment: '/transition',
+        next: t2Item,
+        prev: null,
+      };
+      const t1Item = {
+        toggleTime: t1,
+        pathToFragment: '/first-xf',
+        mobileRider: { sessionId: 'session1' },
+        next: nullTrans,
+        prev: null,
+      };
+      const nullPre = {
+        pathToFragment: '/pre-event',
+        next: t1Item,
+        prev: null,
+      };
+      nullPre.next = t1Item; t1Item.prev = nullPre;
+      t1Item.next = nullTrans; nullTrans.prev = t1Item;
+      nullTrans.next = t2Item; t2Item.prev = nullTrans;
+
+      worker.testingManager.init({ serverTime: String(serverTime), avoidStreamEndFlag: 'true' });
+      worker.plugins.set('mobileRider', {
+        get: (id) => (id === 'session1' ? false : false),
+        set: () => {},
+        getAll: () => ({}),
+      });
+
+      const startItem = worker.getStartScheduleItemByToggleTime(nullPre, Date.now());
+      expect(startItem).to.equal(t1Item, 'getStartScheduleItemByToggleTime must return first timed XF, not the transition null item');
+
+      // Also verify shouldTriggerNextSchedule correctly allows t1Item to trigger
+      worker.currentScheduleItem = { ...nullPre };
+      worker.nextScheduleItem = t1Item;
+      const shouldTrigger = await worker.shouldTriggerNextSchedule(t1Item);
+      expect(shouldTrigger).to.be.true;
+
+      // And that t2Item is correctly blocked because its time has not passed
+      worker.currentScheduleItem = { ...t1Item };
+      const shouldTriggerT2 = await worker.shouldTriggerNextSchedule(t2Item);
+      expect(shouldTriggerT2).to.be.false;
+
+      clock.restore();
+      perfStub.restore();
+    });
+  });
 });

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -224,6 +224,63 @@ describe('TimingWorker', () => {
       const result = await worker.shouldTriggerNextSchedule(nextItem);
       expect(result).to.be.true;
     });
+
+    it('should not trigger future MR slot when avoidStreamEndFlag is set', async () => {
+      const now = Date.now();
+      const nextItem = {
+        toggleTime: now + 600000,
+        pathToFragment: '/future-session',
+        mobileRider: { sessionId: 'session2' },
+      };
+
+      worker.testingManager.init({ avoidStreamEndFlag: true });
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current-session',
+      };
+      worker.plugins.set('mobileRider', new Map([
+        ['session1', true],
+        ['session2', true],
+      ]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.false;
+    });
+
+    it('should trigger next item when prior MR stream ended naturally and toggleTime is in future', async () => {
+      const nextItem = {
+        toggleTime: Date.now() + 600000,
+        pathToFragment: '/next',
+      };
+
+      worker.testingManager.init(null);
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current-session',
+      };
+      worker.plugins.set('mobileRider', new Map([['session1', false]]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.true;
+    });
+
+    it('should not set liveStreamEnd when avoidStreamEndFlag is set on current MR item', async () => {
+      const now = Date.now();
+      const nextItem = {
+        toggleTime: now + 600000,
+        pathToFragment: '/future',
+      };
+
+      worker.testingManager.init({ avoidStreamEndFlag: true });
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current',
+      };
+      worker.plugins.set('mobileRider', new Map([['session1', true]]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.false;
+    });
   });
 
   describe('handleMessage', () => {

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -225,6 +225,27 @@ describe('TimingWorker', () => {
       expect(result).to.be.true;
     });
 
+    it('should not underrun future MR slot before toggleTime even when next stream ended', async () => {
+      const nextItem = {
+        toggleTime: Date.now() + 600000,
+        pathToFragment: '/future-session',
+        mobileRider: { sessionId: 'session2' },
+      };
+
+      worker.testingManager.init(null);
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/current-session',
+      };
+      worker.plugins.set('mobileRider', new Map([
+        ['session1', true],
+        ['session2', false],
+      ]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.false;
+    });
+
     it('should not trigger future MR slot when avoidStreamEndFlag is set', async () => {
       const now = Date.now();
       const nextItem = {


### PR DESCRIPTION
## Summary

- **avoidStreamEndFlag:** Stops treating the flag as natural stream-end; only disables MR blocking while `toggleTime` still selects the current fragment (fixes skip-to-last-slot bug).
- **worker-traditional.js (chrono-box production path):** Aligned with `worker.js` for schedule behavior and performance:
  - Fast sync init via `getFastInitialTime` + background `validateSchedulePosition` (no blocking Akamai call before first render)
  - Monotonic time cache, drift detection, and validated cross-tab time sync
  - MR underrun requires `toggleTime` before early advance (matches module worker)
  - Shared `hasToggleTimePassed` / `parseToggleTime` helpers

## Test plan

- [x] `npx wtr test/unit/features/timing-framework/worker.test.js` (46 passed)
- [x] ESLint on changed JS files
- [ ] Manual: `?avoidStreamEndFlag=true` on multi-slot MR schedule shows current-period fragment
- [ ] Manual: `?serverTime=<ms>&avoidStreamEndFlag=true` at known window
- [ ] Manual: without flag, active MR still holds slot past `toggleTime`

## Notes

`worker.test.js` targets the module worker as the reference implementation; `worker-traditional.js` is kept logically in sync (see README usage guidelines).


Made with [Cursor](https://cursor.com)