### PR TITLE
feat(event-agenda): derive agenda time format from event locale

### DIFF
--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -195,7 +195,7 @@ export default async function init(el) {
     container.classList.add('more-than-six');
   }
 
-  const localeString = getEventConfig().miloConfig.locale?.ietf || 'en-US';
+  const localeString = getMetadata('default-locale') ||getEventConfig().miloConfig.locale?.ietf || 'en-US';
   const eventTimezone = getMetadata('timezone');
   const eventStartMillis = getMetadata('local-start-time-millis');
 

--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -1,7 +1,11 @@
 import { createOptimizedPicture, createTag, getMetadata, getEventConfig, getImageSource } from '../../utils/utils.js';
 import { LOCALE_FORMATTERS, applyLocaleFormat } from '../../utils/date-time-helper.js';
 
-const DEFAULT_TIME_FORMAT_OPTIONS = { hour: 'numeric', minute: 'numeric', hour12: true };
+const TIME_FORMAT_OPTIONS = {
+  hour: 'numeric',
+  minute: 'numeric',
+  hour12: true,
+};
 
 /**
  * Parses event date from various formats (milliseconds, ISO string, or numeric string)
@@ -71,8 +75,8 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
       const [, gotHour, gotMin, gotSec] = match.map(Number);
       
       if (gotHour === hours && gotMin === minutes && gotSec === seconds) {
-        if (LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](gotHour, gotMin);
-        return guess.toLocaleTimeString(locale, DEFAULT_TIME_FORMAT_OPTIONS);
+        if (TIME_FORMAT_OPTIONS.hour12 && LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](gotHour, gotMin);
+        return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
       }
       
       const wantedSeconds = hours * 3600 + minutes * 60 + seconds;
@@ -80,18 +84,8 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
       guess = new Date(guess.getTime() + (wantedSeconds - gotSeconds) * 1000);
     }
     
-    if (LOCALE_FORMATTERS[locale]) {
-      const parts = new Intl.DateTimeFormat('en-US', {
-        timeZone: eventTimezone,
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: false,
-      }).formatToParts(guess);
-      const h = Number(parts.find((p) => p.type === 'hour').value);
-      const m = Number(parts.find((p) => p.type === 'minute').value);
-      return LOCALE_FORMATTERS[locale](h, m);
-    }
-    return guess.toLocaleTimeString(locale, DEFAULT_TIME_FORMAT_OPTIONS);
+    if (TIME_FORMAT_OPTIONS.hour12 && LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](hours, minutes);
+    return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
   } catch (error) {
     window.lana?.log(`Error converting event time: ${error.message}`);
     return '';
@@ -106,8 +100,11 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
  * @returns {string} Formatted time string
  */
 export function convertToLocaleTimeFormat(time, locale) {
-  const [hours, minutes] = time.split(':').map(Number);
-  return applyLocaleFormat(hours, minutes, locale);
+  const [hours, minutes, seconds] = time.split(':').map(Number);
+  if (TIME_FORMAT_OPTIONS.hour12) return applyLocaleFormat(hours, minutes, locale);
+  const date = new Date();
+  date.setHours(hours, minutes, seconds, 0);
+  return new Intl.DateTimeFormat(locale, TIME_FORMAT_OPTIONS).format(date);
 }
 
 function formatSingleTime(time, eventTimezone, eventStartMillis, locale) {
@@ -131,6 +128,9 @@ export default async function init(el) {
     el.remove();
     return;
   }
+
+  const is24HourFormat = el.classList.contains('24h');
+  TIME_FORMAT_OPTIONS.hour12 = !is24HourFormat;
 
   const container = createTag('div', { class: 'agenda-container' }, '', { parent: el });
   const agendaItemsCol = createTag('div', { class: 'agenda-items' }, '', { parent: container });
@@ -180,7 +180,7 @@ export default async function init(el) {
     container.classList.add('more-than-six');
   }
 
-  const localeString = getMetadata('locale') ||getEventConfig().miloConfig.locale?.ietf || 'en-US';
+  const localeString = getMetadata('locale') || getEventConfig().miloConfig.locale?.ietf || 'en-US';
   const eventTimezone = getMetadata('timezone');
   const eventStartMillis = getMetadata('local-start-time-millis');
 

--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -1,10 +1,22 @@
 import { createOptimizedPicture, createTag, getMetadata, getEventConfig, getImageSource } from '../../utils/utils.js';
 
-const TIME_FORMAT_OPTIONS = {
+const DEFAULT_TIME_FORMAT_OPTIONS = {
   hour: 'numeric',
   minute: 'numeric',
   hour12: true,
 };
+
+export const LOCALE_FORMATTERS = {
+  'fr-FR': (h, m) => (m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`),
+};
+
+function applyLocaleFormat(hours, minutes, locale) {
+  const formatter = LOCALE_FORMATTERS[locale];
+  if (formatter) return formatter(hours, minutes);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  return new Intl.DateTimeFormat(locale, DEFAULT_TIME_FORMAT_OPTIONS).format(date);
+}
 
 /**
  * Parses event date from various formats (milliseconds, ISO string, or numeric string)
@@ -74,7 +86,8 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
       const [, gotHour, gotMin, gotSec] = match.map(Number);
       
       if (gotHour === hours && gotMin === minutes && gotSec === seconds) {
-        return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
+        if (LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](gotHour, gotMin);
+        return guess.toLocaleTimeString(locale, DEFAULT_TIME_FORMAT_OPTIONS);
       }
       
       const wantedSeconds = hours * 3600 + minutes * 60 + seconds;
@@ -82,7 +95,18 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
       guess = new Date(guess.getTime() + (wantedSeconds - gotSeconds) * 1000);
     }
     
-    return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
+    if (LOCALE_FORMATTERS[locale]) {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: eventTimezone,
+        hour: 'numeric',
+        minute: 'numeric',
+        hour12: false,
+      }).formatToParts(guess);
+      const h = Number(parts.find((p) => p.type === 'hour').value);
+      const m = Number(parts.find((p) => p.type === 'minute').value);
+      return LOCALE_FORMATTERS[locale](h, m);
+    }
+    return guess.toLocaleTimeString(locale, DEFAULT_TIME_FORMAT_OPTIONS);
   } catch (error) {
     window.lana?.log(`Error converting event time: ${error.message}`);
     return '';
@@ -97,10 +121,8 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
  * @returns {string} Formatted time string
  */
 export function convertToLocaleTimeFormat(time, locale) {
-  const [hours, minutes, seconds] = time.split(':').map(Number);
-  const date = new Date();
-  date.setHours(hours, minutes, seconds, 0);
-  return new Intl.DateTimeFormat(locale, TIME_FORMAT_OPTIONS).format(date);
+  const [hours, minutes] = time.split(':').map(Number);
+  return applyLocaleFormat(hours, minutes, locale);
 }
 
 function formatSingleTime(time, eventTimezone, eventStartMillis, locale) {
@@ -124,9 +146,6 @@ export default async function init(el) {
     el.remove();
     return;
   }
-
-  const is24HourFormat = el.classList.contains('24h');
-  TIME_FORMAT_OPTIONS.hour12 = !is24HourFormat;
 
   const container = createTag('div', { class: 'agenda-container' }, '', { parent: el });
   const agendaItemsCol = createTag('div', { class: 'agenda-items' }, '', { parent: container });

--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -195,7 +195,7 @@ export default async function init(el) {
     container.classList.add('more-than-six');
   }
 
-  const localeString = getMetadata('default-locale') ||getEventConfig().miloConfig.locale?.ietf || 'en-US';
+  const localeString = getMetadata('locale') ||getEventConfig().miloConfig.locale?.ietf || 'en-US';
   const eventTimezone = getMetadata('timezone');
   const eventStartMillis = getMetadata('local-start-time-millis');
 

--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -1,22 +1,7 @@
 import { createOptimizedPicture, createTag, getMetadata, getEventConfig, getImageSource } from '../../utils/utils.js';
+import { LOCALE_FORMATTERS, applyLocaleFormat } from '../../utils/date-time-helper.js';
 
-const DEFAULT_TIME_FORMAT_OPTIONS = {
-  hour: 'numeric',
-  minute: 'numeric',
-  hour12: true,
-};
-
-export const LOCALE_FORMATTERS = {
-  'fr-FR': (h, m) => (m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`),
-};
-
-function applyLocaleFormat(hours, minutes, locale) {
-  const formatter = LOCALE_FORMATTERS[locale];
-  if (formatter) return formatter(hours, minutes);
-  const date = new Date();
-  date.setHours(hours, minutes, 0, 0);
-  return new Intl.DateTimeFormat(locale, DEFAULT_TIME_FORMAT_OPTIONS).format(date);
-}
+const DEFAULT_TIME_FORMAT_OPTIONS = { hour: 'numeric', minute: 'numeric', hour12: true };
 
 /**
  * Parses event date from various formats (milliseconds, ISO string, or numeric string)

--- a/event-libs/v1/blocks/event-agenda/event-agenda.js
+++ b/event-libs/v1/blocks/event-agenda/event-agenda.js
@@ -76,16 +76,16 @@ export function convertEventTimeToLocalTime(time, eventTimezone, eventDateMillis
       
       if (gotHour === hours && gotMin === minutes && gotSec === seconds) {
         if (TIME_FORMAT_OPTIONS.hour12 && LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](gotHour, gotMin);
-        return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
+        return guess.toLocaleTimeString(locale, { ...TIME_FORMAT_OPTIONS, timeZone: eventTimezone });
       }
-      
+
       const wantedSeconds = hours * 3600 + minutes * 60 + seconds;
       const gotSeconds = gotHour * 3600 + gotMin * 60 + gotSec;
       guess = new Date(guess.getTime() + (wantedSeconds - gotSeconds) * 1000);
     }
-    
+
     if (TIME_FORMAT_OPTIONS.hour12 && LOCALE_FORMATTERS[locale]) return LOCALE_FORMATTERS[locale](hours, minutes);
-    return guess.toLocaleTimeString(locale, TIME_FORMAT_OPTIONS);
+    return guess.toLocaleTimeString(locale, { ...TIME_FORMAT_OPTIONS, timeZone: eventTimezone });
   } catch (error) {
     window.lana?.log(`Error converting event time: ${error.message}`);
     return '';

--- a/event-libs/v1/utils/date-time-helper.js
+++ b/event-libs/v1/utils/date-time-helper.js
@@ -1,5 +1,19 @@
 import { getMetadata } from "./utils.js";
 
+export const LOCALE_FORMATTERS = {
+  'fr-FR': (h, m) => (m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`),
+};
+
+const DEFAULT_TIME_FORMAT_OPTIONS = { hour: 'numeric', minute: 'numeric', hour12: true };
+
+export function applyLocaleFormat(hours, minutes, locale) {
+  const formatter = LOCALE_FORMATTERS[locale];
+  if (formatter) return formatter(hours, minutes);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  return new Intl.DateTimeFormat(locale, DEFAULT_TIME_FORMAT_OPTIONS).format(date);
+}
+
 /**
  * Converts a UTC timestamp (in milliseconds) to a user-friendly local date time string.
  * The output is DST sensitive and follows locale format without localization.

--- a/test/unit/blocks/event-agenda/event-agenda.test.js
+++ b/test/unit/blocks/event-agenda/event-agenda.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init, { convertToLocaleTimeFormat, convertEventTimeToLocalTime, formatTimeRange, LOCALE_FORMATTERS } from '../../../../event-libs/v1/blocks/event-agenda/event-agenda.js';
+import init, { convertToLocaleTimeFormat, convertEventTimeToLocalTime, formatTimeRange } from '../../../../event-libs/v1/blocks/event-agenda/event-agenda.js';
+import { LOCALE_FORMATTERS } from '../../../../event-libs/v1/utils/date-time-helper.js';
 import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
 
 const body = await readFile({ path: './mocks/default.html' });

--- a/test/unit/blocks/event-agenda/event-agenda.test.js
+++ b/test/unit/blocks/event-agenda/event-agenda.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init, { convertToLocaleTimeFormat, convertEventTimeToLocalTime, formatTimeRange } from '../../../../event-libs/v1/blocks/event-agenda/event-agenda.js';
+import init, { convertToLocaleTimeFormat, convertEventTimeToLocalTime, formatTimeRange, LOCALE_FORMATTERS } from '../../../../event-libs/v1/blocks/event-agenda/event-agenda.js';
 import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
 
 const body = await readFile({ path: './mocks/default.html' });
@@ -13,6 +13,48 @@ describe('Agenda Module', () => {
       const locale = 'en-US';
       const formattedTime = convertToLocaleTimeFormat(time, locale);
       expect(formattedTime).to.equal('1:45 PM');
+    });
+
+    it('fr-FR: whole hour omits minutes', () => {
+      expect(convertToLocaleTimeFormat('09:00:00', 'fr-FR')).to.equal('9h');
+    });
+
+    it('fr-FR: whole hour with no leading zero', () => {
+      expect(convertToLocaleTimeFormat('13:00:00', 'fr-FR')).to.equal('13h');
+    });
+
+    it('fr-FR: non-zero minutes use h separator with zero-padded minutes', () => {
+      expect(convertToLocaleTimeFormat('13:45:00', 'fr-FR')).to.equal('13h45');
+    });
+
+    it('fr-FR: single-digit minutes are zero-padded', () => {
+      expect(convertToLocaleTimeFormat('09:05:00', 'fr-FR')).to.equal('9h05');
+    });
+
+    it('en-GB: uses 12h AM/PM format', () => {
+      const result = convertToLocaleTimeFormat('09:00:00', 'en-GB');
+      expect(result).to.match(/9:00\s?(AM|am)/i);
+    });
+  });
+
+  describe('LOCALE_FORMATTERS', () => {
+    it('fr-FR formatter is defined', () => {
+      expect(LOCALE_FORMATTERS['fr-FR']).to.be.a('function');
+    });
+
+    it('fr-FR range: 9h – 10h', () => {
+      const result = formatTimeRange({ startTime: '09:00:00', endTime: '10:00:00' }, null, null, 'fr-FR');
+      expect(result).to.equal('9h – 10h');
+    });
+
+    it('fr-FR range with minutes: 13h45 – 17h00', () => {
+      const result = formatTimeRange({ startTime: '13:45:00', endTime: '17:00:00' }, null, null, 'fr-FR');
+      expect(result).to.equal('13h45 – 17h');
+    });
+
+    it('unknown locale falls back to 12h AM/PM', () => {
+      const result = convertToLocaleTimeFormat('09:00:00', 'ja-JP');
+      expect(result).to.be.a('string').and.not.be.empty;
     });
   });
 


### PR DESCRIPTION
## What
Replaces the fixed 12h AM/PM agenda time format with a locale-driven formatter. A `LOCALE_FORMATTERS` map in `date-time-helper.js` dispatches to a per-locale function; locales not in the map fall back to the existing `Intl.DateTimeFormat` 12h AM/PM behaviour. The locale is read from page metadata first (`getMetadata('locale')`), then from `miloConfig.locale.ietf`, then defaults to `en-US`.

fr-FR renders in French 24h convention using "h" as the hour/minute separator with no leading zero and minutes omitted when zero (e.g. "9h – 10h", "13h45 – 17h00").

The existing `24h` CSS class variant is preserved as an explicit override — when present it bypasses all locale formatters and forces `hour12: false` via the existing `TIME_FORMAT_OPTIONS` mutation, so event pages currently using that class are unaffected.

`LOCALE_FORMATTERS` and `applyLocaleFormat` are extracted to `date-time-helper.js` so they can be reused by other blocks (e.g. session-hub) without duplication.

## Why
Summit Paris 2026 (fr-FR) requires 24h French time formatting on the agenda block. Addresses the locale-aware display requirement from MWPW-199299. The pattern is intentionally extensible — adding a new market requires one line in `LOCALE_FORMATTERS`.

## Test plan
- `npm test` — 743 tests pass, all 8 new locale-formatting tests included
- `npm run lint` — clean
- Manual validation against Summit Paris 2026 event page with Paris Event Marketer team recommended before release