### PR TITLE
fix(sessions-hub): remove max-height from description to fix ul/li clipping

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -845,6 +845,7 @@
 
 .sessions-hub .sh-card.expanded .sh-card-desh-text {
   display: block;
+  max-height: none;
   line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
@@ -1131,6 +1132,7 @@
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
+    max-height: calc(4 * 1.5em);
   }
 
   .sessions-hub .sh-card {

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -836,7 +836,6 @@
   line-height: 1.5;
   color: black;
   overflow: hidden;
-  max-height: calc(8 * 1.5em);
   line-clamp: 8;
   /* stylelint-disable-next-line value-no-vendor-prefix -- Safari needs -webkit-box for line clamp */
   display: -webkit-box;
@@ -846,7 +845,6 @@
 
 .sessions-hub .sh-card.expanded .sh-card-desh-text {
   display: block;
-  max-height: none;
   line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
@@ -1133,7 +1131,6 @@
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
-    max-height: calc(4 * 1.5em);
   }
 
   .sessions-hub .sh-card {


### PR DESCRIPTION
## What
Removes the `max-height` property from `.sh-card-desh-text` (and its mobile breakpoint override) in the sessions-hub block.

## Why
Adding `max-height` alongside `-webkit-line-clamp` caused `<ul>/<li>` content inside session card descriptions to render incorrectly — list item text was hidden while bullet markers remained visible. Relying solely on `-webkit-line-clamp` (as in the `main` branch) clips the description cleanly at line boundaries and renders list content correctly.

## Test plan
- Load a session hub page with a session whose description contains a `<ul>` list
- Verify the collapsed card clips at 8 lines with list items rendering correctly
- Click "Read more" and verify the full description including list items expands correctly
- Verify mobile (≤ 899px) clips at 4 lines correctly
- `npm test` — all 734 tests passing