### PR TITLE
fix(mobile-rider): re-attach streamend listener on every ASL toggle

### DIFF
--- a/event-libs/v1/blocks/mobile-rider/mobile-rider.js
+++ b/event-libs/v1/blocks/mobile-rider/mobile-rider.js
@@ -55,7 +55,6 @@ class MobileRider {
   constructor(el) {
     this.el = el;
     this.isEmbedding = false;
-    this._endListenerAttached = false;
     this.init();
   }
 
@@ -214,7 +213,7 @@ class MobileRider {
     const tryAttach = () => {
       const mainTracked = this.#storeHas(this.mainID);
       const vidTracked = this.#storeHas(vid);
-      if (mainTracked || vidTracked) {
+      if ((mainTracked || vidTracked) && window.__mr_player?.on) {
         this.#attachEndListener(vid);
         return true;
       }
@@ -253,7 +252,6 @@ class MobileRider {
 
       window.__mr_player?.dispose?.();
       window.__mr_player = null;
-      this._endListenerAttached = false;
     });
   }
 
@@ -318,16 +316,18 @@ class MobileRider {
           clearInterval(currentCheck);
           currentCheck = null;
           btn.addEventListener('click', () => {
-            try {
-              if (this.store && !this._endListenerAttached) {
-                this._endListenerAttached = true;
-                this.#attachEndListener(vid);
-              }
-            } catch (e) {
-              this.log(`ASL end-listener error: ${e.message}`);
-            }
             if (!container.classList.contains(CONFIG.ASL.TOGGLE_CLASS)) {
               container.classList.add(CONFIG.ASL.TOGGLE_CLASS);
+            }
+            // ASL toggle may replace window.__mr_player; defer so new player is ready
+            if (this.store) {
+              requestAnimationFrame(() => {
+                try {
+                  this.#maybeAttachEndListener(vid);
+                } catch (e) {
+                  this.log(`ASL end-listener error: ${e.message}`);
+                }
+              });
             }
             poll();
           }, { once: true });

--- a/test/unit/blocks/mobile-rider/mobile-rider.test.js
+++ b/test/unit/blocks/mobile-rider/mobile-rider.test.js
@@ -218,6 +218,23 @@ describe('Mobile Rider Module', () => {
         expect(player.on.calledWith('streamend')).to.be.false;
         window.history.replaceState({}, '', window.location.pathname);
       });
+
+      it('should retry attaching end listener until window.__mr_player is ready', async () => {
+        riderInstance.mainID = 'main-video';
+        riderInstance.store = { get: sinon.stub().returns(true) };
+
+        // Player absent when RAF fires — tryAttach must not silently drop the listener
+        globalThis.__mr_player = null;
+        riderInstance.injectPlayer('test-video', 'test-skin');
+        await new Promise((resolve) => { setTimeout(resolve, 30); });
+
+        const player = { off: sinon.stub(), on: sinon.stub() };
+        globalThis.__mr_player = player;
+        // Wait for retry tick (ATTACH_INTERVAL_MS = 5ms)
+        await new Promise((resolve) => { setTimeout(resolve, 30); });
+
+        expect(player.on.calledWith('streamend')).to.be.true;
+      });
     });
 
     describe('setStatus', () => {
@@ -749,6 +766,74 @@ describe('Mobile Rider Module', () => {
       btn.click();
       btn.click(); // second click on same node — { once: true } already removed the handler
       expect(addCount).to.equal(1);
+    });
+
+    it('re-attaches streamend listener to the new player on each ASL toggle', async () => {
+      riderInstance.mainID = 'vid';
+      riderInstance.store = { get: sinon.stub().returns(true) };
+
+      riderInstance.injectPlayer('vid', 'skin', 'asl-id');
+      const player1 = { off: sinon.stub(), on: sinon.stub() };
+      globalThis.__mr_player = player1;
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      const container = riderInstance.wrap.querySelector('.mobile-rider-container');
+      const btn1 = document.createElement('button');
+      btn1.id = 'asl-button';
+      container.appendChild(btn1);
+      await new Promise((resolve) => { setTimeout(resolve, 200); });
+
+      // First toggle: switch to ASL — new player instance appears
+      const player2 = { off: sinon.stub(), on: sinon.stub() };
+      globalThis.__mr_player = player2;
+      btn1.click();
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+      expect(player2.on.calledWith('streamend')).to.be.true;
+
+      // Second toggle: switch back — another player swap
+      btn1.remove();
+      const btn2 = document.createElement('button');
+      btn2.id = 'asl-button';
+      container.appendChild(btn2);
+      await new Promise((resolve) => { setTimeout(resolve, 200); });
+
+      const player3 = { off: sinon.stub(), on: sinon.stub() };
+      globalThis.__mr_player = player3;
+      btn2.click();
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+      expect(player3.on.calledWith('streamend')).to.be.true;
+    });
+
+    it('streamend on ASL player updates store and disposes player', async () => {
+      riderInstance.mainID = 'vid';
+      const mockStore = { get: sinon.stub().returns(true), set: sinon.stub() };
+      riderInstance.store = mockStore;
+
+      riderInstance.injectPlayer('vid', 'skin', 'asl-id');
+      const initialPlayer = { off: sinon.stub(), on: sinon.stub(), dispose: sinon.stub() };
+      globalThis.__mr_player = initialPlayer;
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      const container = riderInstance.wrap.querySelector('.mobile-rider-container');
+      const btn = document.createElement('button');
+      btn.id = 'asl-button';
+      container.appendChild(btn);
+      await new Promise((resolve) => { setTimeout(resolve, 200); });
+
+      // Click ASL — player replaced by ASL player
+      const aslPlayer = { off: sinon.stub(), on: sinon.stub(), dispose: sinon.stub() };
+      globalThis.__mr_player = aslPlayer;
+      btn.click();
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      const onCall = aslPlayer.on.getCalls().find((c) => c.args[0] === 'streamend');
+      expect(onCall, 'streamend listener attached to ASL player').to.not.be.undefined;
+
+      // Fire streamend on ASL player
+      onCall.args[1]();
+      expect(mockStore.set.calledWith('vid', false)).to.be.true;
+      expect(aslPlayer.dispose.called).to.be.true;
+      expect(globalThis.__mr_player).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Resolves

[MWPW-200070](https://jira.corp.adobe.com/browse/MWPW-200070)

## Summary

- **ASL toggle drops `streamend` listener:** `_endListenerAttached` blocked re-attachment after the first ASL click. Subsequent toggles (ASL → non-ASL, non-ASL → ASL) silently lost the listener so chrono-box never received the stream-ended flag.
- **Timing race on player swap:** `#attachEndListener` bound synchronously to `window.__mr_player` at click-time. If mobilerider replaces the player instance during the ASL toggle, the listener ends up on the discarded player. Deferred re-attachment via `requestAnimationFrame` ensures the new player is set before we bind.
- **Player-readiness guard in retry loop:** `#maybeAttachEndListener`'s `tryAttach` only gated on store readiness; if `window.__mr_player` wasn't set yet, `on?.()` silently no-oped and the listener was permanently lost. Added `&& window.__mr_player?.on` so the retry waits for the player instance, not just the store.
- **Cleanup:** Removed `_endListenerAttached` entirely — `#attachEndListener` already prevents listener stacking via `off` before `on`, so the flag was redundant and harmful.

## Test plan

- [ ] **ASL → streamend:** Switch to ASL player; let stream end — player hides and chrono-box advances to next slot
- [ ] **non-ASL → streamend after toggle back:** Switch to ASL, switch back to non-ASL; let stream end — same result as above
- [ ] **Multiple toggles:** Toggle ASL on/off several times; streamend still fires correctly on whichever player is active
- [ ] **No ASL:** Standard non-ASL MR flow unchanged — streamend still advances chrono-box

## Notes

`#attachEndListener` uses `off`/`on` to prevent stacking, so calling `#maybeAttachEndListener` on every toggle is safe regardless of how many times the button is clicked.
