### PR TITLE
[MWPW-196656] fix(sessions-hub): disable Register button when session time is full

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -367,6 +367,8 @@ function applyFilter(sessionAreaEl, state) {
 
 function renderCTAGroup(session, { isEventRegistered = false, isBlocked = false } = {}) {
   const group = createTag('div', { class: 'sh-cta-group' });
+  const primaryTime = session.sessionTimes?.[0];
+  const isSessionFull = !session.isRegistered && !session.isWaitlisted && Boolean(primaryTime?.isFull);
 
   // State 1: registered or waitlisted for THIS session — badge with hover-to-unregister
   if (isEventRegistered && (session.isRegistered || session.isWaitlisted)) {
@@ -420,12 +422,16 @@ function renderCTAGroup(session, { isEventRegistered = false, isBlocked = false 
 
   // State 2: able to register — direct-API button (no modal)
   if (isEventRegistered) {
-    group.append(createTag('button', { class: 'sh-btn sh-btn-register-session', type: 'button' }, dictionaryManager.getValue('Register for session')));
+    const attrs = { class: 'sh-btn sh-btn-register-session', type: 'button' };
+    if (isSessionFull) { attrs.disabled = ''; attrs['aria-disabled'] = 'true'; }
+    group.append(createTag('button', attrs, dictionaryManager.getValue('Register for session')));
     return group;
   }
 
   // Default: not yet event-registered, not blocked — opens RSVP modal
-  group.append(createTag('button', { class: 'sh-btn sh-btn-register-event', type: 'button' }, dictionaryManager.getValue('Register for session')));
+  const attrs = { class: 'sh-btn sh-btn-register-event', type: 'button' };
+  if (isSessionFull) { attrs.disabled = ''; attrs['aria-disabled'] = 'true'; }
+  group.append(createTag('button', attrs, dictionaryManager.getValue('Register for session')));
   return group;
 }
 

--- a/test/unit/blocks/sessions-hub/sessions-hub.test.js
+++ b/test/unit/blocks/sessions-hub/sessions-hub.test.js
@@ -39,6 +39,13 @@ function makeEventData(overrides = {}) {
   };
 }
 
+function setSessionsMeta(sessions) {
+  const meta = document.createElement('meta');
+  meta.name = 'sessions';
+  meta.content = JSON.stringify(sessions);
+  document.head.appendChild(meta);
+}
+
 const mockTagsData = {
   namespaces: {},
 };
@@ -73,13 +80,6 @@ describe('sessions-hub invite-only RSVP gate', () => {
         ':type': 'multi-sheet',
       })],
     ]);
-  }
-
-  function setSessionsMeta(sessions) {
-    const meta = document.createElement('meta');
-    meta.name = 'sessions';
-    meta.content = JSON.stringify(sessions);
-    document.head.appendChild(meta);
   }
 
   beforeEach(() => {
@@ -153,5 +153,138 @@ describe('sessions-hub invite-only RSVP gate', () => {
 
     const rsvpPushes = pushStateSpy.getCalls().filter((c) => String(c.args[2] || '').includes('rsvp-form'));
     expect(rsvpPushes.length).to.equal(0);
+  });
+});
+
+const SESSION_NOT_FULL = makeSession({ sessionId: 'session-not-full' });
+const SESSION_FULL = makeSession({ sessionId: 'session-full', sessionTimes: [{ sessionTimeId: 'time-full', isFull: true }] });
+
+describe('sessions-hub full session', () => {
+  let originalFetch;
+
+  function stubFetch(handlers) {
+    window.fetch = async (url) => {
+      const u = typeof url === 'string' ? url : url.url || '';
+      for (const [pattern, handler] of handlers) {
+        if (u.includes(pattern)) {
+          return { ok: true, status: 200, json: async () => handler(u) };
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+  }
+
+  function stubDefaultFetch(eventOverrides = {}) {
+    stubFetch([
+      ['/v1/events/', () => makeEventData(eventOverrides)],
+      ['/v1/series/', () => ({ speakers: [] })],
+      ['/v1/venues/', () => ({ name: 'Main Hall', locationId: 'loc-1' })],
+      ['/v1/attendees/me/events/', () => ({ sessionIds: [] })],
+      ['chimera-api/tags', () => ({ namespaces: {} })],
+      ['dictionary.json', () => ({
+        data: { total: 0, offset: 0, limit: 0, data: [] },
+        ':names': ['data'],
+        ':version': 3,
+        ':type': 'multi-sheet',
+      })],
+    ]);
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = body;
+    document.head.innerHTML = '<meta name="event-id" content="event-123">';
+    originalFetch = window.fetch;
+    DictionaryManager._clearCache();
+    dictionaryManager.resetLoadedSheetsForTests();
+    BlockMediator.set('imsProfile', { userId: 'test-user', account_type: 'type1' });
+    BlockMediator.set('rsvpData', null);
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    BlockMediator.set('imsProfile', undefined);
+    BlockMediator.set('rsvpData', undefined);
+  });
+
+  it('disables Register button for a full session when user is not event-registered', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([SESSION_FULL]);
+
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+
+    const card = el.querySelector(`[data-session-id="${SESSION_FULL.sessionId}"]`);
+    const registerBtn = card.querySelector('.sh-btn-register-event');
+    expect(registerBtn).to.not.be.null;
+    expect(registerBtn.disabled).to.be.true;
+    expect(registerBtn.getAttribute('aria-disabled')).to.equal('true');
+  });
+
+  it('disables Register for session button for a full session when user is event-registered', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([SESSION_FULL]);
+    BlockMediator.set('rsvpData', { registrationStatus: 'registered' });
+
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+
+    const card = el.querySelector(`[data-session-id="${SESSION_FULL.sessionId}"]`);
+    const registerBtn = card.querySelector('.sh-btn-register-session');
+    expect(registerBtn).to.not.be.null;
+    expect(registerBtn.disabled).to.be.true;
+    expect(registerBtn.getAttribute('aria-disabled')).to.equal('true');
+  });
+
+  it('keeps Register button enabled for a session that is not full', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([SESSION_NOT_FULL]);
+
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+
+    const card = el.querySelector(`[data-session-id="${SESSION_NOT_FULL.sessionId}"]`);
+    const registerBtn = card.querySelector('.sh-btn-register-event');
+    expect(registerBtn).to.not.be.null;
+    expect(registerBtn.disabled).to.be.false;
+  });
+
+  it('shows Registered badge (not a disabled register button) when user is already registered for a full session', async () => {
+    stubFetch([
+      ['/v1/events/', () => makeEventData()],
+      ['/v1/series/', () => ({ speakers: [] })],
+      ['/v1/venues/', () => ({ name: 'Main Hall', locationId: 'loc-1' })],
+      ['/v1/attendees/me/events/', () => ({ sessionIds: [SESSION_FULL.sessionId] })],
+      ['chimera-api/tags', () => ({ namespaces: {} })],
+      ['dictionary.json', () => ({
+        data: { total: 0, offset: 0, limit: 0, data: [] },
+        ':names': ['data'],
+        ':version': 3,
+        ':type': 'multi-sheet',
+      })],
+    ]);
+    setSessionsMeta([SESSION_FULL]);
+    BlockMediator.set('rsvpData', { registrationStatus: 'registered' });
+
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+
+    const card = el.querySelector(`[data-session-id="${SESSION_FULL.sessionId}"]`);
+    expect(card.querySelector('.sh-btn-register-session')).to.be.null;
+    expect(card.querySelector('.sh-btn-register-event')).to.be.null;
+    expect(card.querySelector('.sh-registered-badge')).to.not.be.null;
+  });
+
+  it('correctly handles a mix of full and non-full sessions on the same page', async () => {
+    stubDefaultFetch();
+    setSessionsMeta([SESSION_NOT_FULL, SESSION_FULL]);
+
+    const el = document.querySelector('.sessions-hub');
+    await init(el);
+
+    const notFullCard = el.querySelector(`[data-session-id="${SESSION_NOT_FULL.sessionId}"]`);
+    const fullCard = el.querySelector(`[data-session-id="${SESSION_FULL.sessionId}"]`);
+
+    expect(notFullCard.querySelector('.sh-btn-register-event').disabled).to.be.false;
+    expect(fullCard.querySelector('.sh-btn-register-event').disabled).to.be.true;
   });
 });


### PR DESCRIPTION
JIRA: [MWPW-196656](https://jira.corp.adobe.com/browse/MWPW-196656)

### Changes
When sessionTimes[0].isFull is true and the user is not already registered or waitlisted for that session, the Register button is rendered disabled so users cannot attempt registration that would fail silently.

Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-196656](https://jira.corp.adobe.com/browse/MWPW-196656)

Test URLs:
- Before: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/test-dx-in-person-0529/san-jose/ca/us/2026-07-01/session-hub?timing=1782889199990&espenv=stage&eventlibs=stage
- After: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/test-dx-in-person-0529/san-jose/ca/us/2026-07-01/session-hub?timing=1782889199990&espenv=stage&eventlibs=MWPW-196656
