### PR TITLE
Stage Release for T3-26.30

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -878,6 +878,13 @@ export function getRsvpConfigFromMeta() {
       if (Array.isArray(field.options)) {
         field.options = field.options.map((o) => (typeof o === 'object' ? o.value : o)).join(';');
       }
+      // ESP's field type enum has no dedicated multi-select value — `select` is
+      // single-choice and `checkbox` is multi-choice. `displayas` (EMC's
+      // displayAs, already stored by ESP) carries the render-style hint; remap
+      // to the widget types this file already implements for the legacy
+      // per-cloud JSON path so scope-config-driven fields get the same options.
+      if (field.type === 'select' && field.displayas === 'radio') field.type = 'radio-group';
+      if (field.type === 'checkbox' && field.displayas === 'dropdown') field.type = 'multi-select';
       return field;
     });
 

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -175,14 +175,25 @@ function constructPayload(form) {
     if (fe.value) payload[fe.id] = fe.value;
   });
 
-  // Post-process checkbox groups to convert single-option groups to booleans
+  // Post-process checkbox/radio groups. Single-option checkbox groups convert to
+  // booleans. Radio groups are mutually exclusive by native radio semantics (shared
+  // `name`), so their payload array always has 0 or 1 entries — collapse it to a
+  // plain string, since string-typed attendee fields (e.g. industry, jobTitle) have
+  // no array-to-string coercion downstream.
   Object.keys(payload).forEach((key) => {
     const fieldWrapper = form.querySelector(`[data-field-id="${key}"]`);
-    if (fieldWrapper && (fieldWrapper.dataset.type === 'checkbox' || fieldWrapper.dataset.type === 'checkbox-group')) {
+    if (!fieldWrapper || !Array.isArray(payload[key])) return;
+    // Base attendee array fields (e.g. contactMethods) must stay arrays for the API
+    if (BASE_ATTENDEE_DATA_FILTER[key]?.type === 'array') return;
+
+    if (fieldWrapper.dataset.type === 'radio-group') {
+      payload[key] = payload[key].length > 0 ? payload[key][0] : undefined;
+      return;
+    }
+
+    if (fieldWrapper.dataset.type === 'checkbox' || fieldWrapper.dataset.type === 'checkbox-group') {
       const checkboxes = fieldWrapper.querySelectorAll('input[type="checkbox"]');
-      if (checkboxes.length === 1 && Array.isArray(payload[key]) && payload[key].length <= 1) {
-        // Base attendee array fields (e.g. contactMethods) must stay arrays for the API
-        if (BASE_ATTENDEE_DATA_FILTER[key]?.type === 'array') return;
+      if (checkboxes.length === 1 && payload[key].length <= 1) {
         // Single option checkbox with at most one value - convert to boolean
         payload[key] = payload[key].length > 0;
       }

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -947,6 +947,69 @@ describe('Events Form', () => {
       const result = getRsvpConfigFromMeta();
       expect(result.data[0].required).to.equal('');
     });
+
+    it('remaps checkbox + displayAs "dropdown" to multi-select', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          {
+            field: 'interests', label: 'Interests', type: 'checkbox', displayAs: 'dropdown', required: false, options: [],
+          },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].type).to.equal('multi-select');
+    });
+
+    it('leaves checkbox + displayAs "checkbox" (default) as checkbox', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          {
+            field: 'interests', label: 'Interests', type: 'checkbox', displayAs: 'checkbox', required: false, options: [],
+          },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].type).to.equal('checkbox');
+    });
+
+    it('leaves checkbox with no displayAs as checkbox (default, backward compatible)', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          { field: 'interests', label: 'Interests', type: 'checkbox', required: false, options: [] },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].type).to.equal('checkbox');
+    });
+
+    it('remaps select + displayAs "radio" to radio-group', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          {
+            field: 'industry', label: 'Industry', type: 'select', displayAs: 'radio', required: false, options: [],
+          },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].type).to.equal('radio-group');
+    });
+
+    it('leaves select + displayAs "dropdown" (default) as select', async () => {
+      const { getRsvpConfigFromMeta } = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+      setRsvpConfigMeta({
+        rsvpFormFields: [
+          {
+            field: 'industry', label: 'Industry', type: 'select', displayAs: 'dropdown', required: false, options: [],
+          },
+        ],
+      });
+      const result = getRsvpConfigFromMeta();
+      expect(result.data[0].type).to.equal('select');
+    });
   });
 });
 

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -625,6 +625,77 @@ describe('Events Form', () => {
         expect(payload.contactMethods).to.deep.equal([]);
       });
     });
+
+    describe('radio group string conversion', () => {
+      function simulateRadioGroupPostProcess(form, payload) {
+        Object.keys(payload).forEach((key) => {
+          const fieldWrapperEl = form.querySelector(`[data-field-id="${key}"]`);
+          if (fieldWrapperEl && fieldWrapperEl.dataset.type === 'radio-group' && Array.isArray(payload[key])) {
+            if (BASE_ATTENDEE_DATA_FILTER[key]?.type === 'array') return;
+            payload[key] = payload[key].length > 0 ? payload[key][0] : undefined;
+          }
+        });
+      }
+
+      it('collapses a checked radio group (single choice) to a plain string, not an array', () => {
+        // Radio inputs sharing a name are mutually exclusive by native browser
+        // semantics, so exactly one is checked here — mirrors real rendering.
+        const form = document.createElement('form');
+        const fieldWrapper = document.createElement('div');
+        fieldWrapper.setAttribute('data-field-id', 'industry');
+        fieldWrapper.setAttribute('data-type', 'radio-group');
+
+        const radio1 = document.createElement('input');
+        radio1.type = 'radio';
+        radio1.name = 'industry';
+        radio1.value = 'Technology';
+        radio1.checked = true;
+
+        const radio2 = document.createElement('input');
+        radio2.type = 'radio';
+        radio2.name = 'industry';
+        radio2.value = 'Retail';
+        radio2.checked = false;
+
+        fieldWrapper.append(radio1, radio2);
+        form.appendChild(fieldWrapper);
+
+        const payload = {};
+        [radio1, radio2].forEach((r) => {
+          if (r.checked) {
+            payload[r.name] = payload[r.name] ? [...payload[r.name], r.value] : [r.value];
+          } else {
+            payload[r.name] = payload[r.name] || [];
+          }
+        });
+
+        simulateRadioGroupPostProcess(form, payload);
+
+        expect(payload.industry).to.equal('Technology');
+        expect(typeof payload.industry).to.equal('string');
+      });
+
+      it('collapses an unchecked radio group to undefined', () => {
+        const form = document.createElement('form');
+        const fieldWrapper = document.createElement('div');
+        fieldWrapper.setAttribute('data-field-id', 'industry');
+        fieldWrapper.setAttribute('data-type', 'radio-group');
+
+        const radio1 = document.createElement('input');
+        radio1.type = 'radio';
+        radio1.name = 'industry';
+        radio1.value = 'Technology';
+        radio1.checked = false;
+
+        fieldWrapper.append(radio1);
+        form.appendChild(fieldWrapper);
+
+        const payload = { industry: [] };
+        simulateRadioGroupPostProcess(form, payload);
+
+        expect(payload.industry).to.equal(undefined);
+      });
+    });
   });
 
   describe('inviteOnly + campaign gate', () => {


### PR DESCRIPTION
## Release Notes — T3-26.30

**RSVP Form**
- Restored rendering for RSVP `select`/`checkbox` fields configured with a `displayAs` render hint: `radio-group` for radio-style select fields, and `multi-select` dropdown for multi-select checkbox fields
- Fixed radio-group submissions being sent as a single-item array instead of a plain string, which broke downstream string-typed attendee fields (e.g. industry, job title)