### PR TITLE
fix(timing-framework): skip dead MR on load and fix MR→MR underrun

### DIFF
--- a/event-libs/v1/blocks/mobile-rider/mobile-rider.js
+++ b/event-libs/v1/blocks/mobile-rider/mobile-rider.js
@@ -45,6 +45,12 @@ async function loadScript() {
 }
 
 class MobileRider {
+  #embedRafId = null;
+
+  #embedGeneration = 0;
+
+  #streamEnded = false;
+
   constructor(el) {
     this.el = el;
     this.isEmbedding = false;
@@ -62,6 +68,22 @@ class MobileRider {
     }
   }
 
+  #isStreamInactive(vid) {
+    if (!this.store || !vid) return false;
+
+    const key = this.#storeHas(this.mainID)
+      ? this.mainID
+      : (this.#storeHas(vid) ? vid : null);
+
+    if (!key) return false;
+
+    try {
+      return this.store.get(key) === false;
+    } catch (e) {
+      return false;
+    }
+  }
+
   async init() {
     try {
       this.cfg = this.#parseCfg();
@@ -74,7 +96,13 @@ class MobileRider {
       const selected = await this.#selectInitialVideo(videos);
       if (this.cfg.concurrentenabled && this.store) this.mainID = videos[0].videoid;
 
-      await this.injectPlayer(selected.videoid, this.cfg.skinid, selected.aslid);
+      const videoId = selected.videoid || selected['video-id'];
+      if (this.#isStreamInactive(videoId)) {
+        this.root?.classList.add('is-hidden');
+        return;
+      }
+
+      await this.injectPlayer(videoId, this.cfg.skinid, selected.aslid);
 
       if (this.cfg.concurrentenabled && videos.length > 1) {
         await this.#initDrawer(videos, selected.videoid);
@@ -90,9 +118,20 @@ class MobileRider {
       || createTag('div', { class: 'video-wrapper' }, '', { parent: this.root });
   }
 
+  #cancelPendingEmbed() {
+    if (this.#embedRafId != null) {
+      cancelAnimationFrame(this.#embedRafId);
+      this.#embedRafId = null;
+    }
+  }
+
   async injectPlayer(vid, skin, asl = null) {
     if (!this.wrap || this.isEmbedding) return;
     this.isEmbedding = true;
+    this.#streamEnded = false;
+    this.#cancelPendingEmbed();
+    const generation = this.#embedGeneration + 1;
+    this.#embedGeneration = generation;
 
     const finish = () => {
       setTimeout(() => { this.isEmbedding = false; }, 100);
@@ -120,7 +159,14 @@ class MobileRider {
         poster: this.cfg.poster || this.cfg.thumbnail || '',
       }, '', { parent: container });
 
-      requestAnimationFrame(() => {
+      this.#embedRafId = requestAnimationFrame(() => {
+        this.#embedRafId = null;
+
+        if (generation !== this.#embedGeneration || this.#streamEnded) {
+          finish();
+          return;
+        }
+
         const videoInDoc = document.getElementById(CONFIG.PLAYER.VIDEO_ID);
 
         if (!videoInDoc || !window.mobilerider) {
@@ -189,6 +235,11 @@ class MobileRider {
     // Avoid stacking listeners
     window.__mr_player?.off?.('streamend');
     window.__mr_player?.on?.('streamend', () => {
+      this.#streamEnded = true;
+      this.#cancelPendingEmbed();
+
+      this.wrap?.querySelector('.mobile-rider-container')?.classList.add('is-hidden');
+
       if (this.drawer) {
         this.drawer.remove();
         this.drawer = null;

--- a/event-libs/v1/features/timing-framework/README.md
+++ b/event-libs/v1/features/timing-framework/README.md
@@ -129,8 +129,8 @@ This method:
 After finding the initial position, the framework then validates this position against other conditions:
 
 1. **Mobile Rider Status**
-   - If the initial position has an active MR session, it stays
-   - If the previous position has an active MR session, it may need to go back
+   - On each timer tick, `advancePastInactiveMrSlots()` may skip dead MR slots whose `toggleTime` has passed (landing / late visitor)
+   - Background `validateSchedulePosition()` may adjust position once authoritative time is available
 
 2. **Metadata Conditions**
    - Validates metadata conditions for the initial position
@@ -140,7 +140,7 @@ This two-phase approach ensures:
 - Quick initial positioning based on time
 - Accurate final position based on all conditions
 - Efficient handling of schedule navigation
-- Proper handling of edge cases (like MR overrun)
+- Proper handling of edge cases (MR overrun, underrun, landing on dead MR slots)
 
 ### Example
 
@@ -166,10 +166,10 @@ This two-phase approach ensures:
 
 If current time is 1234567900:
 1. Phase 1: Finds "/session1" as initial position (last passed toggleTime)
-2. Phase 2: 
-   - Checks if session1 is still active
-   - If active, stays on "/session1"
-   - If ended, proceeds to "/post-event"
+2. Phase 2:
+   - If session1 is still active, stays on "/session1" (overrun)
+   - If session1 has ended and "/post-event" toggleTime has passed, proceeds to "/post-event"
+   - If session1 has ended but "/post-event" toggleTime is still future, advances early via natural stream-end underrun (see below)
 
 ## Schedule Trigger Mechanism
 
@@ -177,23 +177,54 @@ The framework uses a sophisticated trigger system that considers multiple factor
 
 ### Trigger Evaluation Order
 
-1. **Mobile Rider (MR) Status**
-   - Overrun Check: If current item has MR and session is still active, stay on current item
-   - Underrun Check: If next item has MR and session has ended, proceed to next item
-   - MR takes precedence over time-based triggers
-   - Uses BroadcastChannel for real-time status updates
+Each `runTimer()` tick calls `advancePastInactiveMrSlots()` first, then `shouldTriggerNextSchedule()`:
 
-2. **Metadata Conditions**
-   - Checks if metadata key matches expected value
-   - If condition not met, blocks transition regardless of time
-   - Can be used to force specific content based on external state
-   - Updates via BroadcastChannel for dynamic changes
+1. **Mobile Rider (MR) status** — see [Mobile Rider edge cases](#mobile-rider-edge-cases) below
+2. **Metadata conditions** — all conditions on the next item must pass
+3. **Time-based trigger (`toggleTime`)** — server-synchronized via Akamai time API
 
-3. **Time-based Trigger (toggleTime)**
-   - Only evaluated if no MR or metadata conditions are blocking
-   - Uses server-synchronized time to prevent client clock manipulation
-   - Supports testing mode via URL parameters
-   - Random polling interval to prevent server load
+MR stream status uses BroadcastChannel (`mobile-rider-store`) for real-time updates within the same tab.
+
+### Mobile Rider edge cases
+
+#### Overrun
+
+**Current slot is MR and the stream is still live** (`store: true`), even if the next slot's `toggleTime` has passed.
+
+- Worker **stays** on the current MR fragment until the stream ends.
+- Schedule clock alone does not force the transition.
+
+#### Natural stream-end underrun (`liveStreamEnd`)
+
+**Current slot is MR and the stream has ended** (`store: false`) while the user is on that slot.
+
+- Worker advances to the **next** schedule item **before** that item's `toggleTime`, if needed.
+- Applies to **MR → plain fragment** and **MR → MR** (next session can be shown early if its stream is already live).
+- Does **not** apply when only the *next* slot's stream is dead but the *current* slot is still live.
+
+#### Landing on a dead MR slot
+
+**User loads the page** after an MR session ended, and schedule positioning lands on that MR slot (`toggleTime` already passed, `store: false`).
+
+- `advancePastInactiveMrSlots()` walks past the dead slot **before** the first `postMessage`, so chrono-box never loads the MR fragment (no player flash).
+- Requires the dead slot's `toggleTime` to have passed; future MR windows are not entered early by this path alone.
+
+#### Future MR window
+
+**Next slot is MR and its `toggleTime` is still in the future.**
+
+- Worker does **not** advance into that slot early, even if that session's stream is already live or already dead in the store.
+- Exception: **natural stream-end underrun** — if the *current* MR stream just ended, advance into the next MR slot even when its `toggleTime` is still future.
+
+#### `avoidStreamEndFlag` (QA / preview only)
+
+When `?avoidStreamEndFlag=true`:
+
+- **Disables overrun hold** — active streams do not block `toggleTime`-based transitions.
+- **Disables `liveStreamEnd`** — stream ending does not trigger early advance.
+- **Disables landing skip** — `advancePastInactiveMrSlots()` does not skip dead MR slots.
+
+Schedule positioning follows **`toggleTime` only** (plus metadata). Use with `?serverTime=` to preview a specific moment without live MR streams affecting the timeline.
 
 ### Example Scenarios
 
@@ -236,6 +267,35 @@ The framework uses a sophisticated trigger system that considers multiple factor
 - If session1 is still active: Stays on current content
 - If session1 has ended: Proceeds to session2
 - Time trigger is ignored if MR session is active
+
+#### Scenario 2b: Mobile Rider natural underrun (MR → MR)
+
+```json
+{
+  "schedule": [
+    {
+      "pathToFragment": "/session1",
+      "toggleTime": 1234567890,
+      "mobileRider": { "sessionId": "session1" }
+    },
+    {
+      "pathToFragment": "/session2",
+      "toggleTime": 1234567899,
+      "mobileRider": { "sessionId": "session2" }
+    }
+  ]
+}
+```
+
+- Session1 ends at 1234567895 (before session2's `toggleTime`)
+- Worker advances to "/session2" immediately when session1 ends — even if session2's stream is already live
+- Does not wait until 1234567899 unless `avoidStreamEndFlag=true`
+
+#### Scenario 2c: Landing on a dead MR slot
+
+- User opens the page at 1234567900; schedule positions at "/session1" but session1 already ended
+- `advancePastInactiveMrSlots()` skips "/session1" before the first fragment load
+- User sees the next non-dead slot directly (no MR player flash)
 
 #### Scenario 3: Metadata-based Control
 ```json
@@ -335,7 +395,13 @@ This would simulate the page as if "now" is the specified timestamp, but time co
 
 ##### 3. `avoidStreamEndFlag` - Mobile Rider Stream Testing
 
-The `avoidStreamEndFlag` parameter treats all Mobile Rider streams as inactive for **blocking** purposes (no overrun hold on an active stream), so time-based schedule positioning can proceed. It does **not** skip `toggleTime` windows or fast-forward to later fragments; only natural stream-end underrun advances before `toggleTime`.
+The `avoidStreamEndFlag` parameter **disables MR stream status for schedule decisions** so authors can preview time-based positioning:
+
+- No **overrun hold** (active streams do not block transitions)
+- No **`liveStreamEnd` underrun** (stream ending does not advance early)
+- No **landing skip** of dead MR slots (`advancePastInactiveMrSlots` is off)
+
+With the flag set, the worker follows **`toggleTime` only** (plus metadata). Combine with `serverTime` to preview a specific schedule window without waiting for live streams.
 
 **Example Usage:**
 ```
@@ -343,10 +409,9 @@ https://your-site.com/event-page?avoidStreamEndFlag=true
 ```
 
 This is useful for:
-- Testing content that appears after Mobile Rider streams
-- Verifying schedule behavior without waiting for streams to end
-- Debugging transitions blocked by active streams
-- Testing fallback content when streams are unavailable
+- Previewing which fragment `toggleTime` selects at a given `serverTime`
+- Verifying schedule authoring without live MR streams blocking or skipping slots
+- Debugging transitions blocked by active streams in production (compare with and without the flag)
 
 You can combine this with `timing` or `serverTime`:
 ```

--- a/event-libs/v1/features/timing-framework/worker-traditional.js
+++ b/event-libs/v1/features/timing-framework/worker-traditional.js
@@ -338,6 +338,28 @@ class TimingWorker {
     return currentTime > numericToggleTime;
   }
 
+  async shouldSkipInactiveMrSlot(scheduleItem) {
+    if (!scheduleItem?.mobileRider) return false;
+
+    const timePassed = await this.hasToggleTimePassed(scheduleItem);
+    if (!timePassed) return false;
+
+    const mobileRiderStore = this.plugins.get('mobileRider');
+    if (!mobileRiderStore) return false;
+
+    const { sessionId } = scheduleItem.mobileRider;
+    const isActive = mobileRiderStore.get(sessionId);
+    const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+    return !avoidingStreamEnd && !isActive;
+  }
+
+  async advancePastInactiveMrSlots() {
+    while (this.nextScheduleItem && await this.shouldSkipInactiveMrSlot(this.nextScheduleItem)) {
+      this.currentScheduleItem = { ...this.nextScheduleItem };
+      this.nextScheduleItem = this.nextScheduleItem.next;
+    }
+  }
+
   /**
    * @param {Object} scheduleItem
    * @returns {boolean}
@@ -365,16 +387,7 @@ class TimingWorker {
 
     if (scheduleItem.mobileRider) {
       const timePassed = await this.hasToggleTimePassed(scheduleItem);
-      if (!timePassed) return false;
-
-      const mobileRiderStore = this.plugins.get('mobileRider');
-      if (mobileRiderStore) {
-        const { sessionId } = scheduleItem.mobileRider;
-        const isActive = mobileRiderStore.get(sessionId);
-        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
-          return true;
-        }
-      }
+      if (!timePassed && !liveStreamEnd) return false;
     }
 
     // Check metadata conditions if present
@@ -401,6 +414,8 @@ class TimingWorker {
   }
 
   async runTimer() {
+    await this.advancePastInactiveMrSlots();
+
     const shouldTrigger = await this.shouldTriggerNextSchedule(this.nextScheduleItem);
 
     let itemToSend = null;

--- a/event-libs/v1/features/timing-framework/worker.js
+++ b/event-libs/v1/features/timing-framework/worker.js
@@ -330,6 +330,28 @@ class TimingWorker {
     return currentTime > numericToggleTime;
   }
 
+  async shouldSkipInactiveMrSlot(scheduleItem) {
+    if (!scheduleItem?.mobileRider) return false;
+
+    const timePassed = await this.hasToggleTimePassed(scheduleItem);
+    if (!timePassed) return false;
+
+    const mobileRiderStore = this.plugins.get('mobileRider');
+    if (!mobileRiderStore) return false;
+
+    const { sessionId } = scheduleItem.mobileRider;
+    const isActive = mobileRiderStore.get(sessionId);
+    const avoidingStreamEnd = this.testingManager.shouldAvoidStreamEnd();
+    return !avoidingStreamEnd && !isActive;
+  }
+
+  async advancePastInactiveMrSlots() {
+    while (this.nextScheduleItem && await this.shouldSkipInactiveMrSlot(this.nextScheduleItem)) {
+      this.currentScheduleItem = { ...this.nextScheduleItem };
+      this.nextScheduleItem = this.nextScheduleItem.next;
+    }
+  }
+
   /**
    * @param {Object} scheduleItem
    * @returns {boolean}
@@ -358,16 +380,7 @@ class TimingWorker {
 
     if (scheduleItem.mobileRider) {
       const timePassed = await this.hasToggleTimePassed(scheduleItem);
-      if (!timePassed) return false;
-
-      const mobileRiderStore = this.plugins.get('mobileRider');
-      if (mobileRiderStore) {
-        const { sessionId } = scheduleItem.mobileRider;
-        const isActive = mobileRiderStore.get(sessionId);
-        if (!this.testingManager.shouldAvoidStreamEnd() && !isActive) {
-          return true;
-        }
-      }
+      if (!timePassed && !liveStreamEnd) return false;
     }
 
     // Check metadata conditions if present
@@ -396,6 +409,8 @@ class TimingWorker {
   }
 
   async runTimer() {
+    await this.advancePastInactiveMrSlots();
+
     const shouldTrigger = await this.shouldTriggerNextSchedule(this.nextScheduleItem);
 
     let itemToSend = null;

--- a/test/unit/blocks/mobile-rider/mobile-rider.test.js
+++ b/test/unit/blocks/mobile-rider/mobile-rider.test.js
@@ -359,6 +359,41 @@ describe('Mobile Rider Module', () => {
         const onCall = player.on.getCalls().find((c) => c.args[0] === 'streamend');
         expect(() => onCall.args[1]()).to.not.throw();
       });
+
+      it('should not re-embed after streamend when pending rAF has not run', async () => {
+        globalThis.mobilerider.embed = sinon.stub();
+        riderInstance.mainID = 'main-video';
+        riderInstance.store = { get: sinon.stub().returns(true), set: sinon.stub() };
+
+        const videoWrapper = document.createElement('div');
+        videoWrapper.className = 'video-wrapper';
+        el.appendChild(videoWrapper);
+        riderInstance.wrap = videoWrapper;
+        riderInstance.isEmbedding = false;
+
+        riderInstance.injectPlayer('test-video', 'test-skin');
+        globalThis.__mr_player = { off: sinon.stub(), on: sinon.stub(), dispose: sinon.stub() };
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+        const embedCountAfterFirst = globalThis.mobilerider.embed.callCount;
+        const onCall = globalThis.__mr_player.on.getCalls().find((c) => c.args[0] === 'streamend');
+        expect(onCall).to.not.be.undefined;
+
+        let pendingRaf = null;
+        window.requestAnimationFrame.restore();
+        sinon.stub(window, 'requestAnimationFrame').callsFake((cb) => {
+          pendingRaf = cb;
+          return 2;
+        });
+        riderInstance.isEmbedding = false;
+        riderInstance.injectPlayer('test-video', 'test-skin');
+
+        onCall.args[1]();
+        expect(riderInstance.wrap.querySelector('.mobile-rider-container.is-hidden')).to.not.be.null;
+
+        pendingRaf?.();
+        expect(globalThis.mobilerider.embed.callCount).to.equal(embedCountAfterFirst);
+      });
     });
 
     describe('embed error handling', () => {
@@ -597,6 +632,27 @@ describe('Mobile Rider Module', () => {
       // The plugin file exists so the import succeeds;
       // verify init completed without errors
       expect(riderInstance.el).to.equal(el);
+    });
+
+    it('should not embed player when stream is already inactive in chrono-box', async () => {
+      sessionStorage.setItem('chrono-box-tab-id', 'test-tab-id');
+
+      const { mobileRiderStore } = await import(
+        '../../../../event-libs/v1/features/timing-framework/plugins/mobile-rider/plugin.js'
+      );
+      mobileRiderStore.set('test-video-123', false);
+
+      document.body.innerHTML = `
+        <div class="chrono-box">
+          ${defaultHtml}
+        </div>
+      `;
+      const el = document.querySelector('.mobile-rider');
+      riderInstance = init(el);
+      await new Promise((resolve) => { setTimeout(resolve, 300); });
+
+      expect(globalThis.mobilerider.embed.called).to.be.false;
+      expect(el.querySelector('.mobile-rider-player.is-hidden')).to.not.be.null;
     });
   });
 

--- a/test/unit/features/timing-framework/worker.test.js
+++ b/test/unit/features/timing-framework/worker.test.js
@@ -155,6 +155,44 @@ describe('TimingWorker', () => {
       expect(result).to.be.true;
     });
 
+    it('should advance to next MR slot when prior stream ended even if next toggleTime is in the future', async () => {
+      const nextItem = {
+        toggleTime: Date.now() + 600000,
+        pathToFragment: '/session2',
+        mobileRider: { sessionId: 'session2' },
+      };
+
+      worker.currentScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/session1',
+      };
+      worker.plugins.set('mobileRider', new Map([
+        ['session1', false],
+        ['session2', true],
+      ]));
+
+      const result = await worker.shouldTriggerNextSchedule(nextItem);
+      expect(result).to.be.true;
+    });
+
+    it('should skip inactive MR slots on load and post the next fragment', async () => {
+      worker.currentScheduleItem = { pathToFragment: '/prev' };
+      worker.nextScheduleItem = {
+        mobileRider: { sessionId: 'session1' },
+        pathToFragment: '/mr-ended',
+        next: {
+          pathToFragment: '/next',
+          next: null,
+        },
+      };
+      worker.plugins.set('mobileRider', new Map([['session1', false]]));
+
+      await worker.runTimer();
+
+      expect(mockPostMessage.calledOnce).to.be.true;
+      expect(mockPostMessage.firstCall.args[0].pathToFragment).to.equal('/next');
+    });
+
     it('should handle mobileRider underrun scenario', async () => {
       const nextItem = {
         mobileRider: { sessionId: 'session1' },


### PR DESCRIPTION
## Resolves

[MWPW-199451](https://jira.corp.adobe.com/browse/MWPW-199451), [MWPW-199449](https://jira.corp.adobe.com/browse/MWPW-199449)

## Summary

- **Landing on dead MR slot:** `advancePastInactiveMrSlots()` / `shouldSkipInactiveMrSlot()` run at the start of each `runTimer()` tick and skip MR slots whose `toggleTime` has passed and stream is inactive **before** the first `postMessage` — fixes the MR player flash when a late visitor lands on an already-ended session.
- **Worker (`worker.js` + `worker-traditional.js`):** Removed the old `shouldTriggerNextSchedule` underrun shortcut (`return true` for inactive next MR) that posted the dead MR fragment first, then advanced on the next poll. **MR → MR natural underrun:** when the **current** MR stream ends (`liveStreamEnd`), advance to the next MR slot even if its `toggleTime` is still in the future (`if (!timePassed && !liveStreamEnd) return false`).
- **mobile-rider.js:** Skip `injectPlayer` on init inside chrono-box when the store already reports inactive; resolve `video-id` vs `videoid`. rAF/`streamend` guards prevent a stale embed after stream end.
- **README:** Document MR overrun, natural underrun, landing skip, future MR window, and corrected `avoidStreamEndFlag` behavior.

## Test plan

- [x] `npx wtr test/unit/features/timing-framework/worker.test.js test/unit/blocks/mobile-rider/mobile-rider.test.js --node-resolve --port=2000` (95 passed)
- [ ] **Landing (primary):** After MR session ended, hard refresh or new tab — first content is the **next** slot, **no** MR player flash
- [ ] **Overrun:** MR still live past `toggleTime` — player stays until stream ends
- [ ] **Natural underrun (MR → fragment):** Current MR ends before next slot `toggleTime` — advance early to next fragment
- [ ] **Natural underrun (MR → MR):** Session 1 ends before Session 2 `toggleTime`, Session 2 already live — advance to Session 2 early
- [ ] **Future MR window:** Session 1 still live, Session 2 `toggleTime` future — do **not** enter Session 2 early
- [ ] **Stream end while watching:** Player stops on `streamend`, no re-embed; advances to next slot within poll interval (~0.5–1.5s)
- [ ] **`?avoidStreamEndFlag=true` + `?serverTime=`:** Preview follows `toggleTime` only; dead MR slots are **not** skipped on load (authoring mode — not prod behavior)

## Notes

`worker.test.js` targets the module worker as the reference implementation; `worker-traditional.js` is kept logically in sync (chrono-box production blob worker path). Live stream end while watching is unchanged in mechanism (poll + `liveStreamEnd`); this PR fixes load-time dead MR flash and enables MR → MR early advance when the current stream ends.