### PR TITLE
[MWPW-196040] feat(profile-cards): support explicit field-based sort

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -481,11 +481,8 @@ function decorateStaticCards(el, { modal } = {}) {
   }
 }
 
-function decorateCards(el, data, { simple, modal } = {}) {
+function decorateCards(el, data, { simple, modal, speakerType } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
-  const rows = el.querySelectorAll(':scope > div');
-  const configRow = rows[1];
-  const speakerType = configRow?.querySelectorAll(':scope > div')?.[1]?.textContent.toLowerCase().trim();
   const filteredData = speakerType
     ? data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType)
     : [...data];
@@ -494,8 +491,6 @@ function decorateCards(el, data, { simple, modal } = {}) {
     el.remove();
     return;
   }
-
-  configRow.remove();
 
   filteredData.forEach((speaker, index) => {
     const cardContainer = createTag('div', { class: 'card-container' });
@@ -536,15 +531,35 @@ function sortDataByOrdinals(data) {
   });
 }
 
+function sortDataByField(data, field, direction) {
+  return [...data].sort((a, b) => {
+    const aVal = (a[field] ?? '').toString().toLowerCase();
+    const bVal = (b[field] ?? '').toString().toLowerCase();
+    const cmp = aVal.localeCompare(bVal);
+    return direction === 'desc' ? -cmp : cmp;
+  });
+}
+
+
+function parseConfigRows(el) {
+  const config = {};
+  const configRowEls = [];
+  const rows = Array.from(el.querySelectorAll(':scope > div'));
+
+  rows.slice(1).forEach((row) => {
+    const cells = row.querySelectorAll(':scope > div');
+    const key = cells[0]?.textContent.toLowerCase().trim();
+    const value = cells[1]?.textContent.trim();
+    if (key) {
+      config[key] = value || '';
+      configRowEls.push(row);
+    }
+  });
+
+  return { config, configRowEls };
+}
 
 export default function init(el) {
-  const rows = el.querySelectorAll(':scope > div');
-  const configRow = rows[1];
-  
-  // Determine if this is metadata-driven or static authoring
-  // Check if the first cell of configRow (if it exists) contains 'type'
-  const firstCell = configRow?.querySelectorAll(':scope > div')?.[0];
-  const isMetadataDriven = firstCell?.textContent.toLowerCase().trim() === 'type';
   const isModal = el.classList.contains('modal');
 
   // Handle grid variant: add default three-up if no *-up class is present
@@ -558,8 +573,10 @@ export default function init(el) {
   const cardsWrapper = createTag('div', { class: 'cards-wrapper' });
   el.append(cardsWrapper);
 
+  const { config, configRowEls } = parseConfigRows(el);
+  const isMetadataDriven = 'type' in config;
+
   if (isMetadataDriven) {
-    // Metadata-driven mode
     let data = [];
 
     try {
@@ -575,9 +592,20 @@ export default function init(el) {
       return;
     }
 
+    configRowEls.forEach((row) => row.remove());
+
     const isSimple = el.classList.contains('simple');
-    const sortedData = sortDataByOrdinals(data);
-    decorateCards(el, sortedData, { simple: isSimple, modal: isModal });
+    const speakerType = config.type?.toLowerCase() || '';
+
+    let sortedData;
+    if ('order' in config) {
+      const direction = el.classList.contains('desc') ? 'desc' : 'asc';
+      sortedData = config.order ? sortDataByField(data, config.order, direction) : sortDataByOrdinals(data);
+    } else {
+      sortedData = sortDataByOrdinals(data);
+    }
+
+    decorateCards(el, sortedData, { simple: isSimple, modal: isModal, speakerType });
   } else {
     decorateStaticCards(el, { modal: isModal });
   }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -574,6 +574,8 @@ export default function init(el) {
   el.append(cardsWrapper);
 
   const { config, configRowEls } = parseConfigRows(el);
+  // Determine if this is metadata-driven or static authoring
+  // Check if the configRows (if it exists) contains 'type'
   const isMetadataDriven = 'type' in config;
 
   if (isMetadataDriven) {

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -535,7 +535,7 @@ function sortDataByField(data, field, direction) {
   return [...data].sort((a, b) => {
     const aVal = (a[field] ?? '').toString().toLowerCase();
     const bVal = (b[field] ?? '').toString().toLowerCase();
-    const cmp = aVal.localeCompare(bVal);
+    const cmp = aVal.localeCompare(bVal, undefined, { sensitivity: 'base' });
     return direction === 'desc' ? -cmp : cmp;
   });
 }

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -207,6 +207,100 @@ describe('Profile Cards Module', () => {
     });
   });
 
+  describe('sorting', () => {
+    const speakers = [
+      { firstName: 'Charlie', lastName: 'Zebra', speakerType: 'Speaker', ordinal: 2 },
+      { firstName: 'Alice', lastName: 'Mango', speakerType: 'Speaker', ordinal: 0 },
+      { firstName: 'Bob', lastName: 'Apple', speakerType: 'Speaker', ordinal: 1 },
+    ];
+
+    function makeBlock(classes, configRows) {
+      const el = document.createElement('div');
+      el.className = `profile-cards ${classes}`;
+      el.innerHTML = `<div><div><h2>Heading</h2></div></div>${configRows}`;
+      document.body.appendChild(el);
+      return el;
+    }
+
+    function getCardNames(el) {
+      return Array.from(el.querySelectorAll('.card-name')).map((n) => n.textContent.trim());
+    }
+
+    beforeEach(() => {
+      setMetadata('speakers', JSON.stringify(speakers));
+    });
+
+    it('falls back to ordinal order when no order row is present', () => {
+      const el = makeBlock('', '<div><div>type</div><div>speaker</div></div>');
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Alice Mango', 'Bob Apple', 'Charlie Zebra']);
+    });
+
+    it('sorts by lastName ascending when order row is present and class is asc', () => {
+      const el = makeBlock('asc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>lastName</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Bob Apple', 'Alice Mango', 'Charlie Zebra']);
+    });
+
+    it('sorts by lastName descending when class is desc', () => {
+      const el = makeBlock('desc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>lastName</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Charlie Zebra', 'Alice Mango', 'Bob Apple']);
+    });
+
+    it('sorts by firstName ascending', () => {
+      const el = makeBlock('asc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>firstName</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Alice Mango', 'Bob Apple', 'Charlie Zebra']);
+    });
+
+    it('applies explicit sort when order row comes before type row', () => {
+      const el = makeBlock('asc', `
+        <div><div>order</div><div>lastName</div></div>
+        <div><div>type</div><div>speaker</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Bob Apple', 'Alice Mango', 'Charlie Zebra']);
+    });
+
+    it('falls back to ordinal order when order row has no field value', () => {
+      const el = makeBlock('asc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div></div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Alice Mango', 'Bob Apple', 'Charlie Zebra']);
+    });
+
+    it('treats missing asc/desc class as ascending', () => {
+      const el = makeBlock('', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>lastName</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.deep.equal(['Bob Apple', 'Alice Mango', 'Charlie Zebra']);
+    });
+
+    it('removes the order config row from the DOM', () => {
+      const el = makeBlock('asc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>lastName</div></div>
+      `);
+      init(el);
+      const configRows = Array.from(el.querySelectorAll(':scope > div:not(.cards-wrapper)')).slice(1);
+      expect(configRows).to.have.lengthOf(0);
+    });
+  });
+
   describe('createSocialIcon', () => {
     it('should return a social icon element', () => {
       const icon = createSocialIcon(document.createElement('svg'), 'facebook');

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -290,6 +290,22 @@ describe('Profile Cards Module', () => {
       expect(getCardNames(el)).to.deep.equal(['Bob Apple', 'Alice Mango', 'Charlie Zebra']);
     });
 
+    it('treats unknown order field as stable sort (all values empty, original order preserved)', () => {
+      const el = makeBlock('asc', `
+        <div><div>type</div><div>speaker</div></div>
+        <div><div>order</div><div>nonExistentField</div></div>
+      `);
+      init(el);
+      expect(getCardNames(el)).to.have.lengthOf(3);
+    });
+
+    it('removes the block when type filter matches zero speakers', () => {
+      const el = makeBlock('', '<div><div>type</div><div>panelist</div></div>');
+      document.body.appendChild(el);
+      init(el);
+      expect(document.body.contains(el)).to.be.false;
+    });
+
     it('removes the order config row from the DOM', () => {
       const el = makeBlock('asc', `
         <div><div>type</div><div>speaker</div></div>


### PR DESCRIPTION
### What changed

  profile-cards now supports an optional order config row that lets authors sort cards by any speaker field. Sort direction
  is controlled by an asc or desc class on the block (defaults to asc when neither is present).

  Example authored table:
  | type  | speaker   |
  | order | lastName  |
  ```<div class="profile-cards grid four-up modal simple asc">```

### Behaviour

| Config | Result |
|---|---|
| No `order` row | Falls back to ordinal sort (existing behaviour, unchanged) |
| `order` row with a field | Sorts by that field, direction from `asc`/`desc` class |
| `order` row with empty field | Falls back to ordinal sort |
| `order` before `type` in the table | Works — config rows are now parsed as a position-independent key/value map |

### Implementation notes

- Replaced positional `rows[1]` / `rows[2]` access with `parseConfigRows()`, which scans all rows after the heading and builds a `{ key: value }` map. This means `type` and `order` can appear in any order in the authored table.
- `speakerType` filtering moved out of `decorateCards` DOM reads and into `init` via the config map — `decorateCards` now receives it as a prop.
- All config rows are removed from the DOM in a single pass before rendering.

### Tests

8 new unit tests covering: asc/desc sorting, sorting by different fields, position-independent config rows, empty `order` field fallback, default-to-asc behaviour, and DOM cleanup of config rows.

Resolves: [MWPW-196040](https://jira.corp.adobe.com/browse/MWPW-196040)

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/drafts/sharmeeb/speaker-hub?martech=off
- After: https://main--da-events--adobecom.aem.page/drafts/sharmeeb/speaker-hub?eventlibs=speaker-hub&martech=off