### PR TITLE
docs: add vertical spacing guidance from MWPW-201396

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,20 @@ Environments are resolved from hostname or `?eccEnv` query param: `dev`, `dev02`
 - Metadata keys are `kebab-case`; parse JSON values in `try/catch`
 - Module-level singletons use the closure-based getter/setter pattern in `utils.js`
 
+### Vertical Spacing
+
+Per [MWPW-201396](https://jira.corp.adobe.com/browse/MWPW-201396), vertical page
+spacing is a design/authoring concern, not an engineering one:
+
+- **Do not hard-code vertical spacing** (top/bottom `padding` or `margin`) into a
+  block's CSS or JS. Spacing guidance lives in the Figma components.
+- Authors must **retain flexibility** to adjust spacing — never lock a block into
+  fixed vertical spacing values.
+- If a block genuinely requires baked-in spacing, it **must be well documented**:
+  why it is needed, the exact values, and the viewport(s) it applies to.
+- Intentional, engineering-owned offsets (e.g. Hero top spacing that accounts for
+  the global navigation) are the documented exception, not the rule.
+
 ## Testing
 
 Tests mirror the source tree under `test/unit/`. HTML fixtures live in `mocks/` subdirectories.


### PR DESCRIPTION
## Summary
- Records the Design/Consonant/Authoring decision from [MWPW-201396](https://jira.corp.adobe.com/browse/MWPW-201396): vertical block spacing is a Figma/authoring concern, not something to hard-code in engineering implementations.
- Adds a `### Vertical Spacing` subsection to `CLAUDE.md` under Coding Standards, so future block work (and Claude Code) follows this convention: no hard-coded top/bottom padding/margin, authors keep flexibility, and any genuinely-required baked-in spacing must be documented (value + viewport + reason).
- The specific blocks called out in the ticket (plans-hero, hub-hero, offer-hero, logo-ticker, pdf-space, brand-concierge, comparison-table-c2) are Consonant/Milo C2 blocks that don't live in this repo, so this PR ports the principle rather than a block-specific list.

## Test plan
- [x] Docs-only change — no code touched, `npm test`/`npm run lint` not applicable
- [ ] Reviewer confirms the guidance text accurately reflects the ticket's confirmed decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)