### PR TITLE
Revert "fix(promotional-content): rehydrate custom-attribute promotional items"

### DIFF
--- a/event-libs/v1/blocks/promotional-content/promotional-content.js
+++ b/event-libs/v1/blocks/promotional-content/promotional-content.js
@@ -11,60 +11,29 @@ async function getPromotionalContentUrl() {
   const { miloConfig } = eventConfig;
   const miloLibs = miloConfig?.miloLibs ? miloConfig.miloLibs : LIBS;
   const { getLocale } = await import(`${miloLibs}/utils/utils.js`);
-
+  
   const { prefix } = getLocale(miloConfig?.locales || FALLBACK_LOCALES);
-
+  
   // Get the domain from import.meta.url
   const moduleUrl = new URL(import.meta.url);
   const domain = `${moduleUrl.protocol}//${moduleUrl.host}`;
-
+  
   return `${domain}${prefix}/event-libs/assets/configs/promotional-content.json`;
 }
 
-async function rehydratePromotionalItems(promotionalItems) {
-  if (promotionalItems.length === 0) return [];
-
-  try {
-    const url = await getPromotionalContentUrl();
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch promotional content: ${response.status}`);
-    }
-
-    const json = await response.json();
-    const data = json.data || [];
-
-    if (!data || data.length === 0) {
-      window.lana?.log(`Error: No promotional content found at ${url}`);
-      return [];
-    }
-
-    return promotionalItems.map((item) => data.find((content) => content.name === item));
-  } catch (error) {
-    window.lana?.log(`Error fetching promotional content: ${JSON.stringify(error)}`);
-    return [];
-  }
-}
-
-async function getPromotionalContent() {
+function getPromotionalContent() {
   const customAttributesMetadata = getMetadata('custom-attributes');
   if (!customAttributesMetadata) return [];
 
-  let promotionalItems = [];
   try {
     const customAttributes = JSON.parse(customAttributesMetadata);
-    promotionalItems = customAttributes
-      .filter((attr) => attr.attribute?.replace(/\s+/g, '').toLowerCase() === 'promotionalitems')
-      .flatMap((attr) => (Array.isArray(attr.values)
-        ? attr.values.map((v) => v?.value).filter(Boolean)
-        : [attr.value]).filter(Boolean));
+    return customAttributes
+      .filter((attr) => attr.attribute === 'promotionalItems' && attr.value)
+      .map((attr) => attr.value);
   } catch (error) {
     window.lana?.log(`Error parsing custom-attributes: ${JSON.stringify(error)}`);
     return [];
   }
-
-  return rehydratePromotionalItems(promotionalItems);
 }
 
 async function getLegacyPromotionalContent() {
@@ -85,7 +54,37 @@ async function getLegacyPromotionalContent() {
     }
   }
 
-  return rehydratePromotionalItems(promotionalItems);
+  // If no promotional items, return early to avoid unnecessary imports and fetch
+  if (promotionalItems.length === 0) {
+    return [];
+  }
+
+  try {
+    const url = await getPromotionalContentUrl();
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch promotional content: ${response.status}`);
+    }
+
+    const json = await response.json();
+    const data = json.data || [];
+
+    if (!data || data.length === 0) {
+      window.lana?.log(`Error: No promotional content found at ${url}`);
+      return [];
+    }
+
+    const rehydratedPromotionalItems = promotionalItems.map((item) => {
+      const promotionalItem = data.find((content) => content.name === item);
+      return promotionalItem;
+    });
+
+    return rehydratedPromotionalItems;
+  } catch (error) {
+    window.lana?.log(`Error fetching promotional content: ${JSON.stringify(error)}`);
+    return [];
+  }
 }
 
 export function addMediaReversedClass(el) {
@@ -102,13 +101,12 @@ export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  let rehydratedItems = await getPromotionalContent();
+  let fragmentUrls = getPromotionalContent();
 
-  if (!rehydratedItems.length) {
-    rehydratedItems = await getLegacyPromotionalContent();
+  if (!fragmentUrls.length) {
+    const legacyItems = await getLegacyPromotionalContent();
+    fragmentUrls = (legacyItems ?? []).map((item) => item?.['fragment-path']).filter(Boolean);
   }
-
-  const fragmentUrls = (rehydratedItems ?? []).map((item) => item?.['fragment-path']).filter(Boolean);
 
   if (!fragmentUrls?.length) return;
 

--- a/test/unit/blocks/promotional-content/promotional-content.test.js
+++ b/test/unit/blocks/promotional-content/promotional-content.test.js
@@ -5,24 +5,12 @@ import init, { addMediaReversedClass } from '../../../../event-libs/v1/blocks/pr
 
 const CUSTOM_ATTRS_WITH_PROMO = JSON.stringify([
   { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
-  { attributeId: '732fdd75', attribute: 'promotionalItems', value: 'Acrobat' },
+  { attributeId: '732fdd75', attribute: 'promotionalItems', value: 'https://example.com/fragments/acrobat' },
   { attributeId: '50578a75', attribute: 'technicalLevel', value: 'advanced' },
 ]);
 
 const CUSTOM_ATTRS_WITHOUT_PROMO = JSON.stringify([
   { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
-]);
-
-// Real EMC shape: attribute label is "Promotional Items" and values are nested objects.
-const CUSTOM_ATTRS_WITH_PROMO_VALUES_SHAPE = JSON.stringify([
-  {
-    attributeId: '0d433aa1-0a5a-4836-9146-c6a97bdf08bc',
-    attribute: 'Promotional Items',
-    values: [
-      { valueId: '4dbc5426-c8e7-4b94-becd-3048b265c61c', value: 'Creative Apprenticeship' },
-      { value: 'Adobe Firefly' },
-    ],
-  },
 ]);
 
 // Bypasses the /libs/utils/utils.js dynamic import (404s in unit tests) so the legacy
@@ -73,13 +61,9 @@ describe('Promotional Content Block', () => {
       expect(fetchStub.called).to.be.false;
     });
 
-    it('rehydrates the promotional item name via promotional-content.json', async () => {
+    it('does not fetch promotional-content.json when custom-attributes provides a fragment URL', async () => {
       addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
-      addMeta('promotional-content-location', MOCK_PROMO_CONFIG_URL);
-      fetchStub.resolves({
-        ok: true,
-        json: () => Promise.resolve({ data: [{ name: 'Acrobat', 'fragment-path': '/fragments/acrobat' }] }),
-      });
+      fetchStub.resolves({ ok: true, text: () => Promise.resolve('<div></div>') });
 
       try {
         await init(el);
@@ -88,32 +72,7 @@ describe('Promotional Content Block', () => {
       }
 
       const configFetched = fetchStub.args.some(([url]) => String(url).includes('promotional-content.json'));
-      expect(configFetched).to.be.true;
-    });
-
-    it('rehydrates promotional items from the "Promotional Items" / values[] shape', async () => {
-      addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO_VALUES_SHAPE);
-      addMeta('promotional-content-location', MOCK_PROMO_CONFIG_URL);
-      fetchStub.resolves({
-        ok: true,
-        json: () => Promise.resolve({
-          data: [
-            { name: 'Creative Apprenticeship', 'fragment-path': '/fragments/creative-apprenticeship' },
-            { name: 'Adobe Firefly', 'fragment-path': '/fragments/adobe-firefly' },
-          ],
-        }),
-      });
-
-      try {
-        await init(el);
-      } catch (e) {
-        // loadFragment dynamic import is not available in unit test env
-      }
-
-      const configFetchedForValuesShape = fetchStub.args.some(
-        ([url]) => String(url).includes('promotional-content.json'),
-      );
-      expect(configFetchedForValuesShape).to.be.true;
+      expect(configFetched).to.be.false;
     });
   });
 


### PR DESCRIPTION
Reverts adobecom/event-libs#180

Some fix is needed from BE too, will re-raise after that with additional changes if needed.
The logic should depend on the `name` instead of the `attribute` using regex. It should also load fragments from the path in the custom-attributes in metadata instead of the config sheet.