### PR TITLE
[MWPW-194614] feat(events-form): inject submit button when rsvp-config has no submit button

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -863,7 +863,7 @@ function addTerms(form, terms) {
   submitWrapper.before(termsWrapper);
 }
 
-function getRsvpConfigFromMeta() {
+export function getRsvpConfigFromMeta() {
   const raw = getMetadata('rsvp-config');
   if (!raw) return null;
 
@@ -880,6 +880,10 @@ function getRsvpConfigFromMeta() {
       }
       return field;
     });
+
+    if (!data.some((f) => f.type === 'submit')) {
+      data.push({ field: 'Submit', type: 'submit', label: 'Submit', required: '', options: '' });
+    }
 
     return { data };
   } catch (error) {

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -443,7 +443,7 @@ function createInput({
   type, field, placeholder, required, defval, pattern, title, limit,
 }) {
   const placeholderText = placeholder ? dictionaryManager.getValue(placeholder, 'rsvp-fields') : '';
-  const isPhoneField = type === 'tel' || type === 'phone' || (typeof field === 'string' && PHONE_FIELD_RE.test(field));
+  const isPhoneField = type === 'tel' || type === 'phone' || (type !== 'text' && typeof field === 'string' && PHONE_FIELD_RE.test(field));
   const attrs = { type: isPhoneField ? 'tel' : type, id: field, placeholder: placeholderText, value: defval };
   if (isPhoneField) {
     attrs.inputmode = 'tel';

--- a/event-libs/v1/utils/constances.js
+++ b/event-libs/v1/utils/constances.js
@@ -150,5 +150,5 @@ export const FALLBACK_LOCALES = {
   za: { ietf: 'en-GB', tk: 'hah7vzn.css' },
 };
 export const LATEST_VERSION = 'v1';
-export const PHONE_FIELD_RE = /phone(?![a-z])/i;
+export const PHONE_FIELD_RE = /phone/i;
 export const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';

--- a/event-libs/v1/utils/constances.js
+++ b/event-libs/v1/utils/constances.js
@@ -150,5 +150,5 @@ export const FALLBACK_LOCALES = {
   za: { ietf: 'en-GB', tk: 'hah7vzn.css' },
 };
 export const LATEST_VERSION = 'v1';
-export const PHONE_FIELD_RE = /phone/i;
+export const PHONE_FIELD_RE = /phone(?![a-z])/i;
 export const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -857,6 +857,83 @@ describe('Events Form', () => {
       expect(errorEl.textContent).to.equal('event-full-no-waitlist-error-msg');
     });
   });
+
+  describe('getRsvpConfigFromMeta', () => {
+    let metaEl;
+
+    afterEach(() => {
+      metaEl?.remove();
+      metaEl = null;
+      document.head.querySelectorAll('meta[name="rsvp-config"]').forEach((el) => el.remove());
+    });
+
+    function setRsvpConfigMeta(value) {
+      metaEl = document.createElement('meta');
+      metaEl.setAttribute('name', 'rsvp-config');
+      metaEl.content = JSON.stringify(value);
+      document.head.appendChild(metaEl);
+    }
+
+    it('returns null when rsvp-config meta is absent', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      expect(getRsvpConfigFromMeta()).to.equal(null);
+    });
+
+    it('returns null when rsvpFormFields is empty', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({ rsvpFormFields: [] });
+      expect(getRsvpConfigFromMeta()).to.equal(null);
+    });
+
+    it('appends a submit field when none exists in rsvpFormFields', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          { field: 'industry', label: 'Industry', type: 'select', required: true, options: [] },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      const submitField = result.data.find((f) => f.type === 'submit');
+      expect(submitField).to.exist;
+      expect(submitField.field).to.equal('Submit');
+      expect(submitField.label).to.equal('Submit');
+    });
+
+    it('does not append a duplicate submit field when one already exists', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          { field: 'industry', label: 'Industry', type: 'select', required: false, options: [] },
+          { field: 'Submit', label: 'Submit', type: 'submit', required: false, options: [] },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      const submitFields = result.data.filter((f) => f.type === 'submit');
+      expect(submitFields).to.have.lengthOf(1);
+    });
+
+    it('maps required boolean true to "x"', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          { field: 'title', label: 'Title', type: 'text', required: true, options: [] },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].required).to.equal('x');
+    });
+
+    it('maps required boolean false to empty string', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          { field: 'title', label: 'Title', type: 'text', required: false, options: [] },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].required).to.equal('');
+    });
+  });
 });
 
 describe('stripTags', () => {

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -302,11 +302,11 @@ describe('Events Form', () => {
   });
 
   describe('createInput - phone field defaults', () => {
-    const PHONE_FIELD_RE = /phone(?![a-z])/i;
+    const PHONE_FIELD_RE = /phone/i;
     const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
 
     function simulateCreatePhoneAwareInput({ type, field, pattern, title }) {
-      const isPhoneField = type === 'tel' || type === 'phone' || (typeof field === 'string' && PHONE_FIELD_RE.test(field));
+      const isPhoneField = type === 'tel' || type === 'phone' || (type !== 'text' && typeof field === 'string' && PHONE_FIELD_RE.test(field));
       const attrs = { type: isPhoneField ? 'tel' : type, id: field };
       if (isPhoneField) {
         attrs.inputmode = 'tel';
@@ -320,8 +320,8 @@ describe('Events Form', () => {
       return input;
     }
 
-    it('applies tel type, pattern, inputmode for businessPhone field', () => {
-      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'businessPhone' });
+    it('applies tel type, pattern, inputmode for businessPhone field (legacy: no explicit type)', () => {
+      const input = simulateCreatePhoneAwareInput({ type: undefined, field: 'businessPhone' });
       expect(input.getAttribute('type')).to.equal('tel');
       expect(input.getAttribute('inputmode')).to.equal('tel');
       expect(input.getAttribute('autocomplete')).to.equal('tel');
@@ -329,10 +329,17 @@ describe('Events Form', () => {
       expect(input.hasAttribute('title')).to.be.false;
     });
 
-    it('applies same defaults for mobilePhone field', () => {
-      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'mobilePhone' });
+    it('applies same defaults for mobilePhone field (legacy: no explicit type)', () => {
+      const input = simulateCreatePhoneAwareInput({ type: undefined, field: 'mobilePhone' });
       expect(input.getAttribute('type')).to.equal('tel');
       expect(input.getAttribute('pattern')).to.equal(PHONE_PATTERN);
+    });
+
+    it('does not apply phone defaults when explicit type is text, even if field name contains phone', () => {
+      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'businessPhone' });
+      expect(input.getAttribute('type')).to.equal('text');
+      expect(input.hasAttribute('pattern')).to.be.false;
+      expect(input.hasAttribute('inputmode')).to.be.false;
     });
 
     it('does not apply phone defaults for non-phone fields', () => {

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -302,7 +302,7 @@ describe('Events Form', () => {
   });
 
   describe('createInput - phone field defaults', () => {
-    const PHONE_FIELD_RE = /phone/i;
+    const PHONE_FIELD_RE = /phone(?![a-z])/i;
     const PHONE_PATTERN = '^\\+?[\\d\\s\\(\\)\\.\\-]{7,20}$';
 
     function simulateCreatePhoneAwareInput({ type, field, pattern, title }) {
@@ -337,6 +337,13 @@ describe('Events Form', () => {
 
     it('does not apply phone defaults for non-phone fields', () => {
       const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'firstName' });
+      expect(input.getAttribute('type')).to.equal('text');
+      expect(input.hasAttribute('pattern')).to.be.false;
+      expect(input.hasAttribute('inputmode')).to.be.false;
+    });
+
+    it('does not apply phone defaults for fields that contain "phone" as a substring (e.g. Phonetic First Name)', () => {
+      const input = simulateCreatePhoneAwareInput({ type: 'text', field: 'Phonetic First Name' });
       expect(input.getAttribute('type')).to.equal('text');
       expect(input.hasAttribute('pattern')).to.be.false;
       expect(input.hasAttribute('inputmode')).to.be.false;


### PR DESCRIPTION
When rsvp-config metadata drives the RSVP form, the stored rsvpFormFields only contain user-facing data fields — no submit button. This caused a null-ref crash in addTerms because .events-form-submit-wrapper was never created.

getRsvpConfigFromMeta now appends a submit field if none is present in the mapped data, ensuring the form always has a submit wrapper.

Resolves: [MWPW-194614](https://jira.corp.adobe.com/browse/MWPW-194614)

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/kr/.snapshots/esp-dev/dxdatest/rsvp-test-config/new-york/ny/us/2026-07-31?timing=1785481199990&espenv=dev&martech=off
- After: https://main--da-events--adobecom.aem.page/kr/.snapshots/esp-dev/dxdatest/rsvp-test-config/new-york/ny/us/2026-07-31?timing=1785481199990&espenv=dev&eventlibs=MWPW-194614&martech=off
