### PR TITLE
Align guest RSVP-token flow with the unified attendee endpoint contract

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.css
+++ b/event-libs/v1/blocks/events-form/events-form.css
@@ -485,7 +485,7 @@
     width: 100%;
   }
   
-  .events-form :is(.events-form-submit-wrapper:last-child, .events-form-heading-wrapper, .thank-you, .events-form-full-width) {
+  .events-form :is(.events-form-submit-wrapper:last-child, .events-form-submit-wrapper, .events-form-heading-wrapper, .thank-you, .events-form-full-width) {
     grid-column: 1 / 3;
     justify-self: center;
   }

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -260,14 +260,12 @@ export async function submitForm(bp) {
   // A valid RSVP token never reaches submitForm unless it's still usable (an
   // invalid token short-circuits before the form is built, see onProfile). Submitting
   // consumes the token server-side in the same call that records the registration.
-  // The endpoint combines create-attendee + add-to-event into one call. Tokens never
-  // carry a bound campaign (EMC composes a separate ?campaign= param on the share
-  // link instead of binding one at generation), so campaignId is never sent in the
-  // body — getRsvpTokenAttendeePayload's filter drops it even though it's on payload
-  // above — and is instead forwarded as a query param on the submit call itself.
+  // The endpoint combines create-attendee + add-to-event into one call, and sources
+  // campaignId from the token itself — getRsvpTokenAttendeePayload's filter doesn't
+  // include campaignId, so it's dropped here even though it's on payload above.
   const rsvpToken = BlockMediator.get('imsProfile')?.rsvpToken;
   if (rsvpToken) {
-    return submitRsvpTokenRegistration(getMetadata('event-id'), rsvpToken, getRsvpTokenAttendeePayload(payload), campaignId);
+    return submitRsvpTokenRegistration(getMetadata('event-id'), rsvpToken, getRsvpTokenAttendeePayload(payload));
   }
 
   return getAndCreateAndAddAttendee(getMetadata('event-id'), payload);

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -1,10 +1,10 @@
-import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent, getCampaign, registerForSessionTime, submitRsvpTokenRegistration } from '../../utils/esp-controller.js';
+import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent, getCampaign, registerForSessionTime } from '../../utils/esp-controller.js';
 import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
 import { dictionaryManager, getInviteOnlyNoCampaignMessage, getRsvpTokenInvalidMessage, getRsvpTokenAlreadyRegisteredMessage } from '../../utils/dictionary-manager.js';
 import { getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl, resolveRoutedCampaignId, shouldForceGuestSignIn } from '../../utils/utils.js';
 import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN, PHONE_FIELD_RE, PHONE_PATTERN  } from '../../utils/constances.js';
-import { BASE_ATTENDEE_DATA_FILTER, getRsvpTokenAttendeePayload } from '../../utils/data-utils.js';
+import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
 import { parseRsvpFieldLimit, stripTags } from '../../utils/sanitize-utils.js';
 import { applyImplicitContactMethodsToPayload, getImplicitConsentRaw } from '../../utils/rsvp-consent.js';
 
@@ -258,17 +258,13 @@ export async function submitForm(bp) {
   }
 
   // A valid RSVP token never reaches submitForm unless it's still usable (an
-  // invalid token short-circuits before the form is built, see onProfile). Submitting
-  // consumes the token server-side in the same call that records the registration.
-  // The endpoint combines create-attendee + add-to-event into one call, using the
-  // same payload schema as that normal flow (per the backend team) — so campaignId
-  // (set on payload above) is included here too via getRsvpTokenAttendeePayload.
+  // invalid token short-circuits before the form is built, see onProfile). A guest
+  // registers via the same normal attendee flow as an IMS user — the rsvp token
+  // is just threaded through as auth instead of a bearer token, and the final
+  // add-to-event call consumes it server-side once the registration succeeds.
+  // campaignId (set on payload above) rides along in that call like any other flow.
   const rsvpToken = BlockMediator.get('imsProfile')?.rsvpToken;
-  if (rsvpToken) {
-    return submitRsvpTokenRegistration(getMetadata('event-id'), rsvpToken, getRsvpTokenAttendeePayload(payload));
-  }
-
-  return getAndCreateAndAddAttendee(getMetadata('event-id'), payload);
+  return getAndCreateAndAddAttendee(getMetadata('event-id'), payload, rsvpToken);
 }
 
 function clearForm(form) {

--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -260,9 +260,9 @@ export async function submitForm(bp) {
   // A valid RSVP token never reaches submitForm unless it's still usable (an
   // invalid token short-circuits before the form is built, see onProfile). Submitting
   // consumes the token server-side in the same call that records the registration.
-  // The endpoint combines create-attendee + add-to-event into one call, and sources
-  // campaignId from the token itself — getRsvpTokenAttendeePayload's filter doesn't
-  // include campaignId, so it's dropped here even though it's on payload above.
+  // The endpoint combines create-attendee + add-to-event into one call, using the
+  // same payload schema as that normal flow (per the backend team) — so campaignId
+  // (set on payload above) is included here too via getRsvpTokenAttendeePayload.
   const rsvpToken = BlockMediator.get('imsProfile')?.rsvpToken;
   if (rsvpToken) {
     return submitRsvpTokenRegistration(getMetadata('event-id'), rsvpToken, getRsvpTokenAttendeePayload(payload));

--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -113,17 +113,20 @@ export function getBaseAttendeePayload(attendeeData) {
 
 /**
  * Fields the RSVP token registration endpoint (POST .../rsvpTokenRegistrations)
- * accepts beyond the base attendee identity fields: identity-level consent
- * (consentStringId, already in BASE_ATTENDEE_DATA_FILTER) plus event-level
- * consent/ticket flags that only live in EVENT_ATTENDEE_DATA_FILTER for the
- * normal create-attendee flow. The RSVP token endpoint combines create+add-to-event
- * in one call, so it needs both.
+ * accepts. Per the backend team, this endpoint is a full replacement for the
+ * normal create-attendee + add-to-event calls (same payload schema), just
+ * gated by a looser auth mechanism (x-adobe-esp-rsvp-token header instead of
+ * IMS bearer auth) so a guest without an Adobe ID can hit it. This filter is
+ * BASE_ATTENDEE_DATA_FILTER plus the event-level fields that only live in
+ * EVENT_ATTENDEE_DATA_FILTER for the normal flow — consent/ticket flags and
+ * campaignId — since the RSVP token endpoint combines both calls into one.
  */
 export const RSVP_TOKEN_ATTENDEE_DATA_FILTER = {
   ...BASE_ATTENDEE_DATA_FILTER,
   shareInfoWithPartners: { type: 'boolean', submittable: true },
   ccSentiment: { type: 'string', submittable: true },
   requiresTicket: { type: 'boolean', submittable: true },
+  campaignId: { type: 'string', submittable: true },
 };
 
 export function getRsvpTokenAttendeePayload(attendeeData) {

--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -111,33 +111,3 @@ export function getBaseAttendeePayload(attendeeData) {
   }, {});
 }
 
-/**
- * Fields the RSVP token registration endpoint (POST .../rsvpTokenRegistrations)
- * accepts. Per the backend team, this endpoint is a full replacement for the
- * normal create-attendee + add-to-event calls (same payload schema), just
- * gated by a looser auth mechanism (x-adobe-esp-rsvp-token header instead of
- * IMS bearer auth) so a guest without an Adobe ID can hit it. This filter is
- * BASE_ATTENDEE_DATA_FILTER plus the event-level fields that only live in
- * EVENT_ATTENDEE_DATA_FILTER for the normal flow — consent/ticket flags and
- * campaignId — since the RSVP token endpoint combines both calls into one.
- */
-export const RSVP_TOKEN_ATTENDEE_DATA_FILTER = {
-  ...BASE_ATTENDEE_DATA_FILTER,
-  shareInfoWithPartners: { type: 'boolean', submittable: true },
-  ccSentiment: { type: 'string', submittable: true },
-  requiresTicket: { type: 'boolean', submittable: true },
-  campaignId: { type: 'string', submittable: true },
-};
-
-export function getRsvpTokenAttendeePayload(attendeeData) {
-  if (!attendeeData) return attendeeData;
-  return Object.entries(attendeeData).reduce((acc, [key, value]) => {
-    const nextValue = RSVP_TOKEN_ATTENDEE_DATA_FILTER[key]?.type === 'boolean'
-      ? coerceBoolean(key, value)
-      : value;
-    if (RSVP_TOKEN_ATTENDEE_DATA_FILTER[key]?.submittable && isValidAttribute(nextValue)) {
-      acc[key] = nextValue;
-    }
-    return acc;
-  }, {});
-}

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -9,7 +9,7 @@ import {
 } from './constances.js';
 import BlockMediator from '../deps/block-mediator.min.js';
 import { getEvent, getCampaign } from './esp-controller.js';
-import { dictionaryManager, getInviteOnlyNoCampaignMessage } from './dictionary-manager.js';
+import { dictionaryManager, getInviteOnlyNoCampaignMessage, getRsvpTokenInvalidMessage } from './dictionary-manager.js';
 import {
   getMetadata,
   setMetadata,
@@ -144,6 +144,12 @@ function setCtaState(targetState, rsvpBtn) { // eslint-disable-line no-unused-va
       updateAnalyticTag(rsvpBtn.el, text);
       checkRed.remove();
     },
+    rsvpTokenInvalid: () => {
+      const text = getRsvpTokenInvalidMessage(dictionaryManager);
+      hideBtn(text);
+      updateAnalyticTag(rsvpBtn.el, text);
+      checkRed.remove();
+    },
     default: () => {
       // Use stored original text as fallback if current originalText is the loading text
       const loadingText = dictionaryManager.getValue('rsvp-loading-cta-text');
@@ -161,6 +167,16 @@ function setCtaState(targetState, rsvpBtn) { // eslint-disable-line no-unused-va
 }
 
 export async function updateRSVPButtonState(rsvpBtn) {
+  const profile = BlockMediator.get('imsProfile');
+  if (profile?.rsvpTokenInvalid) {
+    // Token was already used, expired, or revoked (validated on load, see
+    // profile.js's captureProfile) — reflect it on the CTA itself rather than
+    // letting the guest click through to a form that will just reject them,
+    // and skip the event fetch below since it's moot for a dead token.
+    setCtaState('rsvpTokenInvalid', rsvpBtn);
+    return;
+  }
+
   const eventInfo = await getEvent(getMetadata('event-id'));
   let eventFull = false;
   let waitlistEnabled = getMetadata('allow-wait-listing') === 'true';
@@ -179,7 +195,6 @@ export async function updateRSVPButtonState(rsvpBtn) {
   }
 
   const campaignId = new URLSearchParams(window.location.search).get('campaign');
-  const profile = BlockMediator.get('imsProfile');
   const isLoggedInNonGuest = profile && !profile.noProfile && profile.account_type !== 'guest';
   if (campaignId && CAMPAIGN_ID_PATTERN.test(campaignId) && isLoggedInNonGuest) {
     const campaignInfo = await getCampaign(getMetadata('event-id'), campaignId);

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -124,6 +124,12 @@ function setCtaState(targetState, rsvpBtn) { // eslint-disable-line no-unused-va
       rsvpBtn.el.textContent = waitlistedText;
       rsvpBtn.el.prepend(checkRed);
     },
+    declined: () => {
+      const declinedText = dictionaryManager.getValue('declined-cta-text');
+      disableBtn();
+      updateAnalyticTag(rsvpBtn.el, declinedText);
+      rsvpBtn.el.textContent = declinedText;
+    },
     toWaitlist: () => {
       const waitlistText = dictionaryManager.getValue('waitlist-cta-text');
       enableBtn();
@@ -221,6 +227,8 @@ export async function updateRSVPButtonState(rsvpBtn) {
     setCtaState('registered', rsvpBtn);
   } else if (rsvpData.registrationStatus === 'waitlisted') {
     setCtaState('waitlisted', rsvpBtn);
+  } else if (rsvpData.registrationStatus === 'declined') {
+    setCtaState('declined', rsvpBtn);
   }
 }
 

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -81,8 +81,7 @@ export async function constructRequestOptions(method, body = null, waitForIMS = 
   const authToken = skipAuth ? null : (espAuthTokenOverride || window.adobeIMS?.getAccessToken()?.token);
 
   if (authToken) headers.append('Authorization', `Bearer ${authToken}`);
-  // RSVP-token endpoints authenticate solely via this header — the token never
-  // travels in the URL path or query string, to keep it out of access logs.
+  // The rsvp-token never travels in the URL path or query string, to keep it out of access logs.
   if (rsvpToken) headers.append('x-adobe-esp-rsvp-token', rsvpToken);
   headers.append('x-api-key', 'acom_event_service');
   headers.append('x-request-id', await getUuid(new Date().getTime()));
@@ -321,14 +320,17 @@ export async function createAttendee(attendeeData, rsvpToken = null) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendeeData);
-  // The backend derives the attendee identity from the IMS token itself (a guest
-  // token maps to attendeeId = the email in the body, with isGuest set), so this
-  // still needs the IMS access token even when an rsvp token is also present —
-  // the rsvp-token header alone isn't enough to authenticate this endpoint.
-  if (rsvpToken && !window.adobeIMS?.getAccessToken()?.token) {
-    window.lana?.log('createAttendee: rsvp-token registration submitted with no IMS access token — the backend will reject this request', { tags: 'events-esp-controller', severity: 'warning' });
-  }
-  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
+  // The backend gives the rsvp-token header precedence over any IMS credential, so an
+  // assistant registering a VIP via the link stays correctly scoped to the VIP rather than
+  // themselves — but only once it actually sees the header, and some backend environments
+  // still require *some* Authorization to be present at all. A guest IMS token (auto-issued
+  // to any anonymous visitor) is safe to forward: it carries no identity of its own for the
+  // backend to prefer over the rsvp token. A real signed-in user's token is not forwarded
+  // here, since backends without that precedence yet would resolve identity from it instead
+  // of the rsvp token, registering the assistant rather than the VIP.
+  const imsToken = window.adobeIMS?.getAccessToken();
+  const skipAuth = !!rsvpToken && !imsToken?.isGuestToken;
+  const options = await constructRequestOptions('POST', raw, true, skipAuth, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/attendees`, options);
@@ -352,10 +354,11 @@ export async function addAttendeeToEvent(eventId, attendee, rsvpToken = null) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendee);
-  // Same identity handling as createAttendee above — the IMS token is required
-  // for the backend to resolve who this is. This call also consumes the rsvp
-  // token server-side once the registration succeeds.
-  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
+  // Same identity handling as createAttendee above. This call also consumes
+  // the rsvp token server-side once the registration succeeds.
+  const imsToken = window.adobeIMS?.getAccessToken();
+  const skipAuth = !!rsvpToken && !imsToken?.isGuestToken;
+  const options = await constructRequestOptions('POST', raw, true, skipAuth, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/attendees/${attendee.attendeeId}`, options);
@@ -708,8 +711,8 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData, rsvpToke
   let registrationStatus = 'registered';
 
   if (profile.account_type === 'guest') {
-    // Use BaseAttendee filter for creating new attendee. A guest arriving via
-    // an rsvp token authenticates this call with the token instead of IMS.
+    // Use BaseAttendee filter for creating new attendee. A guest arriving via an rsvp
+    // token authenticates primarily with the rsvp-token header, not a signed-in identity.
     const filteredPayload = getBaseAttendeePayload(attendeeData);
     attendee = await createAttendee(filteredPayload, rsvpToken);
   } else {

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -462,7 +462,7 @@ export async function validateRsvpToken(eventId, token) {
   const options = await constructRequestOptions('GET', null, false, true, token);
 
   try {
-    const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/rsvpTokenRegistrations`, options);
+    const response = await fetch(`${serviceApiEndpoints.esp}/v1/events/${eventId}/rsvpTokenRegistrations`, options);
     const data = await response.json();
 
     if (!response.ok) {

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -477,21 +477,16 @@ export async function validateRsvpToken(eventId, token) {
   }
 }
 
-export async function submitRsvpTokenRegistration(eventId, token, attendeeData, campaignId = null) {
+export async function submitRsvpTokenRegistration(eventId, token, attendeeData) {
   if (!eventId || !token || !attendeeData) return { ok: false, error: 'Missing eventId, token, or attendee data' };
 
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendeeData);
   const options = await constructRequestOptions('POST', raw, false, true, token);
-  const url = new URL(`${serviceApiEndpoints.esl}/v1/events/${eventId}/rsvpTokenRegistrations`);
-  // Tokens never carry a bound campaign (EMC no longer sets one at generation),
-  // so this query-param fallback is the sole campaign-attribution path for
-  // rsvp-token registrations — campaignId is never sent in the request body.
-  if (campaignId) url.searchParams.set('campaignId', campaignId);
 
   try {
-    const response = await fetch(url.toString(), options);
+    const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/rsvpTokenRegistrations`, options);
     const data = await response.json();
 
     if (!response.ok) {

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -722,7 +722,10 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData, rsvpToke
     }
   }
 
-  if (!attendee?.ok) return { ok: false, error: 'Failed to create or update attendee' };
+  // Preserve the upstream status (e.g. 401/404/409/410 for a guest whose rsvp
+  // token went stale between page load and submit) so callers can show the
+  // specific error copy instead of a generic failure message.
+  if (!attendee?.ok) return { ok: false, status: attendee?.status, error: attendee?.error || 'Failed to create or update attendee' };
 
   const newAttendeeData = attendee.data;
 

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -320,17 +320,14 @@ export async function createAttendee(attendeeData, rsvpToken = null) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendeeData);
-  // The backend gives the rsvp-token header precedence over any IMS credential, so an
-  // assistant registering a VIP via the link stays correctly scoped to the VIP rather than
-  // themselves — but only once it actually sees the header, and some backend environments
-  // still require *some* Authorization to be present at all. A guest IMS token (auto-issued
-  // to any anonymous visitor) is safe to forward: it carries no identity of its own for the
-  // backend to prefer over the rsvp token. A real signed-in user's token is not forwarded
-  // here, since backends without that precedence yet would resolve identity from it instead
-  // of the rsvp token, registering the assistant rather than the VIP.
-  const imsToken = window.adobeIMS?.getAccessToken();
-  const skipAuth = !!rsvpToken && !imsToken?.isGuestToken;
-  const options = await constructRequestOptions('POST', raw, true, skipAuth, rsvpToken);
+  // Cluster Gateway requires a valid IMS credential on every request regardless of the
+  // rsvp-token header, so this always forwards whatever IMS token exists (guest or a real
+  // signed-in session) rather than suppressing it — omitting it would get the request
+  // rejected at the gateway before it ever reaches ESP. Which identity actually gets
+  // registered is the backend's call, not ours: ESP's attendee routes give the rsvp-token
+  // header precedence over any IMS identity, so an assistant registering a VIP via the link
+  // while signed into their own Adobe ID still registers the VIP, not themselves.
+  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/attendees`, options);
@@ -356,9 +353,7 @@ export async function addAttendeeToEvent(eventId, attendee, rsvpToken = null) {
   const raw = JSON.stringify(attendee);
   // Same identity handling as createAttendee above. This call also consumes
   // the rsvp token server-side once the registration succeeds.
-  const imsToken = window.adobeIMS?.getAccessToken();
-  const skipAuth = !!rsvpToken && !imsToken?.isGuestToken;
-  const options = await constructRequestOptions('POST', raw, true, skipAuth, rsvpToken);
+  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/attendees/${attendee.attendeeId}`, options);
@@ -712,7 +707,9 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData, rsvpToke
 
   if (profile.account_type === 'guest') {
     // Use BaseAttendee filter for creating new attendee. A guest arriving via an rsvp
-    // token authenticates primarily with the rsvp-token header, not a signed-in identity.
+    // token still forwards whatever IMS token exists alongside it — see createAttendee
+    // for why (Cluster Gateway requires one either way; the backend, not us, decides
+    // which credential's identity the registration actually uses).
     const filteredPayload = getBaseAttendeePayload(attendeeData);
     attendee = await createAttendee(filteredPayload, rsvpToken);
   } else {

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -315,13 +315,16 @@ export async function getAttendee() {
   }
 }
 
-export async function createAttendee(attendeeData) {
+export async function createAttendee(attendeeData, rsvpToken = null) {
   if (!attendeeData) return false;
 
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendeeData);
-  const options = await constructRequestOptions('POST', raw);
+  // A guest registering via an rsvp token has no IMS session — skip waiting for
+  // one and never attach a signed-in caller's own token, so the request stays
+  // anonymous and authenticates solely via the rsvp-token header instead.
+  const options = await constructRequestOptions('POST', raw, !rsvpToken, !!rsvpToken, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/attendees`, options);
@@ -339,13 +342,15 @@ export async function createAttendee(attendeeData) {
   }
 }
 
-export async function addAttendeeToEvent(eventId, attendee) {
+export async function addAttendeeToEvent(eventId, attendee, rsvpToken = null) {
   if (!eventId || !attendee) return false;
 
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendee);
-  const options = await constructRequestOptions('POST', raw);
+  // Same anonymous-guest handling as createAttendee above. This call also
+  // consumes the rsvp token server-side once the registration succeeds.
+  const options = await constructRequestOptions('POST', raw, !rsvpToken, !!rsvpToken, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/attendees/${attendee.attendeeId}`, options);
@@ -450,12 +455,11 @@ export async function getCampaign(eventId, campaignId) {
   }
 }
 
-// RSVP token endpoints — authenticated solely by the x-adobe-esp-rsvp-token
-// header (constructRequestOptions(..., waitForIMS=false, skipAuth=true, token)), so
-// both calls skip waiting for adobeIMS (avoids stalling for a guest with no IMS
-// session) and skip attaching any signed-in caller's own IMS token (keeps the
-// submission anonymous even when the caller, e.g. an assistant, happens to be
-// signed in).
+// Validate-on-load for a guest rsvp token — authenticated solely by the
+// x-adobe-esp-rsvp-token header. This call never consumes the token; actual
+// registration (and consumption) happens via the normal attendee endpoints
+// (createAttendee / addAttendeeToEvent above), with the token threaded through
+// as auth instead of a separate submission endpoint.
 export async function validateRsvpToken(eventId, token) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
@@ -473,30 +477,6 @@ export async function validateRsvpToken(eventId, token) {
     return { ok: true, data };
   } catch (error) {
     window.lana?.log(`Error: Failed to validate RSVP token:${JSON.stringify(error)}`);
-    return { ok: false, status: 'Network Error', error: error.message };
-  }
-}
-
-export async function submitRsvpTokenRegistration(eventId, token, attendeeData) {
-  if (!eventId || !token || !attendeeData) return { ok: false, error: 'Missing eventId, token, or attendee data' };
-
-  const eventServiceEnv = getEventServiceEnv();
-  const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
-  const raw = JSON.stringify(attendeeData);
-  const options = await constructRequestOptions('POST', raw, false, true, token);
-
-  try {
-    const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/rsvpTokenRegistrations`, options);
-    const data = await response.json();
-
-    if (!response.ok) {
-      window.lana?.log(`Error: Failed to submit RSVP token registration. Status:${JSON.stringify(response)}`);
-      return { ok: false, status: response.status, error: data };
-    }
-
-    return { ok: true, data };
-  } catch (error) {
-    window.lana?.log(`Error: Failed to submit RSVP token registration:${JSON.stringify(error)}`);
     return { ok: false, status: 'Network Error', error: error.message };
   }
 }
@@ -713,7 +693,7 @@ export async function unregisterFromSessionTime(sessionTimeId) {
 }
 
 // compound helper functions
-export async function getAndCreateAndAddAttendee(eventId, attendeeData) {
+export async function getAndCreateAndAddAttendee(eventId, attendeeData, rsvpToken = null) {
   const profile = BlockMediator.get('imsProfile');
   const eventObj = await getEvent(eventId);
 
@@ -723,9 +703,10 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData) {
   let registrationStatus = 'registered';
 
   if (profile.account_type === 'guest') {
-    // Use BaseAttendee filter for creating new attendee
+    // Use BaseAttendee filter for creating new attendee. A guest arriving via
+    // an rsvp token authenticates this call with the token instead of IMS.
     const filteredPayload = getBaseAttendeePayload(attendeeData);
-    attendee = await createAttendee(filteredPayload);
+    attendee = await createAttendee(filteredPayload, rsvpToken);
   } else {
     const attendeeResp = await getAttendee();
 
@@ -765,7 +746,9 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData) {
     registrationStatus,
   });
 
-  return addAttendeeToEvent(eventId, eventAttendeePayload);
+  // For a guest, this call both registers and consumes the rsvp token
+  // server-side in one step.
+  return addAttendeeToEvent(eventId, eventAttendeePayload, rsvpToken);
 }
 
 export async function indexPathToSchedule(scheduleId, pagePath) {

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -73,11 +73,11 @@ export async function constructRequestOptions(method, body = null, waitForIMS = 
   }
 
   const headers = new Headers();
-  // skipAuth is for genuinely public/guest-token-authenticated endpoints: never attach
-  // the caller's own IMS identity, even if one happens to be signed in (an assistant
-  // registering on a VIP's behalf must stay anonymous to the backend). The override
-  // takes precedence over window.adobeIMS for callers with no IMS bootstrap at all
-  // (e.g. the standalone tier-1-event-configurator DA app).
+  // skipAuth suppresses the caller's IMS identity entirely — used only by
+  // validateRsvpToken's load-time check, which authenticates solely via the
+  // rsvp-token header and runs before there's necessarily any IMS session to read.
+  // The override takes precedence over window.adobeIMS for callers with no IMS
+  // bootstrap at all (e.g. the standalone tier-1-event-configurator DA app).
   const authToken = skipAuth ? null : (espAuthTokenOverride || window.adobeIMS?.getAccessToken()?.token);
 
   if (authToken) headers.append('Authorization', `Bearer ${authToken}`);
@@ -321,10 +321,14 @@ export async function createAttendee(attendeeData, rsvpToken = null) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendeeData);
-  // A guest registering via an rsvp token has no IMS session — skip waiting for
-  // one and never attach a signed-in caller's own token, so the request stays
-  // anonymous and authenticates solely via the rsvp-token header instead.
-  const options = await constructRequestOptions('POST', raw, !rsvpToken, !!rsvpToken, rsvpToken);
+  // The backend derives the attendee identity from the IMS token itself (a guest
+  // token maps to attendeeId = the email in the body, with isGuest set), so this
+  // still needs the IMS access token even when an rsvp token is also present —
+  // the rsvp-token header alone isn't enough to authenticate this endpoint.
+  if (rsvpToken && !window.adobeIMS?.getAccessToken()?.token) {
+    window.lana?.log('createAttendee: rsvp-token registration submitted with no IMS access token — the backend will reject this request', { tags: 'events-esp-controller', severity: 'warning' });
+  }
+  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/attendees`, options);
@@ -348,9 +352,10 @@ export async function addAttendeeToEvent(eventId, attendee, rsvpToken = null) {
   const eventServiceEnv = getEventServiceEnv();
   const { serviceApiEndpoints } = ENV_MAP[eventServiceEnv.name];
   const raw = JSON.stringify(attendee);
-  // Same anonymous-guest handling as createAttendee above. This call also
-  // consumes the rsvp token server-side once the registration succeeds.
-  const options = await constructRequestOptions('POST', raw, !rsvpToken, !!rsvpToken, rsvpToken);
+  // Same identity handling as createAttendee above — the IMS token is required
+  // for the backend to resolve who this is. This call also consumes the rsvp
+  // token server-side once the registration succeeds.
+  const options = await constructRequestOptions('POST', raw, true, false, rsvpToken);
 
   try {
     const response = await fetch(`${serviceApiEndpoints.esl}/v1/events/${eventId}/attendees/${attendee.attendeeId}`, options);

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -850,7 +850,7 @@ describe('Events Form', () => {
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
     });
 
-    it('never sends campaignId in the RSVP token submit payload (server sources it from the token)', async () => {
+    it('never forwards campaignId on the RSVP token submit call, even when a campaign is routed (server sources it from the token)', async () => {
       resetCampaignMapCache();
       window.history.replaceState({}, '', `${window.location.pathname}?campaign=camp-1`);
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
@@ -865,33 +865,10 @@ describe('Events Form', () => {
         await submitForm({ form: buildForm(), sanitizeList: [] });
 
         const submitCall = fetchStub.getCalls().find((call) => String(call.args[0]).includes('/rsvpTokenRegistrations'));
-        const body = JSON.parse(submitCall.args[1].body);
-        expect(body.campaignId).to.equal(undefined);
-        expect(body.firstName).to.equal('Guest');
-      } finally {
-        window.history.replaceState({}, '', window.location.pathname);
-        resetCampaignMapCache();
-      }
-    });
-
-    it('forwards a routed campaign as a query param on the RSVP token submit call, still never in the body', async () => {
-      resetCampaignMapCache();
-      window.history.replaceState({}, '', `${window.location.pathname}?campaign=camp-1`);
-      BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
-      const fetchStub = sandbox.stub(window, 'fetch').callsFake((url) => {
-        if (typeof url === 'string' && url.includes('campaign-map.json')) {
-          return Promise.resolve({ ok: false, status: 404 });
-        }
-        return Promise.resolve({ json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }), ok: true });
-      });
-
-      try {
-        await submitForm({ form: buildForm(), sanitizeList: [] });
-
-        const submitCall = fetchStub.getCalls().find((call) => String(call.args[0]).includes('/rsvpTokenRegistrations'));
-        expect(submitCall.args[0]).to.include('campaignId=camp-1');
+        expect(submitCall.args[0]).to.not.include('campaignId');
         const body = JSON.parse(submitCall.args[1].body);
         expect(body).to.not.have.property('campaignId');
+        expect(body.firstName).to.equal('Guest');
       } finally {
         window.history.replaceState({}, '', window.location.pathname);
         resetCampaignMapCache();

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -859,7 +859,7 @@ describe('Events Form', () => {
       expect(addToEventOptions.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
-    it('omits Authorization (but keeps the rsvp-token header) when the rsvp link is opened in a real signed-in session', async () => {
+    it('still forwards a real signed-in session\'s IMS token when the rsvp link is opened while signed in — Cluster Gateway requires one either way', async () => {
       const originalAdobeIMS = window.adobeIMS;
       window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
@@ -874,9 +874,9 @@ describe('Events Form', () => {
       const createOptions = fetchStub.getCall(1).args[1];
       const addToEventOptions = fetchStub.getCall(2).args[1];
       expect(createOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
-      expect(createOptions.headers.has('Authorization')).to.be.false;
+      expect(createOptions.headers.get('Authorization')).to.equal('Bearer assistants-own-token');
       expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
-      expect(addToEventOptions.headers.has('Authorization')).to.be.false;
+      expect(addToEventOptions.headers.get('Authorization')).to.equal('Bearer assistants-own-token');
     });
 
     it('forwards a routed campaign in the body of the add-to-event call — same body schema as the normal attendee flow', async () => {

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -850,7 +850,7 @@ describe('Events Form', () => {
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
     });
 
-    it('never forwards campaignId on the RSVP token submit call, even when a campaign is routed (server sources it from the token)', async () => {
+    it('forwards a routed campaign in the body of the RSVP token submit call — same payload schema as the normal attendee flow', async () => {
       resetCampaignMapCache();
       window.history.replaceState({}, '', `${window.location.pathname}?campaign=camp-1`);
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
@@ -867,7 +867,7 @@ describe('Events Form', () => {
         const submitCall = fetchStub.getCalls().find((call) => String(call.args[0]).includes('/rsvpTokenRegistrations'));
         expect(submitCall.args[0]).to.not.include('campaignId');
         const body = JSON.parse(submitCall.args[1].body);
-        expect(body).to.not.have.property('campaignId');
+        expect(body).to.have.property('campaignId', 'camp-1');
         expect(body.firstName).to.equal('Guest');
       } finally {
         window.history.replaceState({}, '', window.location.pathname);

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -833,7 +833,7 @@ describe('Events Form', () => {
       return form;
     }
 
-    it('registers a guest via the normal attendee flow, authenticating with the rsvp-token header', async () => {
+    it('registers a guest via the normal attendee flow, sending both the IMS token and the rsvp-token header', async () => {
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
       const fetchStub = sandbox.stub(window, 'fetch');
       fetchStub.onCall(0).resolves({ json: () => ({ eventId: 'test-event-id', isFull: false }), ok: true });
@@ -851,9 +851,9 @@ describe('Events Form', () => {
       const createOptions = fetchStub.getCall(1).args[1];
       const addToEventOptions = fetchStub.getCall(2).args[1];
       expect(createOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
-      expect(createOptions.headers.has('Authorization')).to.be.false;
+      expect(createOptions.headers.get('Authorization')).to.equal('Bearer fake-token');
       expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
-      expect(addToEventOptions.headers.has('Authorization')).to.be.false;
+      expect(addToEventOptions.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
     it('forwards a routed campaign in the body of the add-to-event call — same body schema as the normal attendee flow', async () => {

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -833,7 +833,9 @@ describe('Events Form', () => {
       return form;
     }
 
-    it('registers a guest via the normal attendee flow, sending both the IMS token and the rsvp-token header', async () => {
+    it('registers a guest via the normal attendee flow, sending both the guest IMS token and the rsvp-token header', async () => {
+      const originalAdobeIMS = window.adobeIMS;
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token', isGuestToken: true }) };
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
       const fetchStub = sandbox.stub(window, 'fetch');
       fetchStub.onCall(0).resolves({ json: () => ({ eventId: 'test-event-id', isFull: false }), ok: true });
@@ -841,6 +843,7 @@ describe('Events Form', () => {
       fetchStub.onCall(2).resolves({ json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }), ok: true });
 
       const result = await submitForm({ form: buildForm(), sanitizeList: [] });
+      window.adobeIMS = originalAdobeIMS;
 
       expect(result.ok).to.be.true;
       expect(result.data).to.have.property('registrationStatus', 'registered');
@@ -854,6 +857,26 @@ describe('Events Form', () => {
       expect(createOptions.headers.get('Authorization')).to.equal('Bearer fake-token');
       expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
       expect(addToEventOptions.headers.get('Authorization')).to.equal('Bearer fake-token');
+    });
+
+    it('omits Authorization (but keeps the rsvp-token header) when the rsvp link is opened in a real signed-in session', async () => {
+      const originalAdobeIMS = window.adobeIMS;
+      window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
+      BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId: 'test-event-id', isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => ({ attendeeId: 'att-1' }), ok: true });
+      fetchStub.onCall(2).resolves({ json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }), ok: true });
+
+      await submitForm({ form: buildForm(), sanitizeList: [] });
+      window.adobeIMS = originalAdobeIMS;
+
+      const createOptions = fetchStub.getCall(1).args[1];
+      const addToEventOptions = fetchStub.getCall(2).args[1];
+      expect(createOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
+      expect(createOptions.headers.has('Authorization')).to.be.false;
+      expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
+      expect(addToEventOptions.headers.has('Authorization')).to.be.false;
     });
 
     it('forwards a routed campaign in the body of the add-to-event call — same body schema as the normal attendee flow', async () => {

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -833,24 +833,30 @@ describe('Events Form', () => {
       return form;
     }
 
-    it('submits the RSVP token registration instead of calling getAndCreateAndAddAttendee', async () => {
+    it('registers a guest via the normal attendee flow, authenticating with the rsvp-token header', async () => {
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({
-        json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }),
-        ok: true,
-      });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId: 'test-event-id', isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => ({ attendeeId: 'att-1' }), ok: true });
+      fetchStub.onCall(2).resolves({ json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }), ok: true });
 
       const result = await submitForm({ form: buildForm(), sanitizeList: [] });
 
       expect(result.ok).to.be.true;
       expect(result.data).to.have.property('registrationStatus', 'registered');
-      expect(fetchStub.calledOnce).to.be.true;
-      const [url, options] = fetchStub.firstCall.args;
-      expect(url).to.include('/v1/events/test-event-id/rsvpTokenRegistrations');
-      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
+      const urls = fetchStub.getCalls().map((call) => call.args[0]);
+      expect(urls.some((url) => url.includes('/rsvpTokenRegistrations'))).to.be.false;
+      expect(urls[1]).to.include('/v1/attendees');
+      expect(urls[2]).to.include('/v1/events/test-event-id/attendees/att-1');
+      const createOptions = fetchStub.getCall(1).args[1];
+      const addToEventOptions = fetchStub.getCall(2).args[1];
+      expect(createOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
+      expect(createOptions.headers.has('Authorization')).to.be.false;
+      expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('valid-rsvp-token-1234567890');
+      expect(addToEventOptions.headers.has('Authorization')).to.be.false;
     });
 
-    it('forwards a routed campaign in the body of the RSVP token submit call — same payload schema as the normal attendee flow', async () => {
+    it('forwards a routed campaign in the body of the add-to-event call — same body schema as the normal attendee flow', async () => {
       resetCampaignMapCache();
       window.history.replaceState({}, '', `${window.location.pathname}?campaign=camp-1`);
       BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'valid-rsvp-token-1234567890' });
@@ -858,15 +864,18 @@ describe('Events Form', () => {
         if (typeof url === 'string' && url.includes('campaign-map.json')) {
           return Promise.resolve({ ok: false, status: 404 });
         }
+        if (typeof url === 'string' && url.includes('/v1/attendees') && !url.includes('/events/')) {
+          return Promise.resolve({ json: () => ({ attendeeId: 'att-1' }), ok: true });
+        }
         return Promise.resolve({ json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }), ok: true });
       });
 
       try {
         await submitForm({ form: buildForm(), sanitizeList: [] });
 
-        const submitCall = fetchStub.getCalls().find((call) => String(call.args[0]).includes('/rsvpTokenRegistrations'));
-        expect(submitCall.args[0]).to.not.include('campaignId');
-        const body = JSON.parse(submitCall.args[1].body);
+        const addToEventCall = fetchStub.getCalls().find((call) => String(call.args[0]).includes('/attendees/att-1'));
+        expect(addToEventCall.args[0]).to.not.include('campaignId');
+        const body = JSON.parse(addToEventCall.args[1].body);
         expect(body).to.have.property('campaignId', 'camp-1');
         expect(body.firstName).to.equal('Guest');
       } finally {
@@ -875,7 +884,7 @@ describe('Events Form', () => {
       }
     });
 
-    it('falls back to getAndCreateAndAddAttendee when no RSVP token is present', async () => {
+    it('registers a non-guest via IMS auth with no rsvp-token header', async () => {
       BlockMediator.set('imsProfile', { account_type: 'type1' });
       const fetchStub = sandbox.stub(window, 'fetch');
       fetchStub.onCall(0).resolves({ json: () => ({ eventId: 'test-event-id', isFull: false }), ok: true });
@@ -888,6 +897,8 @@ describe('Events Form', () => {
       expect(result.ok).to.be.true;
       const urls = fetchStub.getCalls().map((call) => call.args[0]);
       expect(urls.some((url) => url.includes('/rsvpTokenRegistrations'))).to.be.false;
+      const createOptions = fetchStub.getCall(2).args[1];
+      expect(createOptions.headers.has('x-adobe-esp-rsvp-token')).to.be.false;
     });
   });
 

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -117,6 +117,7 @@ describe('updateRSVPButtonState', () => {
     setMetadata('event-id', 'test-event-id');
     BlockMediator.set('rsvpData', null);
     BlockMediator.set('eventData', null);
+    BlockMediator.set('imsProfile', null);
     originalLocationSearch = window.location.search;
   });
 
@@ -177,6 +178,32 @@ describe('updateRSVPButtonState', () => {
     expect(anchor.getAttribute('href')).to.equal('#rsvp-form');
     expect(anchor.textContent).to.equal('Register');
     expect(wrapper.querySelector('.rsvp-btn-message')).to.be.null;
+
+    wrapper.remove();
+  });
+
+  it('hides RSVP button and shows message when the RSVP token is invalid, without fetching the event', async () => {
+    fetchStub = sinon.stub(window, 'fetch');
+    BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'tok-1', rsvpTokenInvalid: true });
+
+    const wrapper = document.createElement('p');
+    const anchor = document.createElement('a');
+    anchor.href = '#rsvp-form';
+    anchor.textContent = 'Register';
+    anchor.dataset.modalHash = '#rsvp-form';
+    wrapper.appendChild(anchor);
+    document.body.appendChild(wrapper);
+    const rsvpBtn = { el: anchor, originalText: 'Register' };
+
+    await updateRSVPButtonState(rsvpBtn);
+
+    expect(fetchStub.called).to.be.false;
+    expect(anchor.style.display).to.equal('none');
+    expect(anchor.getAttribute('aria-hidden')).to.equal('true');
+    expect(anchor.getAttribute('tabindex')).to.equal('-1');
+    const msgEl = wrapper.querySelector('.rsvp-btn-message');
+    expect(msgEl).to.not.be.null;
+    expect(msgEl.textContent).to.include('valid');
 
     wrapper.remove();
   });

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -146,6 +146,28 @@ describe('Adobe Event Service API', () => {
       expect(error).to.be.an('object');
       expect(error.ok).to.be.false;
     });
+
+    it('should authenticate via the rsvp-token header (and omit Authorization) when a token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.createAttendee({ name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
+    });
+
+    it('should authenticate via IMS (and omit the rsvp-token header) when no token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.createAttendee({ name: 'John Doe' });
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
+      expect(options.headers.has('x-adobe-esp-rsvp-token')).to.be.false;
+    });
   });
 
   describe('addAttendeeToEvent', () => {
@@ -162,6 +184,28 @@ describe('Adobe Event Service API', () => {
       const error = await api.addAttendeeToEvent('123', { name: 'John Doe' });
       expect(error).to.be.an('object');
       expect(error.ok).to.be.false;
+    });
+
+    it('should authenticate via the rsvp-token header (and omit Authorization) when a token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.addAttendeeToEvent('123', { name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
+    });
+
+    it('should authenticate via IMS (and omit the rsvp-token header) when no token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.addAttendeeToEvent('123', { name: 'John Doe' });
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
+      expect(options.headers.has('x-adobe-esp-rsvp-token')).to.be.false;
     });
   });
 
@@ -320,63 +364,6 @@ describe('Adobe Event Service API', () => {
     });
   });
 
-  describe('submitRsvpTokenRegistration', () => {
-    it('should submit an RSVP token registration and return the attendee data', async () => {
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({
-        json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }),
-        ok: true,
-      });
-
-      const result = await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John', lastName: 'Doe', email: 'john@test.com' });
-      expect(result.ok).to.be.true;
-      expect(result.data).to.have.property('registrationStatus', 'registered');
-
-      const [url, options] = fetchStub.firstCall.args;
-      expect(url).to.include('/v1/events/event-123/rsvpTokenRegistrations');
-      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
-    });
-
-    it('should route the POST through ESL, not ESP', async () => {
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({
-        json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }),
-        ok: true,
-      });
-      await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
-      const [url] = fetchStub.firstCall.args;
-      expect(url).to.include('service-layer');
-      expect(url).to.not.include('service-platform');
-    });
-
-    it('should return an error without making a request when eventId, token, or data is missing', async () => {
-      const fetchStub = sandbox.stub(window, 'fetch');
-      const result = await api.submitRsvpTokenRegistration('event-123', null, { firstName: 'John' });
-      expect(result.ok).to.be.false;
-      expect(fetchStub.called).to.be.false;
-    });
-
-    it('should return an error if the email is already registered', async () => {
-      sandbox.stub(window, 'fetch').resolves({ json: () => ({ message: 'Conflict' }), ok: false, status: 409 });
-      const result = await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
-      expect(result.ok).to.be.false;
-      expect(result.status).to.equal(409);
-    });
-
-    it('should never attach the caller\'s own Authorization header, even when already signed in', async () => {
-      window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token' }) };
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({ attendeeId: 'att-1' }), ok: true });
-      await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
-      const [, options] = fetchStub.firstCall.args;
-      expect(options.headers.has('Authorization')).to.be.false;
-    });
-
-    it('should handle network errors', async () => {
-      sandbox.stub(window, 'fetch').rejects(new Error('Network failure'));
-      const result = await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
-      expect(result.ok).to.be.false;
-      expect(result.status).to.equal('Network Error');
-    });
-  });
-
   describe('getAndCreateAndAddAttendee', () => {
     const eventId = 'event-123';
     const attendeeData = { firstName: 'John', lastName: 'Doe', email: 'john@test.com' };
@@ -396,6 +383,21 @@ describe('Adobe Event Service API', () => {
       const result = await api.getAndCreateAndAddAttendee(eventId, attendeeData);
       expect(result.ok).to.be.true;
       expect(result.data.registrationStatus).to.equal('registered');
+    });
+
+    it('should authenticate the create-attendee and add-to-event calls via the rsvp-token header when a guest registers with a token', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'tok-1' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(2).resolves({ json: () => ({ registrationStatus: 'registered' }), ok: true });
+
+      await api.getAndCreateAndAddAttendee(eventId, attendeeData, 'tok-1');
+
+      const createOptions = fetchStub.getCall(1).args[1];
+      const addToEventOptions = fetchStub.getCall(2).args[1];
+      expect(createOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
     });
 
     it('should waitlist when event is full regardless of campaign', async () => {

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -147,7 +147,7 @@ describe('Adobe Event Service API', () => {
       expect(error.ok).to.be.false;
     });
 
-    it('should authenticate via the rsvp-token header (and omit Authorization) when a token is passed', async () => {
+    it('should send both the IMS token and the rsvp-token header when a token is passed', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -155,10 +155,10 @@ describe('Adobe Event Service API', () => {
 
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
-      expect(options.headers.has('Authorization')).to.be.false;
+      expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
-    it('should authenticate via IMS (and omit the rsvp-token header) when no token is passed', async () => {
+    it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -167,6 +167,17 @@ describe('Adobe Event Service API', () => {
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
       expect(options.headers.has('x-adobe-esp-rsvp-token')).to.be.false;
+    });
+
+    it('should degrade gracefully (no throw, no Authorization) when a token is passed with no IMS session', async () => {
+      delete window.adobeIMS;
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.createAttendee({ name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
     });
   });
 
@@ -186,7 +197,7 @@ describe('Adobe Event Service API', () => {
       expect(error.ok).to.be.false;
     });
 
-    it('should authenticate via the rsvp-token header (and omit Authorization) when a token is passed', async () => {
+    it('should send both the IMS token and the rsvp-token header when a token is passed', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -194,10 +205,10 @@ describe('Adobe Event Service API', () => {
 
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
-      expect(options.headers.has('Authorization')).to.be.false;
+      expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
-    it('should authenticate via IMS (and omit the rsvp-token header) when no token is passed', async () => {
+    it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -206,6 +217,17 @@ describe('Adobe Event Service API', () => {
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
       expect(options.headers.has('x-adobe-esp-rsvp-token')).to.be.false;
+    });
+
+    it('should degrade gracefully (no throw, no Authorization) when a token is passed with no IMS session', async () => {
+      delete window.adobeIMS;
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.addAttendeeToEvent('123', { name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
     });
   });
 

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -158,7 +158,7 @@ describe('Adobe Event Service API', () => {
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
-    it('should omit the Authorization header (but keep the rsvp-token header) when the caller has a real signed-in session', async () => {
+    it('should still forward a real signed-in session\'s IMS token alongside the rsvp-token header — Cluster Gateway requires one either way', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -166,7 +166,7 @@ describe('Adobe Event Service API', () => {
 
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
-      expect(options.headers.has('Authorization')).to.be.false;
+      expect(options.headers.get('Authorization')).to.equal('Bearer assistants-own-token');
     });
 
     it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {
@@ -219,7 +219,7 @@ describe('Adobe Event Service API', () => {
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
     });
 
-    it('should omit the Authorization header (but keep the rsvp-token header) when the caller has a real signed-in session', async () => {
+    it('should still forward a real signed-in session\'s IMS token alongside the rsvp-token header — Cluster Gateway requires one either way', async () => {
       window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
@@ -227,7 +227,7 @@ describe('Adobe Event Service API', () => {
 
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
-      expect(options.headers.has('Authorization')).to.be.false;
+      expect(options.headers.get('Authorization')).to.equal('Bearer assistants-own-token');
     });
 
     it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -400,6 +400,18 @@ describe('Adobe Event Service API', () => {
       expect(addToEventOptions.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
     });
 
+    it('should preserve the upstream status when create-attendee fails (e.g. an rsvp token that went stale between page load and submit)', async () => {
+      BlockMediator.set('imsProfile', { account_type: 'guest', rsvpToken: 'tok-1' });
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => ({ message: 'Gone' }), ok: false, status: 410 });
+
+      const result = await api.getAndCreateAndAddAttendee(eventId, attendeeData, 'tok-1');
+      expect(result.ok).to.be.false;
+      expect(result.status).to.equal(410);
+      expect(fetchStub.callCount).to.equal(2);
+    });
+
     it('should waitlist when event is full regardless of campaign', async () => {
       BlockMediator.set('imsProfile', { account_type: 'guest' });
       const fetchStub = sandbox.stub(window, 'fetch');

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -333,7 +333,6 @@ describe('Adobe Event Service API', () => {
 
       const [url, options] = fetchStub.firstCall.args;
       expect(url).to.include('/v1/events/event-123/rsvpTokenRegistrations');
-      expect(url).to.not.include('campaignId');
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
     });
 
@@ -346,33 +345,6 @@ describe('Adobe Event Service API', () => {
       const [url] = fetchStub.firstCall.args;
       expect(url).to.include('service-layer');
       expect(url).to.not.include('service-platform');
-    });
-
-    it('should append campaignId as a query param (never in the body) when a campaign is passed', async () => {
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({
-        json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }),
-        ok: true,
-      });
-
-      await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' }, 'camp-1');
-
-      const [url, options] = fetchStub.firstCall.args;
-      expect(url).to.include('/v1/events/event-123/rsvpTokenRegistrations');
-      expect(url).to.include('campaignId=camp-1');
-      const body = JSON.parse(options.body);
-      expect(body).to.not.have.property('campaignId');
-    });
-
-    it('should omit the campaignId query param when no campaign is passed', async () => {
-      const fetchStub = sandbox.stub(window, 'fetch').resolves({
-        json: () => ({ attendeeId: 'att-1' }),
-        ok: true,
-      });
-
-      await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
-
-      const [url] = fetchStub.firstCall.args;
-      expect(url).to.not.include('campaignId');
     });
 
     it('should return an error without making a request when eventId, token, or data is missing', async () => {

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -289,6 +289,14 @@ describe('Adobe Event Service API', () => {
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
     });
 
+    it('should route the GET through ESP, not ESL', async () => {
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({ eventId: 'event-123' }), ok: true });
+      await api.validateRsvpToken('event-123', 'tok-1');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('service-platform');
+      expect(url).to.not.include('service-layer');
+    });
+
     it('should return an error for a used/expired/revoked/unknown token', async () => {
       sandbox.stub(window, 'fetch').resolves({ json: () => ({ message: 'Gone' }), ok: false, status: 410 });
       const result = await api.validateRsvpToken('event-123', 'tok-1');
@@ -327,6 +335,17 @@ describe('Adobe Event Service API', () => {
       expect(url).to.include('/v1/events/event-123/rsvpTokenRegistrations');
       expect(url).to.not.include('campaignId');
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+    });
+
+    it('should route the POST through ESL, not ESP', async () => {
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({
+        json: () => ({ attendeeId: 'att-1', registrationStatus: 'registered' }),
+        ok: true,
+      });
+      await api.submitRsvpTokenRegistration('event-123', 'tok-1', { firstName: 'John' });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('service-layer');
+      expect(url).to.not.include('service-platform');
     });
 
     it('should append campaignId as a query param (never in the body) when a campaign is passed', async () => {

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -147,8 +147,8 @@ describe('Adobe Event Service API', () => {
       expect(error.ok).to.be.false;
     });
 
-    it('should send both the IMS token and the rsvp-token header when a token is passed', async () => {
-      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+    it('should send both the guest IMS token and the rsvp-token header when a token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token', isGuestToken: true }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
       await api.createAttendee({ name: 'John Doe' }, 'tok-1');
@@ -156,6 +156,17 @@ describe('Adobe Event Service API', () => {
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
+    });
+
+    it('should omit the Authorization header (but keep the rsvp-token header) when the caller has a real signed-in session', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.createAttendee({ name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
     });
 
     it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {
@@ -197,8 +208,8 @@ describe('Adobe Event Service API', () => {
       expect(error.ok).to.be.false;
     });
 
-    it('should send both the IMS token and the rsvp-token header when a token is passed', async () => {
-      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token' }) };
+    it('should send both the guest IMS token and the rsvp-token header when a token is passed', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'fake-token', isGuestToken: true }) };
       const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
 
       await api.addAttendeeToEvent('123', { name: 'John Doe' }, 'tok-1');
@@ -206,6 +217,17 @@ describe('Adobe Event Service API', () => {
       const options = fetchStub.firstCall.args[1];
       expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
       expect(options.headers.get('Authorization')).to.equal('Bearer fake-token');
+    });
+
+    it('should omit the Authorization header (but keep the rsvp-token header) when the caller has a real signed-in session', async () => {
+      window.adobeIMS = { getAccessToken: () => ({ token: 'assistants-own-token', isGuestToken: false }) };
+      const fetchStub = sandbox.stub(window, 'fetch').resolves({ json: () => ({}), ok: true });
+
+      await api.addAttendeeToEvent('123', { name: 'John Doe' }, 'tok-1');
+
+      const options = fetchStub.firstCall.args[1];
+      expect(options.headers.get('x-adobe-esp-rsvp-token')).to.equal('tok-1');
+      expect(options.headers.has('Authorization')).to.be.false;
     });
 
     it('should omit the rsvp-token header when no token is passed, and still authenticate via IMS', async () => {

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -131,9 +131,9 @@ describe('data-utils', () => {
       expect(getRsvpTokenAttendeePayload({ requiresTicket: ['No'] }).requiresTicket).to.be.false;
     });
 
-    it('never includes campaignId (server sources it from the token, never the client)', () => {
+    it('includes campaignId — the endpoint shares the same payload schema as the normal attendee flow', () => {
       const out = getRsvpTokenAttendeePayload({ firstName: 'Ada', campaignId: 'camp-1' });
-      expect(out).to.not.have.property('campaignId');
+      expect(out).to.have.property('campaignId', 'camp-1');
     });
 
     it('drops unknown keys', () => {

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -3,7 +3,6 @@ import { expect } from '@esm-bundle/chai';
 import {
   getBaseAttendeePayload,
   getEventAttendeePayload,
-  getRsvpTokenAttendeePayload,
 } from '../../../event-libs/v1/utils/data-utils.js';
 
 describe('data-utils', () => {
@@ -101,49 +100,6 @@ describe('data-utils', () => {
     it('returns argument unchanged when falsy', () => {
       expect(getBaseAttendeePayload(null)).to.equal(null);
       expect(getBaseAttendeePayload(undefined)).to.equal(undefined);
-    });
-  });
-
-  describe('getRsvpTokenAttendeePayload', () => {
-    it('includes base attendee fields plus consent fields the guest submit endpoint accepts', () => {
-      const out = getRsvpTokenAttendeePayload({
-        firstName: 'Ada',
-        lastName: 'Lovelace',
-        email: 'ada@example.com',
-        consentStringId: 'cs3G;ve1;en',
-        shareInfoWithPartners: true,
-        ccSentiment: 'opt-in',
-        requiresTicket: false,
-      });
-      expect(out).to.deep.equal({
-        firstName: 'Ada',
-        lastName: 'Lovelace',
-        email: 'ada@example.com',
-        consentStringId: 'cs3G;ve1;en',
-        shareInfoWithPartners: true,
-        ccSentiment: 'opt-in',
-        requiresTicket: false,
-      });
-    });
-
-    it('coerces shareInfoWithPartners/requiresTicket from radio-group array (Yes/No)', () => {
-      expect(getRsvpTokenAttendeePayload({ shareInfoWithPartners: ['Yes'] }).shareInfoWithPartners).to.be.true;
-      expect(getRsvpTokenAttendeePayload({ requiresTicket: ['No'] }).requiresTicket).to.be.false;
-    });
-
-    it('includes campaignId — the endpoint shares the same payload schema as the normal attendee flow', () => {
-      const out = getRsvpTokenAttendeePayload({ firstName: 'Ada', campaignId: 'camp-1' });
-      expect(out).to.have.property('campaignId', 'camp-1');
-    });
-
-    it('drops unknown keys', () => {
-      const out = getRsvpTokenAttendeePayload({ firstName: 'Ada', totallyMadeUpField: 'x' });
-      expect(out).to.not.have.property('totallyMadeUpField');
-    });
-
-    it('returns argument unchanged when falsy', () => {
-      expect(getRsvpTokenAttendeePayload(null)).to.equal(null);
-      expect(getRsvpTokenAttendeePayload(undefined)).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Route the RSVP-token validate-on-load call through ESP and keep it read-only (`GET /v1/events/{eventId}/rsvpTokenRegistrations`).
- Reflect an invalid/expired/used RSVP token directly in the RSVP CTA button state (`decorate.js`), so a dead link is visibly disabled instead of only failing after the guest clicks through.
- Refactor guest registration to go through the **same normal attendee endpoints** as an IMS user (`POST /v1/attendees` then `POST /v1/events/{eventId}/attendees/{attendeeId}`), authenticating with the `x-adobe-esp-rsvp-token` header instead of IMS, per the backend's unification of the guest flow with the standard attendee flow. `campaignId` now rides in the normal `EventAttendeeBody`, sourced from the routed `campaign` query param as before.
- Fix a regression introduced by that refactor: `getAndCreateAndAddAttendee` was dropping the HTTP status when the first call (`createAttendee`) failed, which would've broken the specific "token invalid" / "already used" error messaging for a guest whose token went stale between page load and submit.
- **Fix (this update):** `createAttendee`/`addAttendeeToEvent` were sending *only* the `x-adobe-esp-rsvp-token` header and suppressing `Authorization` entirely for rsvp-token submits. That's wrong at two layers: Cluster Gateway requires a valid IMS credential on every request regardless of the rsvp-token header, so omitting it gets the request rejected before it ever reaches ESP; and even once it reaches ESP, which identity the registration actually uses is the backend's call, not the frontend's — ESP's attendee routes (on the branches below) give the rsvp-token header precedence over any IMS identity specifically so an assistant registering a VIP via the link while signed into their own Adobe ID still registers the VIP, not themselves. So this now always forwards whatever IMS token exists — guest or a real signed-in session — alongside the rsvp-token header, rather than trying to second-guess which one the backend should prefer.

## Test plan
- [x] `npx eslint` clean on all changed files
- [x] `npm test`: 886/886 passing. Two categories of failures are pre-existing sandbox flakiness unrelated to this branch (reproduced identically on the pre-fix commit): (1) `getRsvpConfigFromMeta` when `events-form.test.js` is run standalone (no outbound network to fetch Milo in this sandbox), and (2) 6 tests (`DictionaryManager`, `getInviteOnlyNoCampaignMessage`, `getRsvpTokenInvalidMessage`, `getRsvpTokenAlreadyRegisteredMessage`, and profile.test.js's RSVP-token-bypass test) that depend on real unstubbed network I/O and are order-sensitive across the full suite. Neither occurs when running just the RSVP-token-related suites directly.
- [x] Reviewed by independent agents: EMC-conventions-equivalent contract-alignment pass (clean) + an adversarial bug hunt (found and fixed the status-drop regression above; verified the fix afterward) + a follow-up 3-agent pass on this update (correctness/security, test coverage, style) that flagged the guest-vs-real-session distinction as a security concern — corrected in a follow-up commit after clarifying that Cluster Gateway requires the IMS token regardless of guest/real-session, and that identity precedence is the backend's responsibility once the request clears the gateway
- [ ] Manual smoke test against a real backend once the corresponding ESP/ESL branches (`feat/MWPW-199979-unify-rsvp-token-attendee-flow`, `feature/sirivuri/MWPW-199979-rsvp-token-attendee-auth`) are merged: generate a guest RSVP link in EMC, register as a guest, confirm the token is consumed and a second attempt is rejected, confirm an expired/invalid token disables the CTA on page load, and confirm a signed-in assistant's rsvp-token registration is correctly scoped to the VIP rather than the assistant

## Notes
- Not part of this PR, flagged for a separate follow-up: `buildErrorMsg` in `events-form.js` has a pre-existing `status === 409` branch labeled "AttendeeAlreadyRegistered," but the backend's 409 for this endpoint actually means `RsvpTokenAlreadyUsed` — a guest whose token was already used by someone else would see "you're already registered" instead of "this link is no longer valid." This predates this branch and isn't something this refactor changed, but is now more reachable given the endpoint unification.
- Correction to the summary bullet above: the dedicated `POST .../rsvpTokenRegistrations` submit endpoint is **not yet** deleted on either backend's `develop` — it's only removed on the unmerged feature branches (`feat/MWPW-199979-unify-rsvp-token-attendee-flow` on ESP, `feature/sirivuri/MWPW-199979-rsvp-token-attendee-auth` on ESL), alongside the new `x-adobe-esp-rsvp-token`-precedence handling those branches add to the unified attendee routes. This event-libs branch is written against that target contract, not against what's currently on `develop` — worth confirming timing with BE before this merges, since until those branches land, an rsvp-token submission still 403s on `develop`-deployed environments regardless of this fix.
