### PR TITLE
[MWPW-194614] fix(rsvp): include phonetic name fields in attendee payload

### DIFF
--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -16,6 +16,8 @@ export const EVENT_ATTENDEE_DATA_FILTER = {
   requiresTicket: { type: 'boolean', submittable: true },
   ccSentiment: { type: 'string', submittable: true },
   campaignId: { type: 'string', submittable: true },
+  phoneticFirstName: { type: 'string', submittable: true },
+  phoneticLastName: { type: 'string', submittable: true },
 };
 
 /**

--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -58,6 +58,8 @@ export const BASE_ATTENDEE_DATA_FILTER = {
   isGuest: { type: 'boolean', submittable: true },
   consentStringId: { type: 'string', submittable: true },
   modificationTime: { type: 'string', submittable: true },
+  phoneticFirstName: { type: 'string', submittable: true },
+  phoneticLastName: { type: 'string', submittable: true },
 };
 
 export function isValidAttribute(attr) {

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -1,6 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 
-import { getEventAttendeePayload } from '../../../event-libs/v1/utils/data-utils.js';
+import {
+  getBaseAttendeePayload,
+  getEventAttendeePayload,
+} from '../../../event-libs/v1/utils/data-utils.js';
 
 describe('data-utils', () => {
   describe('getEventAttendeePayload', () => {
@@ -48,6 +51,42 @@ describe('data-utils', () => {
     it('returns argument unchanged when falsy', () => {
       expect(getEventAttendeePayload(null)).to.equal(null);
       expect(getEventAttendeePayload(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('getBaseAttendeePayload', () => {
+    it('includes phoneticFirstName and phoneticLastName when present', () => {
+      const out = getBaseAttendeePayload({
+        firstName: 'Sharmee',
+        lastName: 'Biswas',
+        email: 'sharmeeb@adobe.com',
+        phoneticFirstName: 'Shar-me',
+        phoneticLastName: 'Bis-wass',
+      });
+      expect(out.phoneticFirstName).to.equal('Shar-me');
+      expect(out.phoneticLastName).to.equal('Bis-wass');
+    });
+
+    it('drops unknown keys not in the allow-list', () => {
+      const out = getBaseAttendeePayload({
+        firstName: 'Ada',
+        totallyMadeUpField: 'x',
+      });
+      expect(out.firstName).to.equal('Ada');
+      expect(out).to.not.have.property('totallyMadeUpField');
+    });
+
+    it('omits phonetic fields when empty', () => {
+      const out = getBaseAttendeePayload({
+        firstName: 'Ada',
+        phoneticFirstName: '',
+      });
+      expect(out).to.not.have.property('phoneticFirstName');
+    });
+
+    it('returns argument unchanged when falsy', () => {
+      expect(getBaseAttendeePayload(null)).to.equal(null);
+      expect(getBaseAttendeePayload(undefined)).to.equal(undefined);
     });
   });
 });

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -52,6 +52,19 @@ describe('data-utils', () => {
       expect(getEventAttendeePayload(null)).to.equal(null);
       expect(getEventAttendeePayload(undefined)).to.equal(undefined);
     });
+
+    it('includes phoneticFirstName and phoneticLastName when present', () => {
+      const out = getEventAttendeePayload({
+        firstName: 'Sharmee',
+        lastName: 'Biswas',
+        email: 'sharmeeb@adobe.com',
+        registrationStatus: 'registered',
+        phoneticFirstName: 'Shar-me',
+        phoneticLastName: 'Bis-wass',
+      });
+      expect(out.phoneticFirstName).to.equal('Shar-me');
+      expect(out.phoneticLastName).to.equal('Bis-wass');
+    });
   });
 
   describe('getBaseAttendeePayload', () => {


### PR DESCRIPTION
## Summary
- RSVP forms configured with custom `rsvp-config` fields (e.g. `phoneticFirstName`, `phoneticLastName`) rendered correctly but were silently stripped from the attendee payload before submission.
- `BASE_ATTENDEE_DATA_FILTER` (gates create/update attendee calls) and `EVENT_ATTENDEE_DATA_FILTER` (gates the event-attendee association call) are hardcoded allow-lists in `event-libs/v1/utils/data-utils.js` — both were missing `phoneticFirstName`/`phoneticLastName`, so those fields never reached ESP even though `constructPayload()` in `events-form.js` captured them fine from the DOM.
- Added both fields to each filter and added regression tests for `getBaseAttendeePayload` and `getEventAttendeePayload`.

Resolves: [MWPW-194614](https://jira.corp.adobe.com/browse/MWPW-194614)

Test URLs:
- Before: https://dev--event-libs--adobecom.aem.live/?martech=off
- After: https://main--da-events--adobecom.aem.page/.snapshots/esp-dev/dxdatest/rsvp-config-test-6-july/los-angeles/ca/us/2026-07-30?timing=1785394799990&espenv=dev&eventlibs=MWPW-194614#rsvp-form-1 

## Test plan
- [x] `npx wtr test/unit/utils/data-utils.test.js` passes (12 tests)
- [ ] Manually RSVP on a page with `rsvp-config` including `phoneticFirstName`/`phoneticLastName` and confirm both fields appear in the ESP attendee record