### PR TITLE
T3-26.26 Stage Take 2

### DIFF
--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -845,6 +845,7 @@
 
 .sessions-hub .sh-card.expanded .sh-card-desh-text {
   display: block;
+  max-height: none;
   line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
@@ -1131,6 +1132,7 @@
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
+    max-height: calc(4 * 1.5em);
   }
 
   .sessions-hub .sh-card {

--- a/event-libs/v1/blocks/sessions-hub/sessions-hub.css
+++ b/event-libs/v1/blocks/sessions-hub/sessions-hub.css
@@ -836,7 +836,6 @@
   line-height: 1.5;
   color: black;
   overflow: hidden;
-  max-height: calc(8 * 1.5em);
   line-clamp: 8;
   /* stylelint-disable-next-line value-no-vendor-prefix -- Safari needs -webkit-box for line clamp */
   display: -webkit-box;
@@ -846,7 +845,6 @@
 
 .sessions-hub .sh-card.expanded .sh-card-desh-text {
   display: block;
-  max-height: none;
   line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
@@ -1133,7 +1131,6 @@
   .sessions-hub .sh-card-desh-text {
     -webkit-line-clamp: 4;
     line-clamp: 4;
-    max-height: calc(4 * 1.5em);
   }
 
   .sessions-hub .sh-card {


### PR DESCRIPTION
## Summary

This PR promotes the latest sessions-hub fixes and the Sessions Guide Part 1 implementation from `dev` to `stage`.

### Key changes

- **Sessions Guide Part 1** (`[MWPW-194331]`): Full FE implementation — UI, layout, and core interactions
- **fix(sessions-hub)**: Remove `max-height` from description text on desktop to fix `<ul>/<li>` clipping — list item content was being hidden while bullet markers remained visible due to `max-height` conflicting with `-webkit-line-clamp`
- **fix(sessions-hub)**: Restore `max-height` on mobile (≤899px) to prevent text overlap on iPhone 12/13
- **fix(sessions-hub)**: Align session cards with toolbar search icon
- **fix(sessions-hub)**: Fix multi-paragraph description overlap on Safari iOS 15/16
- **fix(sessions-hub)**: Restore filter button expand rules for My Sessions view
- **fix(sessions-hub)**: Fix description overflow on Safari iOS 15/16 (iPhone 13/14)
- **fix(sessions-hub)**: Fix sticky event banner layout for all breakpoints
- **fix(sessions-hub)**: Align breakpoints to mobile ≤767px, tablet 768–899px, desktop ≥900px
- **fix(sessions-hub)**: Clamp description to 4 lines and add spacing on mobile
- **feat(sessions-hub)**: Add keyboard accessibility and ARIA fixes for filter panel
- **fix(sessions-hub)**: Fix mobile toolbar layout and search expansion per Figma spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)