### PR TITLE
fix(decorate): stop RSVP button from getting stuck on loading status

### DIFF
--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -191,20 +191,22 @@ export async function updateRSVPButtonState(rsvpBtn) {
   }
 
   const rsvpData = BlockMediator.get('rsvpData');
-  if (!rsvpData) {
+  if (rsvpData?.registrationStatus === 'registered') {
+    setCtaState('registered', rsvpBtn);
+  } else if (rsvpData?.registrationStatus === 'waitlisted') {
+    setCtaState('waitlisted', rsvpBtn);
+  } else {
+    if (rsvpData) {
+      window.lana?.log(
+        `RSVP button: unhandled registrationStatus "${rsvpData.registrationStatus}" — falling back to default CTA`,
+        { tags: 'events-decorate', severity: 'warning' },
+      );
+    }
     if (eventFull) {
-      if (waitlistEnabled) {
-        setCtaState('toWaitlist', rsvpBtn);
-      } else {
-        setCtaState('eventClosed', rsvpBtn);
-      }
+      setCtaState(waitlistEnabled ? 'toWaitlist' : 'eventClosed', rsvpBtn);
     } else {
       setCtaState('default', rsvpBtn);
     }
-  } else if (rsvpData.registrationStatus === 'registered') {
-    setCtaState('registered', rsvpBtn);
-  } else if (rsvpData.registrationStatus === 'waitlisted') {
-    setCtaState('waitlisted', rsvpBtn);
   }
 }
 

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -407,6 +407,128 @@ describe('updateRSVPButtonState', () => {
     expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
     expect(campaignUrlCalled).to.be.false;
   });
+
+  it('escapes the actual stuck-loading state for an unrecognized registrationStatus and logs a warning (regression for stuck-loading bug)', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    // Reproduce the real precondition set by the '#rsvp-form' hash callback while the
+    // RSVP status is loading (see decorate.js regHashCallbacks['#rsvp-form']).
+    rsvpBtn.el.classList.add('rsvp-btn', 'disabled');
+    rsvpBtn.el.setAttribute('tabindex', -1);
+    rsvpBtn.el.textContent = 'Loading RSVP status...';
+    BlockMediator.set('rsvpData', { registrationStatus: 'canceled' });
+    const logSpy = sinon.spy(window.lana, 'log');
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: false,
+          attendeeCount: 10,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+    expect(logSpy.calledWith(sinon.match(/unhandled registrationStatus "canceled"/))).to.be.true;
+    logSpy.restore();
+  });
+
+  it('falls back to default state when rsvpData has no registrationStatus key', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    BlockMediator.set('rsvpData', {});
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: false,
+          attendeeCount: 10,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('falls back to toWaitlist for an unrecognized registrationStatus when event is full and waitlist enabled', async () => {
+    setMetadata('allow-wait-listing', 'true');
+    BlockMediator.set('rsvpData', { registrationStatus: 'declined' });
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: true,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('falls back to eventClosed for an unrecognized registrationStatus when event is full and waitlist disabled', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    BlockMediator.set('rsvpData', { registrationStatus: 'pending' });
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: false,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.true;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('shows the registered state when registrationStatus is registered', async () => {
+    setMetadata('allow-wait-listing', 'false');
+    BlockMediator.set('rsvpData', { registrationStatus: 'registered' });
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: false,
+          allowWaitlisting: false,
+          attendeeCount: 10,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('shows the waitlisted state when registrationStatus is waitlisted', async () => {
+    setMetadata('allow-wait-listing', 'true');
+    BlockMediator.set('rsvpData', { registrationStatus: 'waitlisted' });
+    stubFetchByUrl(sandbox, {
+      eventResponse: {
+        json: () => ({
+          isFull: true,
+          allowWaitlisting: true,
+          attendeeCount: 100,
+          attendeeLimit: 100,
+        }),
+        ok: true,
+      },
+    });
+    await updateRSVPButtonState(rsvpBtn);
+    expect(rsvpBtn.el.classList.contains('disabled')).to.be.false;
+    expect(rsvpBtn.el.getAttribute('tabindex')).to.equal('0');
+  });
 });
 
 describe('signIn', () => {


### PR DESCRIPTION
## Summary
- Attendees on Creative Cafe Portland event pages reported the RSVP button getting stuck showing "loading rsvp status" and never becoming clickable.
- Root cause: `updateRSVPButtonState` in `event-libs/v1/utils/decorate.js` had no fallback branch — if the fetched attendee record's `registrationStatus` was anything other than `registered`/`waitlisted` (e.g. `canceled`, `declined`, `pending`), `setCtaState(...)` was never called, so the button stayed disabled with the loading CTA text forever. This is not error-gated: a *successful* fetch with an unmodeled status triggers it.
- Fix: restructure the branch so `registered`/`waitlisted` are still handled first, and everything else — including a missing `rsvpData` (existing behavior, unchanged) or an unrecognized status (new) — now falls through to the same default/`toWaitlist`/`eventClosed` fallback, with a `window.lana?.log` warning for observability.
- Reviewed with three independent agents (correctness, test-coverage, and product-impact) before opening this PR; findings incorporated: fixed the `lana.log` options format to match Milo's real `tags`/`severity` API, and strengthened the regression test to reproduce the actual stuck-loading DOM precondition and assert the warning log fires.

## Test plan
- [x] `npx wtr test/unit/scripts/decorate.test.js --node-resolve --port=2000` — 117/117 passed (5 new tests: unrecognized-status fallback reproducing the real stuck precondition + lana warning, full/waitlist variants, no-`registrationStatus`-key edge case, unchanged `registered`/`waitlisted` happy paths)
- [x] `npm run lint` — clean
- [x] `npm test` (full suite w/ coverage) — 839/839 passed, verified stable across multiple repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)