### PR TITLE
fix(promotional-content): match custom-attribute promotionalItems by name field

### DIFF
--- a/event-libs/v1/blocks/promotional-content/promotional-content.js
+++ b/event-libs/v1/blocks/promotional-content/promotional-content.js
@@ -21,26 +21,7 @@ async function getPromotionalContentUrl() {
   return `${domain}${prefix}/event-libs/assets/configs/promotional-content.json`;
 }
 
-async function resolveFragmentUrl(path) {
-  if (!path || /^https?:\/\//i.test(path)) return path;
-
-  let prefix = '';
-  try {
-    const eventConfig = getEventConfig();
-    const { miloConfig } = eventConfig;
-    const miloLibs = miloConfig?.miloLibs ? miloConfig.miloLibs : LIBS;
-    const { getLocale } = await import(`${miloLibs}/utils/utils.js`);
-    ({ prefix } = getLocale(miloConfig?.locales || FALLBACK_LOCALES));
-  } catch (error) {
-    window.lana?.log(`Error resolving locale for promotional content: ${JSON.stringify(error)}`);
-  }
-
-  const moduleUrl = new URL(import.meta.url);
-  const domain = `${moduleUrl.protocol}//${moduleUrl.host}`;
-  return `${domain}${prefix}${path}`;
-}
-
-export async function getPromotionalContent() {
+export function getPromotionalContent() {
   const customAttributesMetadata = getMetadata('custom-attributes');
   if (!customAttributesMetadata) return [];
 
@@ -49,10 +30,7 @@ export async function getPromotionalContent() {
     const promotionalItemsAttr = customAttributes.find((attr) => attr.name === 'promotionalItems' && attr.values);
     if (!promotionalItemsAttr) return [];
 
-    const fragmentUrls = await Promise.all(
-      promotionalItemsAttr.values.map((v) => resolveFragmentUrl(v?.value)),
-    );
-    return fragmentUrls.filter(Boolean);
+    return promotionalItemsAttr.values.map((v) => v?.value).filter(Boolean);
   } catch (error) {
     window.lana?.log(`Error parsing custom-attributes: ${JSON.stringify(error)}`);
     return [];
@@ -124,7 +102,7 @@ export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  let fragmentUrls = await getPromotionalContent();
+  let fragmentUrls = getPromotionalContent();
 
   if (!fragmentUrls.length) {
     const legacyItems = await getLegacyPromotionalContent();

--- a/event-libs/v1/blocks/promotional-content/promotional-content.js
+++ b/event-libs/v1/blocks/promotional-content/promotional-content.js
@@ -28,8 +28,9 @@ function getPromotionalContent() {
   try {
     const customAttributes = JSON.parse(customAttributesMetadata);
     return customAttributes
-      .filter((attr) => attr.attribute === 'promotionalItems' && attr.value)
-      .map((attr) => attr.value);
+      .filter((attr) => attr.name === 'promotionalItems')
+      .flatMap((attr) => (Array.isArray(attr.values) ? attr.values.map((v) => v?.value) : [attr.value]))
+      .filter(Boolean);
   } catch (error) {
     window.lana?.log(`Error parsing custom-attributes: ${JSON.stringify(error)}`);
     return [];

--- a/event-libs/v1/blocks/promotional-content/promotional-content.js
+++ b/event-libs/v1/blocks/promotional-content/promotional-content.js
@@ -21,16 +21,38 @@ async function getPromotionalContentUrl() {
   return `${domain}${prefix}/event-libs/assets/configs/promotional-content.json`;
 }
 
-function getPromotionalContent() {
+async function resolveFragmentUrl(path) {
+  if (!path || /^https?:\/\//i.test(path)) return path;
+
+  let prefix = '';
+  try {
+    const eventConfig = getEventConfig();
+    const { miloConfig } = eventConfig;
+    const miloLibs = miloConfig?.miloLibs ? miloConfig.miloLibs : LIBS;
+    const { getLocale } = await import(`${miloLibs}/utils/utils.js`);
+    ({ prefix } = getLocale(miloConfig?.locales || FALLBACK_LOCALES));
+  } catch (error) {
+    window.lana?.log(`Error resolving locale for promotional content: ${JSON.stringify(error)}`);
+  }
+
+  const moduleUrl = new URL(import.meta.url);
+  const domain = `${moduleUrl.protocol}//${moduleUrl.host}`;
+  return `${domain}${prefix}${path}`;
+}
+
+export async function getPromotionalContent() {
   const customAttributesMetadata = getMetadata('custom-attributes');
   if (!customAttributesMetadata) return [];
 
   try {
     const customAttributes = JSON.parse(customAttributesMetadata);
-    return customAttributes
-      .filter((attr) => attr.name === 'promotionalItems')
-      .flatMap((attr) => (Array.isArray(attr.values) ? attr.values.map((v) => v?.value) : [attr.value]))
-      .filter(Boolean);
+    const promotionalItemsAttr = customAttributes.find((attr) => attr.name === 'promotionalItems' && attr.values);
+    if (!promotionalItemsAttr) return [];
+
+    const fragmentUrls = await Promise.all(
+      promotionalItemsAttr.values.map((v) => resolveFragmentUrl(v?.value)),
+    );
+    return fragmentUrls.filter(Boolean);
   } catch (error) {
     window.lana?.log(`Error parsing custom-attributes: ${JSON.stringify(error)}`);
     return [];
@@ -102,7 +124,7 @@ export default async function init(el) {
   const eventConfig = getEventConfig();
   const miloLibs = eventConfig?.miloConfig?.miloLibs ? eventConfig.miloConfig.miloLibs : LIBS;
 
-  let fragmentUrls = getPromotionalContent();
+  let fragmentUrls = await getPromotionalContent();
 
   if (!fragmentUrls.length) {
     const legacyItems = await getLegacyPromotionalContent();

--- a/test/unit/blocks/promotional-content/mocks/libs/utils/utils.js
+++ b/test/unit/blocks/promotional-content/mocks/libs/utils/utils.js
@@ -1,1 +1,1 @@
-export const getLocale = () => ({ prefix: 'https://main--events-milo--adobecom.aem.page' });
+export const getLocale = () => ({ prefix: '/uk' });

--- a/test/unit/blocks/promotional-content/mocks/libs/utils/utils.js
+++ b/test/unit/blocks/promotional-content/mocks/libs/utils/utils.js
@@ -1,1 +1,1 @@
-export const getLocale = () => ({ prefix: '/uk' });
+export const getLocale = () => ({ prefix: 'https://main--events-milo--adobecom.aem.page' });

--- a/test/unit/blocks/promotional-content/promotional-content.test.js
+++ b/test/unit/blocks/promotional-content/promotional-content.test.js
@@ -3,14 +3,33 @@ import sinon from 'sinon';
 import { setEventConfig } from '../../../../event-libs/v1/utils/utils.js';
 import init, { addMediaReversedClass } from '../../../../event-libs/v1/blocks/promotional-content/promotional-content.js';
 
+// Real EMC shape: matched by `name`, fragment paths are the option `value`s directly.
 const CUSTOM_ATTRS_WITH_PROMO = JSON.stringify([
-  { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
-  { attributeId: '732fdd75', attribute: 'promotionalItems', value: 'https://example.com/fragments/acrobat' },
-  { attributeId: '50578a75', attribute: 'technicalLevel', value: 'advanced' },
+  {
+    name: 'promotionalItems',
+    attributeId: '0d433aa1-0a5a-4836-9146-c6a97bdf08bc',
+    inputType: 'multi-select',
+    label: 'Promotional Items',
+    enabled: true,
+    values: [
+      {
+        valueId: '25506162-447f-471c-8419-e397f1d19022',
+        label: 'Adobe Firefly',
+        value: '/events/events-shared/fragments/product-blades/firefly',
+        ordinal: 0,
+      },
+      {
+        valueId: '4dbc5426-c8e7-4b94-becd-3048b265c61c',
+        label: 'Creative Apprenticeship',
+        value: '/events/events-shared/fragments/product-blades/creative-apprenticeship.html',
+        ordinal: 1,
+      },
+    ],
+  },
 ]);
 
 const CUSTOM_ATTRS_WITHOUT_PROMO = JSON.stringify([
-  { attributeId: '09180aab', attribute: 'primaryProductName', value: 'Acrobat' },
+  { name: 'primaryProductName', attributeId: '09180aab', value: 'Acrobat' },
 ]);
 
 // Bypasses the /libs/utils/utils.js dynamic import (404s in unit tests) so the legacy
@@ -61,7 +80,7 @@ describe('Promotional Content Block', () => {
       expect(fetchStub.called).to.be.false;
     });
 
-    it('does not fetch promotional-content.json when custom-attributes provides a fragment URL', async () => {
+    it('does not fetch promotional-content.json when custom-attributes provides fragment paths', async () => {
       addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
       fetchStub.resolves({ ok: true, text: () => Promise.resolve('<div></div>') });
 

--- a/test/unit/blocks/promotional-content/promotional-content.test.js
+++ b/test/unit/blocks/promotional-content/promotional-content.test.js
@@ -105,18 +105,18 @@ describe('Promotional Content Block', () => {
       expect(configFetched).to.be.false;
     });
 
-    it('resolves relative fragment paths against the current domain', async () => {
+    it('returns fragment paths as authored, without altering them', () => {
       addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
 
-      const fragmentUrls = await getPromotionalContent();
+      const fragmentUrls = getPromotionalContent();
 
       expect(fragmentUrls).to.deep.equal([
-        `${window.location.origin}/events/events-shared/fragments/product-blades/firefly`,
-        `${window.location.origin}/events/events-shared/fragments/product-blades/creative-apprenticeship.html`,
+        '/events/events-shared/fragments/product-blades/firefly',
+        '/events/events-shared/fragments/product-blades/creative-apprenticeship.html',
       ]);
     });
 
-    it('leaves absolute https fragment URLs untouched', async () => {
+    it('leaves absolute https fragment URLs untouched', () => {
       const customAttrsWithAbsoluteUrl = JSON.stringify([
         {
           name: 'promotionalItems',
@@ -128,21 +128,9 @@ describe('Promotional Content Block', () => {
       ]);
       addMeta('custom-attributes', customAttrsWithAbsoluteUrl);
 
-      const fragmentUrls = await getPromotionalContent();
+      const fragmentUrls = getPromotionalContent();
 
       expect(fragmentUrls).to.deep.equal(['https://example.com/fragments/product-blades/firefly']);
-    });
-
-    it('prepends the locale prefix to relative fragment paths', async () => {
-      setEventConfig({}, { miloLibs: '/test/unit/blocks/promotional-content/mocks/libs' });
-      addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
-
-      const fragmentUrls = await getPromotionalContent();
-
-      expect(fragmentUrls).to.deep.equal([
-        `${window.location.origin}/uk/events/events-shared/fragments/product-blades/firefly`,
-        `${window.location.origin}/uk/events/events-shared/fragments/product-blades/creative-apprenticeship.html`,
-      ]);
     });
   });
 

--- a/test/unit/blocks/promotional-content/promotional-content.test.js
+++ b/test/unit/blocks/promotional-content/promotional-content.test.js
@@ -1,10 +1,23 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { setEventConfig } from '../../../../event-libs/v1/utils/utils.js';
-import init, { addMediaReversedClass } from '../../../../event-libs/v1/blocks/promotional-content/promotional-content.js';
+import init, { addMediaReversedClass, getPromotionalContent } from '../../../../event-libs/v1/blocks/promotional-content/promotional-content.js';
 
 // Real EMC shape: matched by `name`, fragment paths are the option `value`s directly.
+const PRIMARY_PRODUCT_NAME_ATTR = {
+  name: 'primaryProductName',
+  attributeId: 'e324ff52-f484-4e61-8c29-a2510861c882',
+  inputType: 'single-select',
+  label: 'Primary Product Name',
+  enabled: true,
+  values: [
+    { valueId: '819b2874-8e3a-4413-96ce-88b5cf2112b1', label: 'acrobat', value: 'Acrobat', ordinal: 0 },
+    { valueId: '142f74ca-2258-4876-8b30-3e23aef996d7', label: 'acrobat-sign', value: 'Acrobat Sign', ordinal: 1 },
+  ],
+};
+
 const CUSTOM_ATTRS_WITH_PROMO = JSON.stringify([
+  PRIMARY_PRODUCT_NAME_ATTR,
   {
     name: 'promotionalItems',
     attributeId: '0d433aa1-0a5a-4836-9146-c6a97bdf08bc',
@@ -28,9 +41,7 @@ const CUSTOM_ATTRS_WITH_PROMO = JSON.stringify([
   },
 ]);
 
-const CUSTOM_ATTRS_WITHOUT_PROMO = JSON.stringify([
-  { name: 'primaryProductName', attributeId: '09180aab', value: 'Acrobat' },
-]);
+const CUSTOM_ATTRS_WITHOUT_PROMO = JSON.stringify([PRIMARY_PRODUCT_NAME_ATTR]);
 
 // Bypasses the /libs/utils/utils.js dynamic import (404s in unit tests) so the legacy
 // fetch path can be exercised end-to-end.
@@ -92,6 +103,46 @@ describe('Promotional Content Block', () => {
 
       const configFetched = fetchStub.args.some(([url]) => String(url).includes('promotional-content.json'));
       expect(configFetched).to.be.false;
+    });
+
+    it('resolves relative fragment paths against the current domain', async () => {
+      addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
+
+      const fragmentUrls = await getPromotionalContent();
+
+      expect(fragmentUrls).to.deep.equal([
+        `${window.location.origin}/events/events-shared/fragments/product-blades/firefly`,
+        `${window.location.origin}/events/events-shared/fragments/product-blades/creative-apprenticeship.html`,
+      ]);
+    });
+
+    it('leaves absolute https fragment URLs untouched', async () => {
+      const customAttrsWithAbsoluteUrl = JSON.stringify([
+        {
+          name: 'promotionalItems',
+          attributeId: '0d433aa1-0a5a-4836-9146-c6a97bdf08bc',
+          values: [
+            { valueId: '1', value: 'https://example.com/fragments/product-blades/firefly' },
+          ],
+        },
+      ]);
+      addMeta('custom-attributes', customAttrsWithAbsoluteUrl);
+
+      const fragmentUrls = await getPromotionalContent();
+
+      expect(fragmentUrls).to.deep.equal(['https://example.com/fragments/product-blades/firefly']);
+    });
+
+    it('prepends the locale prefix to relative fragment paths', async () => {
+      setEventConfig({}, { miloLibs: '/test/unit/blocks/promotional-content/mocks/libs' });
+      addMeta('custom-attributes', CUSTOM_ATTRS_WITH_PROMO);
+
+      const fragmentUrls = await getPromotionalContent();
+
+      expect(fragmentUrls).to.deep.equal([
+        `${window.location.origin}/uk/events/events-shared/fragments/product-blades/firefly`,
+        `${window.location.origin}/uk/events/events-shared/fragments/product-blades/creative-apprenticeship.html`,
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Custom Attributes-selected promotional items were never picked up: the code checked `attr.attribute` instead of the actual `attr.name` field EMC sends, and only read a single `attr.value` instead of the multi-select `values[]` array.
- Product blades now render for items selected via Custom Attributes, using the fragment path already present in each `values[].value` — no lookup against `promotional-content.json` needed for this path.
- Legacy `promotional-items` meta path is unchanged.
- Single commit, rebased directly on top of current `dev`.

Test URL
Before: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/test-dx-in-person-qe-baltimore-jul-7-506-pm/baltimore/md/us/2027-09-27?timing=1822076099990&espenv=dev&eventlibs=dev
After: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/automationtestdxda/test-dx-in-person-qe-baltimore-jul-7-506-pm/baltimore/md/us/2027-09-27?timing=1822076099990&espenv=dev&eventlibs=MWPW-200188-v2

### Contract with BE
Meta tag for custom-attributes should have all fields from promotionalItems. Eg:
```
[
                {
                    "name": "primaryProductName",
                    "attributeId": "e324ff52-f484-4e61-8c29-a2510861c882",
                    "inputType": "single-select",
                    "label": "Primary Product Name",
                    "enabled": true,
                    "values": [
                        {
                            "valueId": "819b2874-8e3a-4413-96ce-88b5cf2112b1",
                            "label": "acrobat",
                            "value": "Acrobat",
                            "ordinal": 0
                        },
                        {
                            "valueId": "142f74ca-2258-4876-8b30-3e23aef996d7",
                            "label": "acrobat-sign",
                            "value": "Acrobat Sign",
                            "ordinal": 1
                        }
                    ]
                },
                {
                    "name": "promotionalItems",
                    "attributeId": "0d433aa1-0a5a-4836-9146-c6a97bdf08bc",
                    "inputType": "multi-select",
                    "label": "Promotional Items",
                    "enabled": true,
                    "values": [
                        {
                            "valueId": "25506162-447f-471c-8419-e397f1d19022",
                            "label": "Adobe Firefly",
                            "value": "/events/events-shared/fragments/product-blades/firefly",
                            "ordinal": 0
                        },
                        {
                            "valueId": "4dbc5426-c8e7-4b94-becd-3048b265c61c",
                            "label": "Creative Apprenticeship",
                            "value": "/events/events-shared/fragments/product-blades/creative-apprenticeship.html",
                            "ordinal": 1
                        },
                        {
                            "valueId": "2a6f0f44-ef12-4c3c-826b-3ac4a13f8b57",
                            "label": "Acrobat",
                            "value": "/events/events-shared/fragments/product-blades/acrobat",
                            "ordinal": 2
                        },
                        {
                            "valueId": "a2aa3ca4-3e36-4e52-b063-5ef2bdcbb915",
                            "label": "Adobe Express",
                            "value": "/events/events-shared/fragments/product-blades/adobe-express",
                            "ordinal": 3
                        },
                        {
                            "valueId": "0ae7dbea-721d-4bfa-a74e-8568d90d378a",
                            "label": "Illustrator",
                            "value": "/events/events-shared/fragments/product-blades/illustrator",
                            "ordinal": 4
                        },
                        {
                            "valueId": "f2bc5eb3-4b62-4920-99bd-a4545f3aacd3",
                            "label": "Photoshop",
                            "value": "/events/events-shared/fragments/product-blades/photoshop",
                            "ordinal": 5
                        }
                    ]
                }
            ]
```

## Test plan
- [x] `npx wtr test/unit/blocks/promotional-content/promotional-content.test.js --node-resolve --port=2000` — 9/9 passing