### PR TITLE
Fix theme lookup key in custom-attributes metadata

### DIFF
--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -1014,7 +1014,9 @@ function addStylesToEventPage() {
 export function applyAreaTheme(area = document) {
   try {
     const customAttributes = JSON.parse(getMetadata('custom-attributes'));
-    const theme = customAttributes.find((attr) => attr.attribute.toLowerCase().trim() === 'theme');
+    const theme = customAttributes.find(
+      (attr) => (attr.name ?? attr.attribute)?.toLowerCase().trim() === 'theme',
+    );
     if (!theme) return;
 
     const themeValue = theme.values?.[0]?.value?.toLowerCase().trim();

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -492,9 +492,9 @@ describe('applyAreaTheme', () => {
     document.head.innerHTML = head;
   });
 
-  function setThemeAttribute(attribute, value) {
+  function setThemeAttribute(name, value) {
     setMetadata('custom-attributes', JSON.stringify([
-      { attribute, values: [{ value }] },
+      { name, values: [{ value }] },
     ]));
   }
 
@@ -517,7 +517,7 @@ describe('applyAreaTheme', () => {
 
   it('does nothing when there is no theme attribute', () => {
     setMetadata('custom-attributes', JSON.stringify([
-      { attribute: 'other', values: [{ value: 'dark' }] },
+      { name: 'other', values: [{ value: 'dark' }] },
     ]));
     document.body.innerHTML = '<main><div><div class="foo"></div></div></main>';
     applyAreaTheme();
@@ -617,6 +617,45 @@ describe('applyAreaTheme', () => {
 
   it('resolves the theme attribute and value regardless of case or whitespace', () => {
     setThemeAttribute(' Theme ', ' DARK ');
+    document.body.innerHTML = '<main><div><div class="foo"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.foo');
+    expect(block.classList.contains('dark')).to.be.true;
+  });
+
+  it('applies the theme from a real EMC-shaped custom-attributes payload', () => {
+    setMetadata('custom-attributes', JSON.stringify([
+      {
+        name: 'promotionalItems',
+        attributeId: '0d433aa1-0a5a-4836-9146-c6a97bdf08bc',
+        inputType: 'multi-select',
+        label: 'Promotional Items',
+        enabled: true,
+        values: [
+          { valueId: '25506162-aaaa', label: 'Adobe Firefly', value: '/fragments/firefly', ordinal: 0 },
+        ],
+      },
+      {
+        name: 'theme',
+        attributeId: 'e47464c8-33f8-4e35-bbc8-08b97da80958',
+        inputType: 'single-select',
+        label: 'Theme',
+        enabled: true,
+        values: [
+          { valueId: '827c5fd5-96e7-4b34-8400-04b9d6e3e5a4', label: 'Light', value: 'light', ordinal: 0 },
+        ],
+      },
+    ]));
+    document.body.innerHTML = '<main><div><div class="foo"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.foo');
+    expect(block.classList.contains('light')).to.be.true;
+  });
+
+  it('still resolves the theme via the legacy `attribute` key', () => {
+    setMetadata('custom-attributes', JSON.stringify([
+      { attribute: 'theme', values: [{ value: 'dark' }] },
+    ]));
     document.body.innerHTML = '<main><div><div class="foo"></div></div></main>';
     applyAreaTheme();
     const block = document.querySelector('.foo');


### PR DESCRIPTION
## What
`applyAreaTheme()` (added in #177) looked up the theme entry in the `custom-attributes` page metadata via `attr.attribute`. Real CMS-authored metadata keys each entry by `attr.name` (the same shape `getPromotionalContent()` already reads), so the lookup threw inside the `.find()` callback, was silently swallowed by the surrounding `try/catch`, and no theme was ever applied. Now the lookup checks `attr.name` first, falling back to `attr.attribute` for backwards compatibility.

## Why
Authored pages set theme via metadata like:
```json
[{"name":"theme","attributeId":"...","inputType":"single-select","label":"Theme","enabled":true,"values":[{"valueId":"...","label":"Light","value":"light","ordinal":0}]}]
```
which never triggered the theme class because of the key mismatch.

## Test plan
- Updated `applyAreaTheme` unit tests to build fixtures with the real `name` key
- Added a test using the full real EMC-shaped payload (with `attributeId`, `inputType`, `label`, `enabled`, `values[].valueId`)
- Added a test confirming the legacy `attribute` key still resolves
- `npm test` — 827 passed, 0 failed
- `npm run lint` — clean