### PR TITLE
[MWPW-196040] : [Speaker hub] Support all speakers in profile cards

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -486,10 +486,9 @@ function decorateCards(el, data, { simple, modal } = {}) {
   const rows = el.querySelectorAll(':scope > div');
   const configRow = rows[1];
   const speakerType = configRow?.querySelectorAll(':scope > div')?.[1]?.textContent.toLowerCase().trim();
-  const showAll = !speakerType || speakerType === 'all';
-  const filteredData = showAll
-    ? [...data]
-    : data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType);
+  const filteredData = speakerType
+    ? data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType)
+    : [...data];
 
   if (filteredData.length === 0) {
     el.remove();

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -486,7 +486,10 @@ function decorateCards(el, data, { simple, modal } = {}) {
   const rows = el.querySelectorAll(':scope > div');
   const configRow = rows[1];
   const speakerType = configRow?.querySelectorAll(':scope > div')?.[1]?.textContent.toLowerCase().trim();
-  const filteredData = data.filter((speaker) => speaker.speakerType.toLowerCase() === speakerType);
+  const showAll = !speakerType || speakerType === 'all';
+  const filteredData = showAll
+    ? [...data]
+    : data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType);
 
   if (filteredData.length === 0) {
     el.remove();

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -155,35 +155,21 @@ describe('Profile Cards Module', () => {
       expect(cards).to.have.lengthOf(9);
     });
 
-    it('renders all speakers when type cell is "all"', () => {
+    it('filters by type when type cell has a value', () => {
       const container = document.createElement('div');
       container.innerHTML = `
-        <div id="all-keyword-cards" class="profile-cards">
-          <div><div><h2>Everyone</h2></div></div>
-          <div><div>type</div><div>all</div></div>
+        <div id="filtered-cards" class="profile-cards">
+          <div><div><h2>Speakers only</h2></div></div>
+          <div><div>type</div><div>speaker</div></div>
         </div>
       `;
       document.body.appendChild(container);
-      const el = container.querySelector('#all-keyword-cards');
+      const el = container.querySelector('#filtered-cards');
       init(el);
 
       const cards = el.querySelectorAll('.card-container');
-      expect(cards).to.have.lengthOf(9);
-    });
-
-    it('treats "ALL" case-insensitively', () => {
-      const container = document.createElement('div');
-      container.innerHTML = `
-        <div id="all-upper-cards" class="profile-cards">
-          <div><div><h2>Everyone</h2></div></div>
-          <div><div>type</div><div>ALL</div></div>
-        </div>
-      `;
-      document.body.appendChild(container);
-      const el = container.querySelector('#all-upper-cards');
-      init(el);
-
-      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(9);
+      expect(cards.length).to.be.greaterThan(0);
+      expect(cards.length).to.be.lessThan(9);
     });
 
     it('does not throw when a speaker entry has no speakerType and type cell is empty', () => {

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import init, { createSocialIcon, buildModalContent } from '../../../../event-libs/v1/blocks/profile-cards/profile-cards.js';
+import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
 
 /** Mirrors Milo modal.js FOCUSABLES selector for initial-focus assertions */
 const MODAL_FOCUSABLES_SELECTOR = 'a:not(.hide-video, .faas), button:not([disabled], .locale-modal-v2 .paddle), input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
@@ -135,6 +136,74 @@ describe('Profile Cards Module', () => {
       expect(firstCard.getAttribute('aria-haspopup')).to.equal('dialog');
       expect(firstCard.getAttribute('aria-label')).to.include('Open profile modal for');
       expect(keydownEvent.defaultPrevented).to.be.true;
+    });
+
+    it('renders all speakers when type cell is empty', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div id="all-cards" class="profile-cards">
+          <div><div><h2>Everyone</h2></div></div>
+          <div><div>type</div><div></div></div>
+        </div>
+      `;
+      document.body.appendChild(container);
+      const el = container.querySelector('#all-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      // head mock contains 9 speakers across speaker/judge/host types
+      expect(cards).to.have.lengthOf(9);
+    });
+
+    it('renders all speakers when type cell is "all"', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div id="all-keyword-cards" class="profile-cards">
+          <div><div><h2>Everyone</h2></div></div>
+          <div><div>type</div><div>all</div></div>
+        </div>
+      `;
+      document.body.appendChild(container);
+      const el = container.querySelector('#all-keyword-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      expect(cards).to.have.lengthOf(9);
+    });
+
+    it('treats "ALL" case-insensitively', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div id="all-upper-cards" class="profile-cards">
+          <div><div><h2>Everyone</h2></div></div>
+          <div><div>type</div><div>ALL</div></div>
+        </div>
+      `;
+      document.body.appendChild(container);
+      const el = container.querySelector('#all-upper-cards');
+      init(el);
+
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(9);
+    });
+
+    it('does not throw when a speaker entry has no speakerType and type cell is empty', () => {
+      setMetadata('speakers', JSON.stringify([
+        { firstName: 'A', lastName: 'One', title: 't', bio: '', socialLinks: [] },
+        { firstName: 'B', lastName: 'Two', title: 't', bio: '', socialLinks: [], speakerType: 'Speaker' },
+      ]));
+
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div id="loose-cards" class="profile-cards">
+          <div><div><h2>Anyone</h2></div></div>
+          <div><div>type</div><div></div></div>
+        </div>
+      `;
+      document.body.appendChild(container);
+      const el = container.querySelector('#loose-cards');
+
+      expect(() => init(el)).to.not.throw();
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(2);
     });
 
     it('should make static-authored modal cards interactive', () => {


### PR DESCRIPTION
Resolves: [MWPW-196040](https://jira.corp.adobe.com/browse/MWPW-196040)

### Profile Cards — support all-speakers view and fix type filtering

**What changed**

Previously decorateCards always filtered by speakerType, which meant a block with no type value would produce zero
results and silently remove itself from the page. Now:

  - If the type cell is empty → show all speakers (no filter applied)
  - If the type cell has a value → filter to that speaker type (existing behaviour, unchanged)

  This aligns with standard UX filtering convention: no selection = no restriction.

  Also adds a ?. optional chain on speaker.speakerType so speakers missing the field don't throw when a type filter is
  active.

**Test coverage added**

  - Empty type cell renders all speakers across all types
  - Non-empty type cell filters to the matching subset
  - Speaker entries without a speakerType field don't throw when filtering

**How to test**

  Author a profile-cards metadata-driven block with the type row present but the value cell left blank — all speakers
  should render. Author one with type: speaker — only speakers should render.

**Test URLs:**
- Before: https://main--da-events--adobecom.aem.page/drafts/sharmeeb/speaker-hub
- After: https://main--da-events--adobecom.aem.page/drafts/sharmeeb/speaker-hub?eventlibs=speaker-hub
