### PR TITLE
[MWPW-195684] fix(sessions-hub): fix mobile toolbar layout and search 

### DIFF
--- a/event-libs/v1/blocks/mobile-rider/drawer.css
+++ b/event-libs/v1/blocks/mobile-rider/drawer.css
@@ -134,7 +134,7 @@
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
-  display: box;
+  display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
@@ -148,7 +148,7 @@
   font-weight: 100;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: box;
+  display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   width: 100%;

--- a/event-libs/v1/blocks/mobile-rider/drawer.css
+++ b/event-libs/v1/blocks/mobile-rider/drawer.css
@@ -134,7 +134,7 @@
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
-  display: -webkit-box;
+  display: box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
@@ -148,7 +148,7 @@
   font-weight: 100;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: -webkit-box;
+  display: box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   width: 100%;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -158,7 +158,7 @@
   height: 40px;
   border-radius: 50%;
   background: var(--color-white, #fff);
-  border: 2px solid var(--color-gray-200, #e9e9e9);
+  border: none;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -196,9 +196,15 @@
   display: none;
 }
 
-/* Expanded state — the icon button morphs into a pill input */
+/* Search row — hidden until expanded; shown inline in the actions row */
 
-.sessions-hub .sh-search-wrap.expanded {
+.sessions-hub .sh-search-row {
+  display: none;
+  align-items: center;
+}
+
+.sessions-hub .sh-toolbar-actions:has(.sh-search-wrap.expanded) .sh-search-row {
+  display: inline-flex;
   height: 40px;
   padding: 0 4px 0 14px;
   border: 2px solid var(--color-gray-900, #131313);
@@ -207,16 +213,13 @@
   box-sizing: border-box;
 }
 
-.sessions-hub .sh-search-wrap.expanded .sh-search-toggle {
-  width: auto;
-  height: auto;
-  border: none;
-  background: transparent;
-  pointer-events: none;
+.sessions-hub .sh-search-row svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
 }
 
-.sessions-hub .sh-search-wrap.expanded .sh-search {
-  display: block;
+.sessions-hub .sh-search-row .sh-search {
   width: 200px;
   min-width: 0;
   height: 36px;
@@ -229,7 +232,12 @@
   color: var(--color-gray-900, #131313);
 }
 
-.sessions-hub .sh-search-wrap.expanded .sh-search-clear {
+.sessions-hub .sh-search-row .sh-search,
+.sessions-hub .sh-search-row .sh-search-clear {
+  display: block;
+}
+
+.sessions-hub .sh-search-row .sh-search-clear {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -242,8 +250,14 @@
   flex-shrink: 0;
 }
 
-.sessions-hub .sh-search-wrap.expanded .sh-search-clear:hover {
+.sessions-hub .sh-search-row .sh-search-clear:hover {
   background: var(--color-gray-100, #f3f3f3);
+}
+
+@media (min-width: 601px) {
+  .sessions-hub .sh-search-wrap.expanded .sh-search-toggle {
+    display: none;
+  }
 }
 
 /* Filter button + wrapper */
@@ -492,7 +506,7 @@
   display: inline-flex;
 }
 
-.sessions-hub .sh-filter-item:focus-within {
+.sessions-hub .sh-filter-item:has(input:focus-visible) {
   outline: 2px solid var(--color-accent, #1473e6);
   outline-offset: 2px;
 }
@@ -1136,11 +1150,50 @@
   .sessions-hub .sh-filter-btn-label {
     display: none;
   }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-wrap {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn {
+    width: 100%;
+    padding: 0 16px;
+    border-radius: 20px;
+  }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn-label {
+    display: inline;
+  }
 }
 
 
 /* Mobile: bottom-sheet filter modal (full-viewport backdrop + drill-in). */
 @media (max-width: 600px) {
+  .sessions-hub .sh-toolbar-actions {
+    align-self: stretch;
+    flex-wrap: wrap;
+  }
+
+  .sessions-hub .sh-view-dropdown {
+    flex: 1;
+  }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-search-wrap.expanded) .sh-search-row {
+    display: flex;
+    flex: 1 0 100%;
+    order: 99;
+  }
+
+  .sessions-hub .sh-search-row .sh-search {
+    flex: 1;
+    width: auto;
+  }
+
+  .sessions-hub .sh-search-wrap.expanded .sh-search-toggle {
+    background: var(--color-gray-200, #e9e9e9);
+  }
+
   .sessions-hub .sh-filter-backdrop {
     display: block;
     position: absolute;
@@ -1283,10 +1336,7 @@
     display: block;
     position: sticky;
     bottom: 0;
-    margin-top: auto;
-    margin-right: -24px;
-    margin-bottom: -24px;
-    margin-left: -24px;
+    margin: auto -24px -24px;
     padding: 24px;
     background: var(--color-white, #fff);
     border-top: 1px solid var(--color-gray-200, #dadada);
@@ -1320,10 +1370,6 @@
   outline-offset: 2px;
 }
 
-.sessions-hub .sh-filter-item input[type='checkbox']:focus-visible {
-  outline: 2px solid var(--color-accent, #1473e6);
-  outline-offset: 2px;
-}
 
 .sh-event-banner .sh-btn-event-register:focus-visible {
   outline: 2px solid #fff;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -1177,6 +1177,12 @@
 
   .sessions-hub .sh-view-dropdown {
     flex: 1;
+    min-width: 0;
+  }
+
+  .sessions-hub .sh-view-toggle {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .sessions-hub .sh-toolbar-actions:has(.sh-search-wrap.expanded) .sh-search-row {

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -698,8 +698,6 @@ function renderFilterPanel(sessions) {
     createTag('button', { class: 'sh-filter-apply', type: 'button' }, dictionaryManager.getValue('Apply')),
     createTag('button', { class: 'sh-filter-reset', type: 'button' }, dictionaryManager.getValue('Reset all')),
   );
-  sidebar.append(actions);
-
   const backdrop = createTag('div', { class: 'sh-filter-backdrop', 'aria-hidden': 'true' });
 
   const optionsWrap = createTag('div', { class: 'sh-filter-options' });
@@ -745,6 +743,8 @@ function renderFilterPanel(sessions) {
   });
   optionsWrap.append(saveActions);
 
+  sidebar.append(actions);
+
   panel.append(backdrop, sidebar, optionsWrap);
   return panel;
 }
@@ -763,7 +763,7 @@ function getActiveTagList(activeTags) {
 
 const ACTIVE_FILTERS_COLLAPSED_COUNT = 3;
 
-function updateActiveFilters(containerEl, listEl, state) {
+function updateActiveFilters(containerEl) {
   if (!containerEl) return;
   const list = getActiveTagList(getFilterState().activeTags);
   containerEl.innerHTML = '';
@@ -1157,7 +1157,7 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
     if (seeAll) {
       const expanded = activeFilters.dataset.expanded === 'true';
       activeFilters.dataset.expanded = expanded ? 'false' : 'true';
-      updateActiveFilters(activeFilters, listEl, state);
+      updateActiveFilters(activeFilters);
       return;
     }
     const removeBtn = e.target.closest('.sh-filter-tag-remove');
@@ -1172,7 +1172,7 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
     }
     setFilterState({ ...fs, activeTags: newTags });
     applyFilter(listEl, state);
-    updateActiveFilters(activeFilters, listEl, state);
+    updateActiveFilters(activeFilters);
   });
 
   searchInput.addEventListener('input', debounce(() => {
@@ -1216,7 +1216,11 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
     if (filterBtn.disabled) return;
     const isHidden = filterPanel.classList.toggle('hidden');
     filterBtn.setAttribute('aria-expanded', String(!isHidden));
-    filterPanel.setAttribute('aria-hidden', String(isHidden));
+    if (isHidden) {
+      filterPanel.setAttribute('aria-hidden', 'true');
+    } else {
+      filterPanel.removeAttribute('aria-hidden');
+    }
     if (!isHidden) {
       filterPanel.classList.remove('sh-detail-open');
       pendingTags = cloneActiveTags(getFilterState().activeTags);
@@ -1232,9 +1236,7 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
 
   const detailTitle = filterPanel.querySelector('.sh-filter-detail-title');
 
-  filterPanel.addEventListener('click', (e) => {
-    const cat = e.target.closest('.sh-filter-cat');
-    if (!cat) return;
+  const activateCategoryDrillIn = (cat, moveFocus = false) => {
     const { category } = cat.dataset;
     filterPanel.querySelectorAll('.sh-filter-cat').forEach((c) => {
       const isActive = c === cat;
@@ -1246,6 +1248,34 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
     });
     if (detailTitle) detailTitle.textContent = cat.textContent;
     filterPanel.classList.add('sh-detail-open');
+    if (moveFocus) {
+      const firstCb = filterPanel.querySelector(`.sh-filter-option-grid.active input[type="checkbox"]`);
+      if (firstCb) setTimeout(() => firstCb.focus(), 0);
+    }
+  };
+
+  filterPanel.addEventListener('click', (e) => {
+    const cat = e.target.closest('.sh-filter-cat');
+    if (!cat) return;
+    activateCategoryDrillIn(cat, false);
+  });
+
+  filterPanel.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      filterPanel.classList.add('hidden');
+      filterBtn.setAttribute('aria-expanded', 'false');
+      filterPanel.setAttribute('aria-hidden', 'true');
+      filterBtn.focus();
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      const cat = e.target.closest('.sh-filter-cat');
+      if (cat) {
+        e.preventDefault();
+        activateCategoryDrillIn(cat, true);
+        return;
+      }
+    }
   });
 
   filterPanel.querySelector('.sh-filter-back')?.addEventListener('click', () => {
@@ -1256,7 +1286,7 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
   applyBtn?.addEventListener('click', () => {
     setFilterState({ ...getFilterState(), activeTags: cloneActiveTags(pendingTags) });
     applyFilter(listEl, state);
-    updateActiveFilters(activeFilters, listEl, state);
+    updateActiveFilters(activeFilters);
     filterPanel.classList.add('hidden');
     filterBtn.setAttribute('aria-expanded', 'false');
     filterPanel.setAttribute('aria-hidden', 'true');
@@ -1267,7 +1297,7 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
   saveBtn?.addEventListener('click', () => {
     setFilterState({ ...getFilterState(), activeTags: cloneActiveTags(pendingTags) });
     applyFilter(listEl, state);
-    updateActiveFilters(activeFilters, listEl, state);
+    updateActiveFilters(activeFilters);
     filterPanel.classList.add('hidden');
     filterBtn.setAttribute('aria-expanded', 'false');
     filterPanel.setAttribute('aria-hidden', 'true');
@@ -1283,16 +1313,9 @@ function bindToolbarEvents(toolbarEl, listEl, state) {
     });
     setFilterState({ ...getFilterState(), activeTags: new Map() });
     applyFilter(listEl, state);
-    updateActiveFilters(activeFilters, listEl, state);
+    updateActiveFilters(activeFilters);
   });
 
-  filterPanel.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape') return;
-    filterPanel.classList.add('hidden');
-    filterBtn.setAttribute('aria-expanded', 'false');
-    filterPanel.setAttribute('aria-hidden', 'true');
-    filterBtn.focus();
-  });
 
   filterPanel.addEventListener('click', (e) => {
     if (e.target !== filterPanel) return;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.js
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.js
@@ -862,9 +862,11 @@ function renderToolbar(state) {
     'aria-label': dictionaryManager.getValue('Clear search'),
   });
   searchClear.append(createIcon(CLOSE_ICON));
-  searchWrap.append(searchToggle, searchInput, searchClear);
+  const searchRow = createTag('div', { class: 'sh-search-row' });
+  searchRow.append(createIcon(SEARCH_ICON), searchInput, searchClear);
+  searchWrap.append(searchToggle);
 
-  actions.append(downloadBtn, dropdown, filterWrap, searchWrap);
+  actions.append(downloadBtn, dropdown, filterWrap, searchWrap, searchRow);
   inner.append(actions);
   toolbar.append(inner);
   return toolbar;


### PR DESCRIPTION

- Search input moved to sh-search-row (sibling of sh-search-wrap) so the toggle stays visible in the top row while the pill expands onto a new row on mobile
- Desktop: pill appears inline in the actions row; toggle hides when expanded
- Mobile: actions row stretches full width; dropdown grows to fill space; search row wraps to a full-width row below on expand
- Unregistered mobile: filter button grows to fill remaining space and shows Filter label; search toggle stays at right
- Removed grey border from search toggle (not in Figma spec)
- Fixed blue focus ring on filter items: :focus-within → :has(input:focus-visible)

Resolves: [MWPW-195684](https://jira.corp.adobe.com/browse/MWPW-195684)

Test URLs:
- Before: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/sessions-uat-adobe-summit-london-2026/london/gb/2026-07-07/session-hub?timing=1783439999990&espenv=stage&eventlibs=dev
- After: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/sessions-uat-adobe-summit-london-2026/london/gb/2026-07-07/session-hub?timing=1783439999990&espenv=stage&eventlibs=session-hub-enhancements

https://main--da-bacom--adobecom.aem.page/uk/drafts/robertw/roadshow-testing/testing-session-hub-template/london/gb/2026-07-08/session-hub?timing=1783511999990&espenv=stage&eventlibs=session-hub-enhancements