### PR TITLE
[Mwpw 198650] : Session hub spacing and breakpoint fixes

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -1099,18 +1099,24 @@
     justify-content: flex-end;
   }
 
+}
+
+/* ─── Tablet banner (768px – 899px) ─────────────────────────────────────── */
+
+@media (min-width: 768px) and (max-width: 899px) {
   .sh-event-banner {
     padding: 40px 0;
   }
 
-  .sh-event-banner .sh-btn-event-register {
-    width: auto;
+  .sh-banner-inner {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0 40px;
+    gap: 32px;
   }
 
-  .sh-banner-inner {
-    padding: 0 24px;
-    gap: 56px;
-    flex-wrap: nowrap;
+  .sh-event-banner .sh-btn-event-register {
+    width: 100%;
   }
 
   .sh-banner-title {
@@ -1135,6 +1141,21 @@
 
   .sessions-hub .sh-card-left {
     padding-right: 0;
+  }
+
+  .sh-event-banner {
+    padding: 40px 0;
+  }
+
+  .sh-banner-inner {
+    flex-wrap: nowrap;
+    padding: 0 24px;
+    gap: 56px;
+    align-items: center;
+  }
+
+  .sh-event-banner .sh-btn-event-register {
+    width: auto;
   }
 }
 
@@ -1168,6 +1189,17 @@
     align-self: stretch;
     flex-wrap: wrap;
     justify-content: flex-end;
+  }
+
+  .sh-banner-inner {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0 32px;
+    gap: 32px;
+  }
+
+  .sh-banner-title {
+    font-size: 24px;
   }
 
   .sessions-hub .sh-view-dropdown {

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -1133,6 +1133,16 @@
   }
 }
 
+@media (max-width: 768px) {
+  .sessions-hub .sh-card-desh-text {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+  }
+  .sessions-hub .sh-card {
+    row-gap: 16px;
+  }
+}
+
 @media (min-width: 901px) {
   .sessions-hub .sh-toolbar {
     top: var(--toolbar-top, 0);
@@ -1140,7 +1150,7 @@
 }
 
 /* Tablet (and below): filter collapses to an icon-only */
-@media (max-width: 900px) {
+@media (max-width: 768px) {
   .sessions-hub .sh-filter-btn {
     width: 40px;
     padding: 0;
@@ -1169,7 +1179,7 @@
 
 
 /* Mobile: bottom-sheet filter modal (full-viewport backdrop + drill-in). */
-@media (max-width: 600px) {
+@media (max-width: 360px) {
   .sessions-hub .sh-toolbar-actions {
     align-self: stretch;
     flex-wrap: wrap;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -835,6 +835,7 @@
   line-height: 1.5;
   color: black;
   overflow: hidden;
+  max-height: calc(8 * 1.5em);
   line-clamp: 8;
   /* stylelint-disable-next-line value-no-vendor-prefix -- Safari needs -webkit-box for line clamp */
   display: -webkit-box;
@@ -844,6 +845,7 @@
 
 .sessions-hub .sh-card.expanded .sh-card-desh-text {
   display: block;
+  max-height: none;
   line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
@@ -1130,6 +1132,7 @@
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
+    max-height: calc(4 * 1.5em);
   }
 
   .sessions-hub .sh-card {
@@ -1172,6 +1175,7 @@
   .sessions-hub .sh-toolbar-inner {
     padding: 16px 32px;
   }
+
 
   .sessions-hub .sh-card {
     grid-template-columns: 340px 1fr;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -1082,20 +1082,13 @@
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
-<<<<<<< Updated upstream
-/* ─── Tablet (768px–899px) and above ─────────────────────────────────────── */
-
-@media (min-width: 768px) {
-=======
 /* ─── Tablet and above (≥ 600px) ────────────────────────────────────────── */
 
 @media (min-width: 600px) {
->>>>>>> Stashed changes
   .sessions-hub .sh-toolbar-inner {
     flex-direction: row;
     justify-content: flex-end;
     align-items: center;
-    padding: 16px 32px;
   }
 
   .sessions-hub .sh-btn,
@@ -1104,21 +1097,9 @@
   }
 }
 
-<<<<<<< Updated upstream
-  .sessions-hub .sh-cta-group {
-    justify-content: flex-end;
-  }
-
-}
-
-/* ─── Tablet banner (768px – 899px) ─────────────────────────────────────── */
-
-@media (min-width: 768px) and (max-width: 899px) {
-=======
 /* ─── Tablet banner (600px – 899px) ─────────────────────────────────────── */
 
 @media (min-width: 600px) and (max-width: 899px) {
->>>>>>> Stashed changes
   .sh-event-banner {
     padding: 40px 0;
   }
@@ -1128,13 +1109,10 @@
     align-items: stretch;
     padding: 0 40px;
     gap: 32px;
-<<<<<<< Updated upstream
   }
 
   .sh-event-banner .sh-btn-event-register {
     width: 100%;
-=======
->>>>>>> Stashed changes
   }
 
   .sh-banner-title {
@@ -1146,47 +1124,6 @@
   }
 }
 
-<<<<<<< Updated upstream
-/* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */
-
-@media (min-width: 900px) {
-  .sessions-hub .sh-toolbar {
-    top: var(--toolbar-top, 0);
-=======
-/* ─── Tablet and below (≤ 899px) ────────────────────────────────────────── */
-
-@media (max-width: 899px) {
-  .sessions-hub .sh-card-desh-text {
-    -webkit-line-clamp: 4;
-    line-clamp: 4;
->>>>>>> Stashed changes
-  }
-
-  .sessions-hub .sh-card {
-    row-gap: 16px;
-  }
-
-<<<<<<< Updated upstream
-  .sessions-hub .sh-card-left {
-    padding-right: 0;
-  }
-
-  .sh-event-banner {
-    padding: 40px 0;
-  }
-
-  .sh-banner-inner {
-    flex-wrap: nowrap;
-    padding: 0 24px;
-    gap: 56px;
-    align-items: center;
-  }
-
-  .sh-event-banner .sh-btn-event-register {
-    width: auto;
-  }
-}
-
 /* ─── Tablet and below (≤ 899px) ────────────────────────────────────────── */
 
 @media (max-width: 899px) {
@@ -1199,8 +1136,6 @@
     row-gap: 16px;
   }
 
-=======
->>>>>>> Stashed changes
   .sessions-hub .sh-filter-btn {
     width: 40px;
     padding: 0;
@@ -1212,11 +1147,6 @@
   }
 }
 
-<<<<<<< Updated upstream
-/* ─── Mobile (≤ 767px) ───────────────────────────────────────────────────── */
-
-@media (max-width: 767px) {
-=======
 /* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */
 
 @media (min-width: 900px) {
@@ -1259,7 +1189,6 @@
 /* ─── Mobile (< 600px) ───────────────────────────────────────────────────── */
 
 @media (max-width: 599px) {
->>>>>>> Stashed changes
   .sessions-hub .sh-toolbar-actions {
     align-self: stretch;
     flex-wrap: wrap;

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -598,6 +598,7 @@
 .sessions-hub .sh-session-area {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 0 24px;
 }
 
 .sessions-hub .sh-no-results {
@@ -617,7 +618,7 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding: 24px 24px 100px;
+  padding: 24px 0 100px;
 }
 
 /* ─── Session card ───────────────────────────────────────────────────────── */
@@ -1174,6 +1175,10 @@
 
   .sessions-hub .sh-toolbar-inner {
     padding: 16px 32px;
+  }
+
+  .sessions-hub .sh-session-area {
+    padding: 0 32px;
   }
 
 

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -254,7 +254,7 @@
   background: var(--color-gray-100, #f3f3f3);
 }
 
-@media (min-width: 601px) {
+@media (min-width: 768px) {
   .sessions-hub .sh-search-wrap.expanded .sh-search-toggle {
     display: none;
   }
@@ -1080,16 +1080,23 @@
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
-@media (min-width: 601px) {
+/* ─── Tablet (768px–899px) and above ─────────────────────────────────────── */
+
+@media (min-width: 768px) {
   .sessions-hub .sh-toolbar-inner {
     flex-direction: row;
     justify-content: flex-end;
     align-items: center;
+    padding: 16px 32px;
   }
 
   .sessions-hub .sh-btn,
   .sessions-hub .sh-registered-badge {
     width: auto;
+  }
+
+  .sessions-hub .sh-cta-group {
+    justify-content: flex-end;
   }
 
   .sh-event-banner {
@@ -1115,9 +1122,11 @@
   }
 }
 
-@media (min-width: 769px) {
-  .sessions-hub .sh-toolbar-inner {
-    padding: 16px 32px;
+/* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */
+
+@media (min-width: 900px) {
+  .sessions-hub .sh-toolbar {
+    top: var(--toolbar-top, 0);
   }
 
   .sessions-hub .sh-card {
@@ -1127,30 +1136,20 @@
   .sessions-hub .sh-card-left {
     padding-right: 0;
   }
-
-  .sessions-hub .sh-cta-group {
-    justify-content: flex-end;
-  }
 }
 
-@media (max-width: 768px) {
+/* ─── Tablet and below (≤ 899px) ────────────────────────────────────────── */
+
+@media (max-width: 899px) {
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
   }
+
   .sessions-hub .sh-card {
     row-gap: 16px;
   }
-}
 
-@media (min-width: 901px) {
-  .sessions-hub .sh-toolbar {
-    top: var(--toolbar-top, 0);
-  }
-}
-
-/* Tablet (and below): filter collapses to an icon-only */
-@media (max-width: 768px) {
   .sessions-hub .sh-filter-btn {
     width: 40px;
     padding: 0;
@@ -1160,29 +1159,15 @@
   .sessions-hub .sh-filter-btn-label {
     display: none;
   }
-
-  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-wrap {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn {
-    width: 100%;
-    padding: 0 16px;
-    border-radius: 20px;
-  }
-
-  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn-label {
-    display: inline;
-  }
 }
 
+/* ─── Mobile (≤ 767px) ───────────────────────────────────────────────────── */
 
-/* Mobile: bottom-sheet filter modal (full-viewport backdrop + drill-in). */
-@media (max-width: 360px) {
+@media (max-width: 767px) {
   .sessions-hub .sh-toolbar-actions {
     align-self: stretch;
     flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   .sessions-hub .sh-view-dropdown {

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -1145,6 +1145,21 @@
   .sessions-hub .sh-filter-btn-label {
     display: none;
   }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-wrap {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn {
+    width: 100%;
+    padding: 0 16px;
+    border-radius: 20px;
+  }
+
+  .sessions-hub .sh-toolbar-actions:has(.sh-view-dropdown[hidden]) .sh-filter-btn-label {
+    display: inline;
+  }
 }
 
 /* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -254,7 +254,7 @@
   background: var(--color-gray-100, #f3f3f3);
 }
 
-@media (min-width: 768px) {
+@media (min-width: 600px) {
   .sessions-hub .sh-search-wrap.expanded .sh-search-toggle {
     display: none;
   }
@@ -825,6 +825,8 @@
 
 .sessions-hub .sh-card-desc {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .sessions-hub .sh-card-desh-text {
@@ -1080,9 +1082,15 @@
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
+<<<<<<< Updated upstream
 /* ─── Tablet (768px–899px) and above ─────────────────────────────────────── */
 
 @media (min-width: 768px) {
+=======
+/* ─── Tablet and above (≥ 600px) ────────────────────────────────────────── */
+
+@media (min-width: 600px) {
+>>>>>>> Stashed changes
   .sessions-hub .sh-toolbar-inner {
     flex-direction: row;
     justify-content: flex-end;
@@ -1094,7 +1102,9 @@
   .sessions-hub .sh-registered-badge {
     width: auto;
   }
+}
 
+<<<<<<< Updated upstream
   .sessions-hub .sh-cta-group {
     justify-content: flex-end;
   }
@@ -1104,6 +1114,11 @@
 /* ─── Tablet banner (768px – 899px) ─────────────────────────────────────── */
 
 @media (min-width: 768px) and (max-width: 899px) {
+=======
+/* ─── Tablet banner (600px – 899px) ─────────────────────────────────────── */
+
+@media (min-width: 600px) and (max-width: 899px) {
+>>>>>>> Stashed changes
   .sh-event-banner {
     padding: 40px 0;
   }
@@ -1113,10 +1128,13 @@
     align-items: stretch;
     padding: 0 40px;
     gap: 32px;
+<<<<<<< Updated upstream
   }
 
   .sh-event-banner .sh-btn-event-register {
     width: 100%;
+=======
+>>>>>>> Stashed changes
   }
 
   .sh-banner-title {
@@ -1128,17 +1146,27 @@
   }
 }
 
+<<<<<<< Updated upstream
 /* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */
 
 @media (min-width: 900px) {
   .sessions-hub .sh-toolbar {
     top: var(--toolbar-top, 0);
+=======
+/* ─── Tablet and below (≤ 899px) ────────────────────────────────────────── */
+
+@media (max-width: 899px) {
+  .sessions-hub .sh-card-desh-text {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+>>>>>>> Stashed changes
   }
 
   .sessions-hub .sh-card {
-    grid-template-columns: 340px 1fr;
+    row-gap: 16px;
   }
 
+<<<<<<< Updated upstream
   .sessions-hub .sh-card-left {
     padding-right: 0;
   }
@@ -1171,6 +1199,8 @@
     row-gap: 16px;
   }
 
+=======
+>>>>>>> Stashed changes
   .sessions-hub .sh-filter-btn {
     width: 40px;
     padding: 0;
@@ -1182,9 +1212,54 @@
   }
 }
 
+<<<<<<< Updated upstream
 /* ─── Mobile (≤ 767px) ───────────────────────────────────────────────────── */
 
 @media (max-width: 767px) {
+=======
+/* ─── Desktop (≥ 900px) ──────────────────────────────────────────────────── */
+
+@media (min-width: 900px) {
+  .sessions-hub .sh-toolbar {
+    top: var(--toolbar-top, 0);
+  }
+
+  .sessions-hub .sh-toolbar-inner {
+    padding: 16px 32px;
+  }
+
+  .sessions-hub .sh-card {
+    grid-template-columns: 340px 1fr;
+  }
+
+  .sessions-hub .sh-card-left {
+    padding-right: 0;
+  }
+
+  .sessions-hub .sh-cta-group {
+    justify-content: flex-end;
+  }
+
+  .sh-event-banner {
+    padding: 40px 0;
+  }
+
+  .sh-banner-inner {
+    flex-wrap: nowrap;
+    padding: 0 24px;
+    gap: 56px;
+    align-items: center;
+  }
+
+  .sh-event-banner .sh-btn-event-register {
+    width: auto;
+  }
+}
+
+/* ─── Mobile (< 600px) ───────────────────────────────────────────────────── */
+
+@media (max-width: 599px) {
+>>>>>>> Stashed changes
   .sessions-hub .sh-toolbar-actions {
     align-self: stretch;
     flex-wrap: wrap;


### PR DESCRIPTION
Fix sessions-hub block responsive layout per MWPW-198650:

- **Description truncation**: Clamp to 4 lines on tablet and mobile (≤899px); 8 lines on desktop
- **Card layout**: 2-column grid (340px + 1fr) desktop-only (≥900px); single column on tablet/mobile so description breaks to its own row
- **16px row-gap** on tablet/mobile for card spacing
- **Filter button**: icon-only (no label) at tablet and below (≤899px)
- **Toolbar actions**: right-aligned on mobile
- **Sticky event banner**: column layout on mobile (<600px) and tablet (600–899px); row layout on desktop (≥900px)
- **Breakpoints standardized** to PM spec: Mobile <600px, Tablet 600–899px, Desktop ≥900px
- **Safari iOS 15/16 fix**: added `overflow: hidden` and `min-width: 0` to `.sh-card-desc` to prevent description text overlapping on iPhone 13/14

Resolves: [MWPW-198650](https://jira.corp.adobe.com/browse/MWPW-198650)

## Test URLs

- Before: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/sessions-uat-adobe-summit-london-2026/london/gb/2026-07-07/session-hub?timing=1783439999990&espenv=stage&eventlibs=dev
- After: https://main--da-bacom--adobecom.aem.page/drafts/robertw/roadshow-testing/sessions-uat-adobe-summit-london-2026/london/gb/2026-07-07/session-hub?timing=1783439999990&espenv=stage&eventlibs=MWPW-198650