### PR TITLE
[MWPW-197632 ] fix(event-agenda): prevent title text overlapping toggle button

### DIFF
--- a/event-libs/v1/blocks/event-agenda/event-agenda.css
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.css
@@ -70,6 +70,7 @@
 
 .event-agenda.collapsible .agenda-item-container .agenda-list-item .agenda-title-detail-container {
   border-inline-start: none;
+  padding-inline-end: 52px; /* .agenda-toggle width (28px) + right (16px) + gap (8px) */
 }
 
 .event-agenda .agenda-item-container .agenda-list-item  .agenda-title-detail {
@@ -257,6 +258,12 @@
   .event-agenda.collapsible.background .agenda-item-container .agenda-list-item.expanded .agenda-time {
     background: linear-gradient(180deg, #FAFAFA 22.33%, rgb(255 255 255 / 0%) 99.96%);
   }
+
+  /* 52px = .agenda-toggle width (28px) + right (16px) + gap (8px) */
+  .event-agenda.collapsible.background .agenda-item-container .agenda-list-item .agenda-title-detail-container {
+    padding-inline-end: 52px;
+  }
+
 }
 
 @media (min-width: 1440px) {


### PR DESCRIPTION
## What
JIRA: https://jira.corp.adobe.com/browse/MWPW-197632
Adds `padding-inline-end: 52px` to the `.agenda-title-detail-container` in the collapsible variant so the title text cannot run underneath the absolutely-positioned `agenda-toggle` button. A combined `.collapsible.background` selector (higher specificity, later in source) is required because the background variant's shorthand `padding: 20px 16px` resets the inline-end padding set by the collapsible-only rule.

The 52px is derived from: `.agenda-toggle` width (28px) + its `right` offset (16px) + an 8px gap.

## Why
[MWPW-197632](https://jira.corp.adobe.com/browse/MWPW-197632) — agenda session titles were visually overlapping the expand/collapse toggle icon in the collapsible + background variant of the event-agenda block.

## Test plan
- `npm run lint` — passes clean
- `npm test` — 556 tests passed, 0 failed
- Visually confirm on a collapsible agenda page that long session titles wrap before reaching the toggle button

Test page: https://main--da-bacom--adobecom.aem.page/.snapshots/esp-stage/da-dx-in-person/discover-new-insights-and-whats-next-for-marketing-and-ai/san-jose/ca/us/2026-06-08?timing=1780948799990&espenv=stage&eventlibs=mwpw-197632