### PR TITLE
[MWPW-200845]:- Mobile-rider c2 block and border-radius changes

### DIFF
--- a/event-libs/v1/c2/blocks/mobile-rider/drawer.css
+++ b/event-libs/v1/c2/blocks/mobile-rider/drawer.css
@@ -1,0 +1,212 @@
+.mobile-rider .mobile-rider-drawer {
+  width: 100%;
+  background: #181818;
+  box-sizing: border-box;
+  box-shadow: 0 -2px 8px rgb(0 0 0 / 12%);
+  margin: 0;
+  padding: 0;
+  position: static;
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.mobile-rider .drawer-content {
+  margin: 0;
+}
+
+.mobile-rider .drawer-title {
+  color: #fff;
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem 1rem;
+  padding: 0;
+}
+
+.mobile-rider .drawer-items {
+  background-color: #0e0e0e;
+  height: 80px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 10px;
+}
+
+.mobile-rider .now-playing-header {
+  height: 80px;
+  width: 90px;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mobile-rider .now-playing-title {
+  color: #fff;
+  margin: 0;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.mobile-rider .now-playing-subtitle {
+  font-size: 12px;
+  line-height: 1;
+  color: #fff;
+  font-weight: lighter;
+}
+
+.mobile-rider .drawer-item {
+  background-color: #1d1d1d;
+  width: 317px;
+  margin: 0 9px;
+  height: 64px;
+  font-size: 12px;
+  padding: 0 0 0 10px;
+  display: flex;
+  align-items: center;
+}
+
+.mobile-rider .drawer-item.current {
+  border-bottom: 3px solid #1473e6;
+}
+
+/* Blue background on hover only for non-current items */
+.mobile-rider .drawer-item:not(.current):hover {
+  background-color: #1473e6;
+}
+
+.mobile-rider .drawer-item-thumbnail {
+  height: 45px;
+  width: 74.66px;
+  margin: 0;
+  border: 3px solid black;
+  position: relative;
+}
+
+.mobile-rider .drawer-item-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Play button overlay */
+.mobile-rider .drawer-item:hover .drawer-item-thumbnail::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  background-color: #1473e6;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mobile-rider .drawer-item:hover .drawer-item-thumbnail::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 0;
+  height: 0;
+  border-left: 8px solid white;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  z-index: 1;
+}
+
+.mobile-rider .drawer-item-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 0.75rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.mobile-rider .drawer-item-title {
+  color: #fcfcfc;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  /* stylelint-disable-next-line value-no-vendor-prefix -- required for -webkit-line-clamp */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-wrap: break-word;
+  width: 100%;
+  padding-bottom: 5px;
+}
+
+.mobile-rider .drawer-item-description {
+  font-size: 12px;
+  font-weight: 100;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* stylelint-disable-next-line value-no-vendor-prefix -- required for -webkit-line-clamp */
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  width: 100%;
+  color: #fcfcfc;
+}
+
+/* Hover effects for current item */
+.mobile-rider .drawer-item.current .drawer-item-thumbnail {
+  border: 3px solid white;
+}
+
+.mobile-rider .drawer-item:not(.current):hover .drawer-item-thumbnail {
+  border: 3px solid white;
+}
+
+.mobile-rider .drawer-item.current:hover .drawer-item-title {
+  text-decoration: underline;
+  text-decoration-color: white;
+}
+
+@media (max-width: 768px) {
+  .mobile-rider .drawer-items {
+    gap: 0.5rem;
+  }
+}
+
+/* Mobile devices */
+@media (max-width: 600px) {
+  .mobile-rider .drawer-items {
+    flex-direction: column !important;
+    gap: 0.5rem;
+    align-items: flex-start;
+    height: auto;
+    padding: 10px;
+  }
+
+  .mobile-rider .drawer-item {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+  }
+
+  .mobile-rider .now-playing-header {
+    height: auto;
+    width: auto;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .mobile-rider .now-playing-title {
+    line-height: 1;
+    font-weight: lighter;
+  }
+}

--- a/event-libs/v1/c2/blocks/mobile-rider/drawer.js
+++ b/event-libs/v1/c2/blocks/mobile-rider/drawer.js
@@ -1,0 +1,108 @@
+/* eslint-disable no-underscore-dangle */
+import { createTag } from '../../../utils/utils.js';
+
+class Drawer {
+  constructor(root, cfg = {}) {
+    if (!root) throw new Error('Drawer needs a root element.');
+
+    this.root = root;
+    this.cfg = cfg;
+    this.items = cfg.items || [];
+    this.renderItem = cfg.renderItem || (() => createTag('div', { class: 'drawer-item' }, 'Item'));
+    this.onClick = cfg.onItemClick || (() => {});
+    this.itemsEl = null;
+
+    this.render();
+  }
+
+  /**
+   * Builds the Drawer UI
+   */
+  render() {
+    // 1. Create Main Drawer Container
+    const drawer = createTag('div', {
+      class: 'drawer',
+      'aria-label': this.cfg.ariaLabel || 'Drawer',
+    }, '', { parent: this.root });
+    const content = createTag('div', { class: 'drawer-content' }, '', { parent: drawer });
+
+    this.itemsEl = createTag('div', { class: 'drawer-items' }, '', { parent: content });
+    this.items.forEach((data, i) => {
+      const el = this.renderItem(data, i);
+      if (!el) return;
+
+      if (i === 0) el.classList.add('current');
+
+      this.bindEvents(el, data);
+      this.itemsEl.append(el);
+    });
+  }
+
+  /**
+   * Adds Accessibility and Click listeners
+   */
+  bindEvents(el, data) {
+    const handler = (e) => {
+      // Prevent event bubbling if necessary
+      e.stopPropagation();
+      this.setActive(el, data);
+    };
+
+    el.addEventListener('click', handler);
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handler(e);
+      }
+    });
+  }
+
+  /**
+   * Sets active state and triggers the external callback
+   */
+  async setActive(el, data) {
+    this.#updateVisuals(el);
+
+    try {
+      // Pass the data back to MobileRider
+      await this.onClick(el, data);
+    } catch (e) {
+      window.lana?.log?.(`[Drawer] Click callback failed: ${e.message}`);
+    }
+  }
+
+  /**
+   * Public method to update state from external URL/logic
+   */
+  setActiveById(id) {
+    if (!this.itemsEl || !id) return;
+    const el = this.itemsEl.querySelector(`[data-id="${id}"]`);
+    if (el) this.#updateVisuals(el);
+  }
+
+  /**
+   * Internal helper to handle CSS classes
+   */
+  #updateVisuals(el) {
+    this.itemsEl.querySelectorAll('.drawer-item.current').forEach((i) => i.classList.remove('current'));
+    el.classList.add('current');
+    el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  /**
+   * Cleanup method
+   */
+  remove() {
+    const drawerElement = this.root.querySelector('.drawer');
+    if (drawerElement) drawerElement.remove();
+  }
+}
+
+export default function initDrawers(root, cfg) {
+  try {
+    return new Drawer(root, cfg);
+  } catch (e) {
+    window.lana?.log?.(`Drawer init failed: ${e.message}`);
+    return null;
+  }
+}

--- a/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
+++ b/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
@@ -12,17 +12,6 @@
   box-sizing: border-box;
 }
 
-/*
- * Width-capping lives here (the outer block), not on .mobile-rider-container
- * (the inner box that has border-radius + overflow: hidden). Confirmed by
- * testing: putting max-width on the SAME element as border-radius +
- * overflow: hidden breaks <video> clipping at the bottom edge (the video's
- * bottom corners render square) — moving max-width to this outer wrapper and
- * letting the container simply be width: 100% of it avoids the bug entirely.
- * contain: paint was tried on the container as a fix and did not resolve it,
- * confirming this is specifically about max-width + border-radius +
- * overflow: hidden coexisting on one element, not a general compositing fix.
- */
 @media (min-width: 1024px) {
   .mobile-rider {
     max-width: var(--s2a-layout-rich-media-content-measure-wide, 1192px);
@@ -63,24 +52,6 @@
   height: 100%;
 }
 
-/*
- * Carried over from the classic (non-C2) block — dropped by mistake in the
- * initial C2 copy. If this block is authored inside a Milo Marquee's asset
- * cell (e.g. the split-marquee embed), Milo's own marquee.css out-specifies
- * the rule above: `.marquee.split .asset video` is (0,3,1) vs. this file's
- * `.mobile-rider .mobile-rider-container video` at (0,2,1), and sets
- * `max-height: 360px`; at >=1200px, `.marquee .asset video` (also more
- * specific) adds `max-width: initial; min-height: 150px`. All three win on
- * specificity alone, clamping the video instead of filling the rounded,
- * overflow: hidden container — defeating the corner-rounding this block
- * ships. `!important` guarantees this wins regardless of exactly how
- * specific Milo's marquee selectors are (or become later), rather than
- * relying on a specificity arms race. max-height is new here — the classic
- * block's original version of this rule didn't set it, but the split
- * variant's max-height: 360px needs neutralizing too, or the video still
- * gets capped short of filling the container even with max-width/min-height
- * fixed.
- */
 .marquee .asset .mobile-rider img,
 .marquee .asset .mobile-rider video {
   max-width: none !important;
@@ -92,17 +63,6 @@
   line-height: 1;
 }
 
-/* MAX 2026 (C2) rounds the MR player on desktop; mobile keeps squared corners
-   (base rules above leave it square). This is the C2 copy of the block, so it
-   only loads on C2 pages — no foundation-meta gate needed. Radius per the
-   Figma SSOT (HP_Player cornerRadius = 24px, both the full-takeover and the
-   split-marquee embed; the 375px mobile frame is squared). overflow: hidden
-   clips the square video/poster to the rounded wrapper. The 1024px cutoff is
-   the C2 "not mobile" boundary the marquee itself uses — adjust here if design
-   wants the mobile/desktop switch at a different width.
-
-   No max-width here — see the .mobile-rider rule above for why the
-   width-capping deliberately lives on the outer element instead. */
 @media (min-width: 1024px) {
   .mobile-rider .mobile-rider-container {
     border-radius: var(--s2a-border-radius-24, 24px);
@@ -110,21 +70,6 @@
   }
 }
 
-/*
- * The MobileRider player ships its own skin (adobe-skin.min.css, loaded at
- * runtime from mobilerider.com) that styles its overlay headings — e.g.
- * `.overlays-wrapper .titlecontainer h1`. But Milo's C2 global typography
- * (`h1, h2, .heading-*` in libs/c2/styles/styles.css) uses bare element
- * selectors that ALSO match those headings and force values the skin doesn't
- * set (letter-spacing, line-height, font-weight...), cramping the player title.
- *
- * Scoping this reset to `.mobile-rider :is(h1..h6)` gives it specificity
- * (0,1,1): higher than C2's bare `h1` (0,0,1), so it wins over the C2 leak, but
- * lower than the skin's own `.overlays-wrapper .titlecontainer h1` (0,2,1), so
- * the skin still wins on everything it sets. `revert` rolls the leaked
- * properties back to the browser default — i.e. renders as if C2's global
- * heading styles weren't there — letting the player's own skin come through.
- */
 .mobile-rider :is(h1, h2, h3, h4, h5, h6) {
   font-size: revert;
   font-weight: revert;

--- a/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
+++ b/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
@@ -1,0 +1,111 @@
+/* stylelint-disable selector-class-pattern */
+
+@import '../../styles/tokens.css';
+
+/* Mobile Rider Player Styles */
+
+.mobile-rider {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/*
+ * Width-capping lives here (the outer block), not on .mobile-rider-container
+ * (the inner box that has border-radius + overflow: hidden). Confirmed by
+ * testing: putting max-width on the SAME element as border-radius +
+ * overflow: hidden breaks <video> clipping at the bottom edge (the video's
+ * bottom corners render square) — moving max-width to this outer wrapper and
+ * letting the container simply be width: 100% of it avoids the bug entirely.
+ * contain: paint was tried on the container as a fix and did not resolve it,
+ * confirming this is specifically about max-width + border-radius +
+ * overflow: hidden coexisting on one element, not a general compositing fix.
+ */
+@media (min-width: 1024px) {
+  .mobile-rider {
+    max-width: var(--s2a-layout-rich-media-content-measure-wide, 1192px);
+  }
+}
+
+.mobile-rider .mobile-rider-container {
+  position: relative;
+  width: 100%;
+}
+
+.mobile-rider .mobile-rider-container .mr-poster {
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+  display: block;
+}
+
+.mobile-rider > :not(.mobile-rider-player) {
+  display: none;
+}
+
+.mobile-rider .mobile-rider-container.is-hidden {
+  display: none;
+}
+
+.mobile-rider .mobile-rider-container.isASL {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+}
+
+.mobile-rider .mobile-rider-container video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.mobile-rider h2#title_container {
+  line-height: 1;
+}
+
+/* MAX 2026 (C2) rounds the MR player on desktop; mobile keeps squared corners
+   (base rules above leave it square). This is the C2 copy of the block, so it
+   only loads on C2 pages — no foundation-meta gate needed. Radius per the
+   Figma SSOT (HP_Player cornerRadius = 24px, both the full-takeover and the
+   split-marquee embed; the 375px mobile frame is squared). overflow: hidden
+   clips the square video/poster to the rounded wrapper. The 1024px cutoff is
+   the C2 "not mobile" boundary the marquee itself uses — adjust here if design
+   wants the mobile/desktop switch at a different width.
+
+   No max-width here — see the .mobile-rider rule above for why the
+   width-capping deliberately lives on the outer element instead. */
+@media (min-width: 1024px) {
+  .mobile-rider .mobile-rider-container {
+    border-radius: var(--s2a-border-radius-24, 24px);
+    overflow: hidden;
+  }
+}
+
+/*
+ * The MobileRider player ships its own skin (adobe-skin.min.css, loaded at
+ * runtime from mobilerider.com) that styles its overlay headings — e.g.
+ * `.overlays-wrapper .titlecontainer h1`. But Milo's C2 global typography
+ * (`h1, h2, .heading-*` in libs/c2/styles/styles.css) uses bare element
+ * selectors that ALSO match those headings and force values the skin doesn't
+ * set (letter-spacing, line-height, font-weight...), cramping the player title.
+ *
+ * Scoping this reset to `.mobile-rider :is(h1..h6)` gives it specificity
+ * (0,1,1): higher than C2's bare `h1` (0,0,1), so it wins over the C2 leak, but
+ * lower than the skin's own `.overlays-wrapper .titlecontainer h1` (0,2,1), so
+ * the skin still wins on everything it sets. `revert` rolls the leaked
+ * properties back to the browser default — i.e. renders as if C2's global
+ * heading styles weren't there — letting the player's own skin come through.
+ */
+.mobile-rider :is(h1, h2, h3, h4, h5, h6) {
+  font-size: revert;
+  font-weight: revert;
+  font-family: revert;
+  line-height: revert;
+  letter-spacing: revert;
+  margin: revert;
+  scroll-margin-top: revert;
+}

--- a/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
+++ b/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.css
@@ -63,6 +63,31 @@
   height: 100%;
 }
 
+/*
+ * Carried over from the classic (non-C2) block — dropped by mistake in the
+ * initial C2 copy. If this block is authored inside a Milo Marquee's asset
+ * cell (e.g. the split-marquee embed), Milo's own marquee.css out-specifies
+ * the rule above: `.marquee.split .asset video` is (0,3,1) vs. this file's
+ * `.mobile-rider .mobile-rider-container video` at (0,2,1), and sets
+ * `max-height: 360px`; at >=1200px, `.marquee .asset video` (also more
+ * specific) adds `max-width: initial; min-height: 150px`. All three win on
+ * specificity alone, clamping the video instead of filling the rounded,
+ * overflow: hidden container — defeating the corner-rounding this block
+ * ships. `!important` guarantees this wins regardless of exactly how
+ * specific Milo's marquee selectors are (or become later), rather than
+ * relying on a specificity arms race. max-height is new here — the classic
+ * block's original version of this rule didn't set it, but the split
+ * variant's max-height: 360px needs neutralizing too, or the video still
+ * gets capped short of filling the container even with max-width/min-height
+ * fixed.
+ */
+.marquee .asset .mobile-rider img,
+.marquee .asset .mobile-rider video {
+  max-width: none !important;
+  min-height: auto !important;
+  max-height: none !important;
+}
+
 .mobile-rider h2#title_container {
   line-height: 1;
 }

--- a/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.js
+++ b/event-libs/v1/c2/blocks/mobile-rider/mobile-rider.js
@@ -1,0 +1,450 @@
+/* eslint-disable no-underscore-dangle */
+import { createTag, getEventConfig } from '../../../utils/utils.js';
+
+const DRAWER_CSS_URL = new URL('./drawer.css', import.meta.url).href;
+const BLOCK_CSS_URL = new URL('./mobile-rider.css', import.meta.url).href;
+
+const CONFIG = {
+  ANALYTICS: { PROVIDER: 'adobe' },
+  SCRIPTS: {
+    DEV_URL: '//assets.mobilerider.com/p/player-adobe-integration/player.min.js',
+    PROD_URL: '//assets.mobilerider.com/p/adobe/player.min.js',
+  },
+  PLAYER: {
+    DEFAULT_OPTIONS: { autoplay: true, controls: true, muted: true },
+    CONTAINER_ID: 'mr-adobe',
+    VIDEO_ID: 'idPlayer',
+    VIDEO_CLASS: 'mobileRider_viewport',
+  },
+  ASL: { TOGGLE_CLASS: 'isASL', BUTTON_ID: 'asl-button', CHECK_INTERVAL: 100, MAX_CHECKS: 50 },
+  STORE: { ATTACH_RETRIES: 20, ATTACH_INTERVAL_MS: 5 },
+};
+
+/** * UTILITIES */
+const getEnv = () => getEventConfig()?.miloConfig?.env?.name || 'prod';
+const isProd = () => getEnv() === 'prod';
+const toBool = (v) => {
+  if (typeof v !== 'string') return v;
+  const s = v.trim().toLowerCase();
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  return v;
+};
+
+let scriptPromise = null;
+async function loadScript() {
+  if (window.mobilerider) return;
+  if (!scriptPromise) {
+    const src = isProd() ? CONFIG.SCRIPTS.PROD_URL : CONFIG.SCRIPTS.DEV_URL;
+    scriptPromise = new Promise((res, rej) => {
+      const s = createTag('script', { src, async: true }, '', { parent: document.head });
+      s.onload = res;
+      s.onerror = () => { scriptPromise = null; rej(new Error('Script Load Fail')); };
+    });
+  }
+  return scriptPromise;
+}
+
+class MobileRider {
+  #embedRafId = null;
+
+  #embedGeneration = 0;
+
+  #streamEnded = false;
+
+  constructor(el) {
+    this.el = el;
+    this.isEmbedding = false;
+    this.init();
+  }
+
+  log(msg) { window.lana?.log?.(`[MobileRider] ${msg}`); }
+
+  #storeHas(id) {
+    if (!this.store || !id) return false;
+    try {
+      return this.store.get(id) != null;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  #isStreamInactive(vid) {
+    if (!this.store || !vid) return false;
+
+    const key = this.#storeHas(this.mainID)
+      ? this.mainID
+      : (this.#storeHas(vid) ? vid : null);
+
+    if (!key) return false;
+
+    try {
+      return this.store.get(key) === false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async init() {
+    try {
+      if (!document.getElementById('mobile-rider-css')) {
+        createTag('link', { rel: 'stylesheet', href: BLOCK_CSS_URL, id: 'mobile-rider-css' }, '', { parent: document.head });
+      }
+      this.cfg = this.#parseCfg();
+      await Promise.all([loadScript(), this.el.closest('.chrono-box') ? this.#loadStore() : null]);
+
+      this.#setupDOM();
+      const videos = this.cfg.concurrentenabled ? this.#parseConcurrent(this.cfg) : [this.cfg];
+      this.allVideos = videos;
+
+      const selected = await this.#selectInitialVideo(videos);
+      if (this.cfg.concurrentenabled && this.store) this.mainID = videos[0].videoid;
+
+      const videoId = selected.videoid || selected['video-id'];
+      if (this.#isStreamInactive(videoId)) {
+        this.root?.classList.add('is-hidden');
+        return;
+      }
+
+      await this.injectPlayer(videoId, this.cfg.skinid, selected.aslid);
+
+      if (this.cfg.concurrentenabled && videos.length > 1) {
+        await this.#initDrawer(videos, selected.videoid);
+      }
+    } catch (e) { this.log(e.message); }
+  }
+
+  #setupDOM() {
+    this.root = this.el.querySelector('.mobile-rider-player')
+      || createTag('div', { class: 'mobile-rider-player' }, '', { parent: this.el });
+
+    this.wrap = this.root.querySelector('.video-wrapper')
+      || createTag('div', { class: 'video-wrapper' }, '', { parent: this.root });
+  }
+
+  #cancelPendingEmbed() {
+    if (this.#embedRafId != null) {
+      cancelAnimationFrame(this.#embedRafId);
+      this.#embedRafId = null;
+    }
+  }
+
+  async injectPlayer(vid, skin, asl = null) {
+    if (!this.wrap || this.isEmbedding) return;
+    this.isEmbedding = true;
+    this.#streamEnded = false;
+    this.#cancelPendingEmbed();
+    const generation = this.#embedGeneration + 1;
+    this.#embedGeneration = generation;
+
+    const finish = () => {
+      setTimeout(() => { this.isEmbedding = false; }, 100);
+    };
+
+    try {
+      if (window.__mr_player) {
+        try { window.__mr_player.dispose?.(); } catch (e) { /* ignore */ }
+        window.__mr_player = null;
+      }
+
+      this.wrap.innerHTML = '';
+
+      const container = createTag('div', {
+        class: 'mobile-rider-container',
+        id: CONFIG.PLAYER.CONTAINER_ID,
+        'data-videoid': vid,
+      }, '', { parent: this.wrap });
+
+      createTag('video', {
+        id: CONFIG.PLAYER.VIDEO_ID,
+        class: CONFIG.PLAYER.VIDEO_CLASS,
+        controls: true,
+        playsinline: '',
+        poster: this.cfg.poster || this.cfg.thumbnail || '',
+      }, '', { parent: container });
+
+      this.#embedRafId = requestAnimationFrame(() => {
+        this.#embedRafId = null;
+
+        if (generation !== this.#embedGeneration || this.#streamEnded) {
+          finish();
+          return;
+        }
+
+        const videoInDoc = document.getElementById(CONFIG.PLAYER.VIDEO_ID);
+
+        if (!videoInDoc || !window.mobilerider) {
+          this.log('DOM or Library not ready');
+          finish();
+          return;
+        }
+
+        try {
+          window.mobilerider.embed(videoInDoc.id, vid, skin, {
+            ...CONFIG.PLAYER.DEFAULT_OPTIONS,
+            ...this.#getOverrides(),
+            analytics: { provider: CONFIG.ANALYTICS.PROVIDER },
+            identifier1: vid,
+            identifier2: asl || '',
+            sessionId: vid,
+          });
+          if (asl) this.#initASL(container, vid);
+          this.#maybeAttachEndListener(vid);
+        } catch (e) {
+          this.log(`Embed Error: ${e.message}`);
+        }
+
+        finish();
+      });
+    } catch (e) {
+      this.log(`Inject Error: ${e.message}`);
+      finish();
+    }
+  }
+
+  #getOverrides() {
+    return Object.keys(CONFIG.PLAYER.DEFAULT_OPTIONS).reduce((acc, k) => {
+      if (k in this.cfg) acc[k] = toBool(this.cfg[k]);
+      return acc;
+    }, {});
+  }
+
+  #maybeAttachEndListener(vid) {
+    const tryAttach = () => {
+      const mainTracked = this.#storeHas(this.mainID);
+      const vidTracked = this.#storeHas(vid);
+      if ((mainTracked || vidTracked) && window.__mr_player?.on) {
+        this.#attachEndListener(vid);
+        return true;
+      }
+      return false;
+    };
+
+    if (tryAttach()) return;
+
+    // Retry a bit: supports tests where instance.store is assigned after init()
+    let attempts = 0;
+    const tick = () => {
+      attempts += 1;
+      if (tryAttach()) return;
+      if (attempts >= CONFIG.STORE.ATTACH_RETRIES) return;
+      setTimeout(tick, CONFIG.STORE.ATTACH_INTERVAL_MS);
+    };
+    setTimeout(tick, 0);
+  }
+
+  #attachEndListener(vid) {
+    if (new URLSearchParams(window.location.search).get('avoidStreamEndFlag') === 'true') return;
+    // Avoid stacking listeners
+    window.__mr_player?.off?.('streamend');
+    window.__mr_player?.on?.('streamend', () => {
+      this.#streamEnded = true;
+      this.#cancelPendingEmbed();
+
+      this.wrap?.querySelector('.mobile-rider-container')?.classList.add('is-hidden');
+
+      if (this.drawer) {
+        this.drawer.remove();
+        this.drawer = null;
+      }
+
+      if (this.store) this.setStatus(vid, false);
+
+      window.__mr_player?.dispose?.();
+      window.__mr_player = null;
+    });
+  }
+
+  async #selectInitialVideo(videos) {
+    const urlIdxRaw = new URLSearchParams(window.location.search).get('video');
+    const urlIdx = urlIdxRaw ? parseInt(urlIdxRaw, 10) : null;
+    if (urlIdx && videos[urlIdx - 1]) return videos[urlIdx - 1];
+
+    const sessionTitle = sessionStorage?.getItem('concurrentVideoTitle');
+    if (sessionTitle) {
+      const found = videos.find((v) => v.title?.trim() === sessionTitle.trim());
+      if (found) {
+        sessionStorage.removeItem('concurrentVideoTitle');
+        return found;
+      }
+    }
+    return videos[0];
+  }
+
+  async #initDrawer(videos, activeId) {
+    if (!document.getElementById('mobile-rider-drawer-css')) {
+      createTag('link', { rel: 'stylesheet', href: DRAWER_CSS_URL, id: 'mobile-rider-drawer-css' }, '', { parent: document.head });
+    }
+    const { default: createDrawer } = await import('./drawer.js');
+    this.drawer = createDrawer(this.root, {
+      items: videos,
+      renderItem: (v) => this.#renderDrawerItem(v),
+      onItemClick: (_el, v) => this.#activateVideo(v),
+    });
+    this.drawer?.setActiveById?.(activeId);
+  }
+
+  #activateVideo(v) {
+    const idx = this.allVideos.indexOf(v) + 1;
+    const url = new URL(window.location.href);
+    if (idx === 1) url.searchParams.delete('video');
+    else url.searchParams.set('video', String(idx));
+    if (url.toString() !== window.location.href) window.history.replaceState({}, '', url.toString());
+    this.injectPlayer(v.videoid, this.cfg.skinid, v.aslid);
+  }
+
+  #renderDrawerItem(v) {
+    const item = createTag('div', { class: 'drawer-item', 'data-id': v.videoid, role: 'button', tabindex: '0' });
+    if (v.thumbnail) {
+      const thumb = createTag('div', { class: 'drawer-item-thumbnail' }, '', { parent: item });
+      createTag('img', { src: v.thumbnail }, '', { parent: thumb });
+    }
+    const content = createTag('div', { class: 'drawer-item-content' }, '', { parent: item });
+    createTag('div', { class: 'drawer-item-title' }, v.title || '', { parent: content });
+    createTag('div', { class: 'drawer-item-description' }, v.description || '', { parent: content });
+    return item;
+  }
+
+  #initASL(container, vid) {
+    let currentCheck = null;
+    const poll = () => {
+      clearInterval(currentCheck);
+      let attempts = 0;
+      currentCheck = setInterval(() => {
+        const btn = container.querySelector(`#${CONFIG.ASL.BUTTON_ID}`);
+        if (btn) {
+          clearInterval(currentCheck);
+          currentCheck = null;
+          btn.addEventListener('click', () => {
+            if (!container.classList.contains(CONFIG.ASL.TOGGLE_CLASS)) {
+              container.classList.add(CONFIG.ASL.TOGGLE_CLASS);
+            }
+            // ASL toggle may replace window.__mr_player; defer so new player is ready
+            if (this.store) {
+              requestAnimationFrame(() => {
+                try {
+                  this.#maybeAttachEndListener(vid);
+                } catch (e) {
+                  this.log(`ASL end-listener error: ${e.message}`);
+                }
+              });
+            }
+            poll();
+          }, { once: true });
+        } else if (++attempts > CONFIG.ASL.MAX_CHECKS) {
+          clearInterval(currentCheck);
+          currentCheck = null;
+        }
+      }, CONFIG.ASL.CHECK_INTERVAL);
+    };
+    poll();
+  }
+
+  #parseCfg() {
+    if (this.el.dataset.extractedVideoId) {
+      return {
+        videoid: this.el.dataset.extractedVideoId,
+        skinid: this.el.dataset.extractedSkinId || '',
+        autoplay: toBool(this.el.dataset.extractedAutoplay || 'true'),
+        poster: this.el.dataset.extractedThumbnail || '',
+        concurrentenabled: false,
+      };
+    }
+
+    return [...this.el.querySelectorAll(':scope > div > div:first-child')].reduce((acc, div) => {
+      const key = div.textContent.trim().toLowerCase().replace(/ /g, '-');
+      acc[key] = toBool(div.nextElementSibling?.textContent?.trim() || '');
+      return acc;
+    }, {});
+  }
+
+  #parseConcurrent(meta) {
+    const matches = Object.keys(meta)
+      .filter((k) => k.startsWith('concurrentvideoid'))
+      .map((k) => k.replace('concurrentvideoid', ''));
+
+    return [...new Set(matches)].sort((a, b) => Number(a) - Number(b)).map((i) => ({
+      videoid: meta[`concurrentvideoid${i}`],
+      aslid: meta[`concurrentaslid${i}`],
+      title: meta[`concurrenttitle${i}`],
+      description: meta[`concurrentdescription${i}`],
+      thumbnail: meta[`concurrentthumbnail${i}`],
+    }));
+  }
+
+  async #loadStore() {
+    try {
+      const { mobileRiderStore } = await import(
+        new URL('../../../features/timing-framework/plugins/mobile-rider/plugin.js', import.meta.url).href
+      );
+      this.store = mobileRiderStore;
+    } catch (e) { this.log('Store Fail'); }
+  }
+
+  setStatus(id, live) { this.#updateStatus(id, live); }
+
+  #updateStatus(id, live) {
+    if (!this.store) return;
+
+    const key = this.#storeHas(this.mainID)
+      ? this.mainID
+      : (this.#storeHas(id) ? id : null);
+
+    if (!key) return;
+
+    try {
+      if (this.store.get(key) === live) return;
+      this.store.set(key, live);
+    } catch (e) {
+      this.log(`Status update failed: ${e.message}`);
+    }
+  }
+}
+
+/**
+ * URL/Anchor Helpers
+ */
+function extractVideoParamsFromHref(anchor) {
+  try {
+    const href = anchor.getAttribute('href');
+    if (!href) return null;
+    const url = new URL(href, window.location.href);
+
+    const videoId = url.searchParams.get('videoId')
+      || url.searchParams.get('id')
+      || url.pathname.split('/').pop();
+
+    if (!videoId || videoId.includes('.html')) return null;
+
+    return {
+      videoId,
+      skinId: url.searchParams.get('skinId'),
+      autoplay: url.searchParams.get('autoplay'),
+      thumbnail: url.searchParams.get('thumbnail'),
+    };
+  } catch (e) { return null; }
+}
+
+function handleAnchorElement(anchor) {
+  if (anchor.tagName !== 'A' || !anchor.classList.contains('link-block')) return anchor;
+
+  const params = extractVideoParamsFromHref(anchor);
+  if (!params || !params.videoId) return anchor;
+
+  const mobileRiderDiv = createTag('div', { class: 'mobile-rider' });
+
+  mobileRiderDiv.dataset.extractedVideoId = params.videoId;
+  if (params.skinId) mobileRiderDiv.dataset.extractedSkinId = params.skinId;
+  if (params.autoplay) mobileRiderDiv.dataset.extractedAutoplay = params.autoplay;
+  if (params.thumbnail) mobileRiderDiv.dataset.extractedThumbnail = params.thumbnail;
+
+  anchor.insertAdjacentElement('afterend', mobileRiderDiv);
+  anchor.remove();
+
+  return mobileRiderDiv;
+}
+
+export default (el) => {
+  const processedEl = handleAnchorElement(el);
+  return new MobileRider(processedEl);
+};

--- a/event-libs/v1/c2/styles/tokens.css
+++ b/event-libs/v1/c2/styles/tokens.css
@@ -1,0 +1,938 @@
+/* =========================================
+   s2a Design Tokens — v0.0.17
+   Source: adobecom-s2a-tokens-0.0.17.tgz
+   Last verified: 2026-05-26
+
+   Shared C2 tokens — import this file from any block under c2/blocks/.
+   Duplicated here from blocks/sessions-guide/sessions-guide-tokens.css so
+   sessions-guide's own migration to c2/ can happen independently; once that
+   block moves, it should switch to this file and the local copy can go away.
+
+   Local extensions beyond the package:
+     - Full font-family stacks (package ships single font name only)
+     - --s2a-router-card-*, --s2a-app-card-*, --s2a-product-lockup-*,
+       --s2a-layout-rich-media-* retained locally (DESIGN ONLY since 0.0.14)
+   ========================================= */
+
+
+/* =========================================
+   Primitive Tokens
+   Source: tokens.primitives.css
+   ========================================= */
+   :root {
+    /* Color — Gray */
+    --s2a-color-gray-25: #fff;
+    --s2a-color-gray-50: #f8f8f8;
+    --s2a-color-gray-75: #f3f3f3;
+    --s2a-color-gray-100: #e9e9e9;
+    --s2a-color-gray-200: #e1e1e1;
+    --s2a-color-gray-300: #dadada;
+    --s2a-color-gray-400: #c6c6c6;
+    --s2a-color-gray-500: #8f8f8f;
+    --s2a-color-gray-600: #717171;
+    --s2a-color-gray-700: #505050;
+    --s2a-color-gray-800: #292929;
+    --s2a-color-gray-900: #131313;
+    --s2a-color-gray-1000: #000;
+
+    /* Color — Green */
+    --s2a-color-green-100: #edfcf1;
+    --s2a-color-green-200: #d7f7e1;
+    --s2a-color-green-300: #adeec5;
+    --s2a-color-green-400: #6be3a2;
+    --s2a-color-green-500: #2bd17d;
+    --s2a-color-green-600: #12b867;
+    --s2a-color-green-700: #0ba45d;
+    --s2a-color-green-800: #079355;
+    --s2a-color-green-900: #05834e;
+    --s2a-color-green-1000: #036e45;
+    --s2a-color-green-1100: #025d3c;
+    --s2a-color-green-1200: #014c34;
+    --s2a-color-green-1300: #003d2c;
+    --s2a-color-green-1400: #002e22;
+    --s2a-color-green-1500: #002119;
+    --s2a-color-green-1600: #000f0c;
+
+    /* Color — Blue */
+    --s2a-color-blue-100: #f5f9ff;
+    --s2a-color-blue-200: #e5f0fe;
+    --s2a-color-blue-300: #cbe2fe;
+    --s2a-color-blue-400: #accffd;
+    --s2a-color-blue-500: #8eb9fc;
+    --s2a-color-blue-600: #729efd;
+    --s2a-color-blue-700: #5d89ff;
+    --s2a-color-blue-800: #4b75ff;
+    --s2a-color-blue-900: #3b63fb;
+    --s2a-color-blue-1000: #274dea;
+    --s2a-color-blue-1100: #1d3ecf;
+    --s2a-color-blue-1200: #1532ad;
+    --s2a-color-blue-1300: #10288c;
+    --s2a-color-blue-1400: #0c1f69;
+    --s2a-color-blue-1500: #0e1843;
+    --s2a-color-blue-1600: #070b1e;
+
+    /* Color — Red */
+    --s2a-color-red-100: #fff6f5;
+    --s2a-color-red-200: #ffebe8;
+    --s2a-color-red-300: #ffd6d1;
+    --s2a-color-red-400: #ffbcb4;
+    --s2a-color-red-500: #ff9d91;
+    --s2a-color-red-600: #ff7665;
+    --s2a-color-red-700: #ff513d;
+    --s2a-color-red-800: #f03823;
+    --s2a-color-red-900: #d73220;
+    --s2a-color-red-1000: #b72818;
+    --s2a-color-red-1100: #9c2113;
+    --s2a-color-red-1200: #811b0e;
+    --s2a-color-red-1300: #68150a;
+    --s2a-color-red-1400: #501006;
+    --s2a-color-red-1500: #3b0b04;
+    --s2a-color-red-1600: #1d0502;
+
+    /* Color — Orange */
+    --s2a-color-orange-100: #fff6e7;
+    --s2a-color-orange-200: #ffeccf;
+    --s2a-color-orange-300: #ffda9e;
+    --s2a-color-orange-400: #ffc15e;
+    --s2a-color-orange-500: #ffa213;
+    --s2a-color-orange-600: #fc7d00;
+    --s2a-color-orange-700: #e86a00;
+    --s2a-color-orange-800: #d45b00;
+    --s2a-color-orange-900: #c24e00;
+    --s2a-color-orange-1000: #a73e00;
+    --s2a-color-orange-1100: #903300;
+    --s2a-color-orange-1200: #762900;
+    --s2a-color-orange-1300: #5f2000;
+    --s2a-color-orange-1400: #491800;
+    --s2a-color-orange-1500: #341200;
+    --s2a-color-orange-1600: #190800;
+
+    /* Color — Yellow */
+    --s2a-color-yellow-100: #fff8cc;
+    --s2a-color-yellow-200: #fff197;
+    --s2a-color-yellow-300: #ffde2c;
+    --s2a-color-yellow-400: #f5c700;
+    --s2a-color-yellow-500: #e6af00;
+    --s2a-color-yellow-600: #d29500;
+    --s2a-color-yellow-700: #c18300;
+    --s2a-color-yellow-800: #af7400;
+    --s2a-color-yellow-900: #9e6600;
+    --s2a-color-yellow-1000: #865500;
+    --s2a-color-yellow-1100: #724800;
+    --s2a-color-yellow-1200: #5d3b00;
+    --s2a-color-yellow-1300: #4b2f00;
+    --s2a-color-yellow-1400: #382300;
+    --s2a-color-yellow-1500: #281900;
+    --s2a-color-yellow-1600: #120b00;
+
+    /* Color — Transparent Black */
+    --s2a-color-transparent-black-00: rgb(0 0 0 / 0%);
+    --s2a-color-transparent-black-04: rgb(0 0 0 / 4%);
+    --s2a-color-transparent-black-08: rgb(0 0 0 / 8%);
+    --s2a-color-transparent-black-12: rgb(0 0 0 / 12%);
+    --s2a-color-transparent-black-16: rgb(0 0 0 / 16%);
+    --s2a-color-transparent-black-24: rgb(0 0 0 / 24%);
+    --s2a-color-transparent-black-32: rgb(0 0 0 / 32%);
+    --s2a-color-transparent-black-48: rgb(0 0 0 / 48%);
+    --s2a-color-transparent-black-64: rgb(0 0 0 / 64%);
+    --s2a-color-transparent-black-72: rgb(0 0 0 / 72%);
+    --s2a-color-transparent-black-80: rgb(0 0 0 / 80%);
+    --s2a-color-transparent-black-88: rgb(0 0 0 / 88%);
+    --s2a-color-transparent-black-96: rgb(0 0 0 / 96%);
+
+    /* Color — Transparent White */
+    --s2a-color-transparent-white-00: rgb(255 255 255 / 0%);
+    --s2a-color-transparent-white-04: rgb(255 255 255 / 4%);
+    --s2a-color-transparent-white-08: rgb(255 255 255 / 8%);
+    --s2a-color-transparent-white-12: rgb(255 255 255 / 12%);
+    --s2a-color-transparent-white-16: rgb(255 255 255 / 16%);
+    --s2a-color-transparent-white-24: rgb(255 255 255 / 24%);
+    --s2a-color-transparent-white-32: rgb(255 255 255 / 32%);
+    --s2a-color-transparent-white-48: rgb(255 255 255 / 48%);
+    --s2a-color-transparent-white-64: rgb(255 255 255 / 64%);
+    --s2a-color-transparent-white-72: rgb(255 255 255 / 72%);
+    --s2a-color-transparent-white-80: rgb(255 255 255 / 80%);
+    --s2a-color-transparent-white-88: rgb(255 255 255 / 88%);
+    --s2a-color-transparent-white-96: rgb(255 255 255 / 96%);
+
+    /* Color — Brand */
+    --s2a-color-brand-adobe-red: #eb1000;
+    --s2a-color-brand-cc-3dar: #99e83f;
+    --s2a-color-brand-cc-il: #ff9a00;
+    --s2a-color-brand-cc-ppafx: #99f;
+    --s2a-color-brand-cc-ps: #3a18ff;
+
+    /* Border Radius */
+    --s2a-border-radius-0: 0;
+    --s2a-border-radius-2: 2px;
+    --s2a-border-radius-4: 4px;
+    --s2a-border-radius-8: 8px;
+    --s2a-border-radius-12: 12px;
+    --s2a-border-radius-16: 16px;
+    --s2a-border-radius-24: 24px;
+    --s2a-border-radius-32: 32px;
+    --s2a-border-radius-999: 999px;
+
+    /* Border Width */
+    --s2a-border-width-0: 0;
+    --s2a-border-width-1: 1px;
+    --s2a-border-width-2: 2px;
+    --s2a-border-width-4: 4px;
+
+    /* Opacity */
+    --s2a-opacity-00: 0;
+    --s2a-opacity-08: 8%;
+    --s2a-opacity-16: 16%;
+    --s2a-opacity-24: 24%;
+    --s2a-opacity-32: 32%;
+    --s2a-opacity-48: 48%;
+    --s2a-opacity-64: 64%;
+    --s2a-opacity-100: 100%;
+
+    /* Shadow */
+    --s2a-shadow-level-1-x: 0;
+    --s2a-shadow-level-1-y: 1px;
+    --s2a-shadow-level-1-blur: 6px;
+    --s2a-shadow-level-1-spread: 0;
+    --s2a-shadow-level-1-color: var(--s2a-color-transparent-black-12);
+    --s2a-shadow-level-2-x: 0;
+    --s2a-shadow-level-2-y: 2px;
+    --s2a-shadow-level-2-blur: 8px;
+    --s2a-shadow-level-2-spread: 0;
+    --s2a-shadow-level-2-color: var(--s2a-color-transparent-black-16);
+    --s2a-shadow-level-3-x: 0;
+    --s2a-shadow-level-3-y: 4px;
+    --s2a-shadow-level-3-blur: 12px;
+    --s2a-shadow-level-3-spread: 0;
+    --s2a-shadow-level-3-color: var(--s2a-color-transparent-black-16);
+    --s2a-shadow-level-4-x: 0;
+    --s2a-shadow-level-4-y: 6px;
+    --s2a-shadow-level-4-blur: 16px;
+    --s2a-shadow-level-4-spread: 0;
+    --s2a-shadow-level-4-color: var(--s2a-color-transparent-black-16);
+
+    /* Spacing */
+    --s2a-spacing-0: 0;
+    --s2a-spacing-2: 2px;
+    --s2a-spacing-4: 4px;
+    --s2a-spacing-8: 8px;
+    --s2a-spacing-12: 12px;
+    --s2a-spacing-16: 16px;
+    --s2a-spacing-20: 20px;
+    --s2a-spacing-24: 24px;
+    --s2a-spacing-32: 32px;
+    --s2a-spacing-40: 40px;
+    --s2a-spacing-48: 48px;
+    --s2a-spacing-64: 64px;
+    --s2a-spacing-80: 80px;
+    --s2a-spacing-96: 96px;
+    --s2a-spacing-124: 124px;
+    --s2a-spacing-160: 160px;
+    --s2a-spacing-240: 240px;
+
+    /* Font Family — local extension: full stack (package ships single name) */
+    --s2a-font-family-adobe-clean: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+    --s2a-font-family-adobe-clean-display: 'Adobe Clean Display', adobe-clean-display, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+
+    /* Font Letter Spacing */
+    --s2a-font-letter-spacing-neg-3-84: -3.84px;
+    --s2a-font-letter-spacing-neg-3-2: -3.2px;
+    --s2a-font-letter-spacing-neg-2-88: -2.88px;
+    --s2a-font-letter-spacing-neg-1-68: -1.68px;
+    --s2a-font-letter-spacing-neg-1-44: -1.44px;
+    --s2a-font-letter-spacing-neg-1: -1px;
+    --s2a-font-letter-spacing-neg-0-96: -0.96px;
+    --s2a-font-letter-spacing-neg-0-48: -0.48px;
+    --s2a-font-letter-spacing-neg-0-2: -0.2px;
+    --s2a-font-letter-spacing-neg-0-16: -0.16px;
+    --s2a-font-letter-spacing-0: 0;
+
+    /* Font Line Height */
+    --s2a-font-line-height-16: 16px;
+    --s2a-font-line-height-18: 18px;
+    --s2a-font-line-height-20: 20px;
+    --s2a-font-line-height-21: 21px;
+    --s2a-font-line-height-24: 24px;
+    --s2a-font-line-height-32: 32px;
+    --s2a-font-line-height-40: 40px;
+    --s2a-font-line-height-48: 48px;
+    --s2a-font-line-height-56: 56px;
+    --s2a-font-line-height-69: 69px;
+    --s2a-font-line-height-76: 76px;
+    --s2a-font-line-height-92: 92px;
+
+    /* Font Size */
+    --s2a-font-size-12: 0.75rem;
+    --s2a-font-size-14: 0.875rem;
+    --s2a-font-size-16: 1rem;
+    --s2a-font-size-18: 1.125rem;
+    --s2a-font-size-20: 1.25rem;
+    --s2a-font-size-24: 1.5rem;
+    --s2a-font-size-32: 2rem;
+    --s2a-font-size-36: 2.25rem;
+    --s2a-font-size-40: 2.5rem;
+    --s2a-font-size-48: 3rem;
+    --s2a-font-size-56: 3.5rem;
+    --s2a-font-size-64: 4rem;
+    --s2a-font-size-72: 4.5rem;
+    --s2a-font-size-80: 5rem;
+    --s2a-font-size-96: 6rem;
+
+    /* Font Weight */
+    --s2a-font-weight-adobe-clean-regular: 400;
+    --s2a-font-weight-adobe-clean-medium: 500;
+    --s2a-font-weight-adobe-clean-bold: 700;
+    --s2a-font-weight-adobe-clean-extrabold: 800;
+    --s2a-font-weight-adobe-clean-black: 900;
+    --s2a-font-weight-adobe-clean-display-black: 900;
+
+    /* Blur */
+    --s2a-blur-8: 8px;
+    --s2a-blur-16: 16px;
+    --s2a-blur-24: 24px;
+    --s2a-blur-32: 32px;
+    --s2a-blur-64: 64px;
+    --s2a-blur-128: 128px;
+
+    /* =========================================
+       Semantic Tokens
+       Source: tokens.semantic.css
+       ========================================= */
+
+    /* Border Radius */
+    --s2a-border-radius-none: var(--s2a-border-radius-0);
+    --s2a-border-radius-2xs: var(--s2a-border-radius-2);
+    --s2a-border-radius-xs: var(--s2a-border-radius-4);
+    --s2a-border-radius-sm: var(--s2a-border-radius-8);
+    --s2a-border-radius-md: var(--s2a-border-radius-16);
+    --s2a-border-radius-lg: var(--s2a-border-radius-32);
+    --s2a-border-radius-round: var(--s2a-border-radius-999);
+
+    /* Border Width */
+    --s2a-border-width-sm: var(--s2a-border-width-1);
+    --s2a-border-width-md: var(--s2a-border-width-2);
+    --s2a-border-width-lg: var(--s2a-border-width-4);
+
+    /* Opacity */
+    --s2a-opacity-scrim-subtle: var(--s2a-opacity-32);
+    --s2a-opacity-disabled: var(--s2a-opacity-48);
+    --s2a-opacity-scrim-strong: var(--s2a-opacity-64);
+
+    /* Spacing */
+    --s2a-spacing-none: var(--s2a-spacing-0);
+    --s2a-spacing-3xs: var(--s2a-spacing-2);
+    --s2a-spacing-2xs: var(--s2a-spacing-4);
+    --s2a-spacing-xs: var(--s2a-spacing-8);
+    --s2a-spacing-sm: var(--s2a-spacing-12);
+    --s2a-spacing-md: var(--s2a-spacing-16);
+    --s2a-spacing-lg: var(--s2a-spacing-24);
+    --s2a-spacing-xl: var(--s2a-spacing-32);
+    --s2a-spacing-2xl: var(--s2a-spacing-40);
+    --s2a-spacing-3xl: var(--s2a-spacing-48);
+    --s2a-spacing-4xl: var(--s2a-spacing-64);
+
+    /* Layout */
+    --s2a-layout-sm: var(--s2a-spacing-80);
+    --s2a-layout-md: var(--s2a-spacing-96);
+    --s2a-layout-lg: var(--s2a-spacing-124);
+    --s2a-layout-xl: var(--s2a-spacing-160);
+    --s2a-layout-2xl: var(--s2a-spacing-240);
+
+    /* Font Family */
+    --s2a-font-family-default: var(--s2a-font-family-adobe-clean);
+    --s2a-font-family-heading: var(--s2a-font-family-adobe-clean-display);
+    --s2a-font-family-subheading: var(--s2a-font-family-adobe-clean-display);
+    --s2a-font-family-body: var(--s2a-font-family-adobe-clean);
+    --s2a-font-family-label: var(--s2a-font-family-adobe-clean);
+    --s2a-font-family-eyebrow: var(--s2a-font-family-adobe-clean);
+    --s2a-font-family-caption: var(--s2a-font-family-adobe-clean);
+
+    /* Font Letter Spacing — 0.0.16: 7xl–11xl removed; 2xl–6xl remapped */
+    --s2a-font-letter-spacing-xs: var(--s2a-font-letter-spacing-neg-3-84);
+    --s2a-font-letter-spacing-sm: var(--s2a-font-letter-spacing-neg-3-2);
+    --s2a-font-letter-spacing-md: var(--s2a-font-letter-spacing-neg-2-88);
+    --s2a-font-letter-spacing-lg: var(--s2a-font-letter-spacing-neg-1-68);
+    --s2a-font-letter-spacing-xl: var(--s2a-font-letter-spacing-neg-1-44);
+    --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1);
+    --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-0-96);
+    --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0-48);
+    --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0-2);
+    --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-0);
+
+    /* Font Line Height */
+    --s2a-font-line-height-2xs: var(--s2a-font-line-height-16);
+    --s2a-font-line-height-xs: var(--s2a-font-line-height-18);
+    --s2a-font-line-height-sm: var(--s2a-font-line-height-20);
+    --s2a-font-line-height-md: var(--s2a-font-line-height-24);
+    --s2a-font-line-height-lg: var(--s2a-font-line-height-32);
+    --s2a-font-line-height-xl: var(--s2a-font-line-height-40);
+    --s2a-font-line-height-2xl: var(--s2a-font-line-height-48);
+    --s2a-font-line-height-3xl: var(--s2a-font-line-height-56);
+    --s2a-font-line-height-4xl: var(--s2a-font-line-height-69);
+    --s2a-font-line-height-5xl: var(--s2a-font-line-height-76);
+    --s2a-font-line-height-6xl: var(--s2a-font-line-height-92);
+
+    /* Font Size */
+    --s2a-font-size-xs: var(--s2a-font-size-12);
+    --s2a-font-size-sm: var(--s2a-font-size-14);
+    --s2a-font-size-md: var(--s2a-font-size-16);
+    --s2a-font-size-lg: var(--s2a-font-size-18);
+    --s2a-font-size-xl: var(--s2a-font-size-20);
+    --s2a-font-size-2xl: var(--s2a-font-size-24);
+    --s2a-font-size-3xl: var(--s2a-font-size-32);
+    --s2a-font-size-4xl: var(--s2a-font-size-36);
+    --s2a-font-size-5xl: var(--s2a-font-size-40);
+    --s2a-font-size-6xl: var(--s2a-font-size-48);
+    --s2a-font-size-7xl: var(--s2a-font-size-56);
+    --s2a-font-size-8xl: var(--s2a-font-size-64);
+    --s2a-font-size-9xl: var(--s2a-font-size-72);
+    --s2a-font-size-10xl: var(--s2a-font-size-80);
+    --s2a-font-size-11xl: var(--s2a-font-size-96);
+
+    /* Blur */
+    --s2a-blur-xs: var(--s2a-blur-8);
+    --s2a-blur-sm: var(--s2a-blur-16);
+    --s2a-blur-md: var(--s2a-blur-32);
+    --s2a-blur-lg: var(--s2a-blur-64);
+
+    /* Font Weight — Role */
+    --s2a-font-weight-heading: var(--s2a-font-weight-adobe-clean-display-black);
+    --s2a-font-weight-body: var(--s2a-font-weight-adobe-clean-regular);
+    --s2a-font-weight-eyebrow: var(--s2a-font-weight-adobe-clean-bold);
+    --s2a-font-weight-label: var(--s2a-font-weight-adobe-clean-bold);
+    --s2a-font-weight-caption: var(--s2a-font-weight-adobe-clean-bold);
+}
+
+
+/* =========================================
+   Semantic Color Tokens — Light Mode
+   Source: tokens.semantic.light.css
+   ========================================= */
+:root,
+:root[data-theme="light"] {
+    --s2a-color-background-default: var(--s2a-color-gray-25);
+    --s2a-color-background-subtle: var(--s2a-color-gray-50);
+    --s2a-color-background-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-background-knockout: var(--s2a-color-gray-1000);
+    --s2a-color-background-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-background-disabled: var(--s2a-color-gray-50);
+    --s2a-color-background-utility-error: var(--s2a-color-red-900);
+    --s2a-color-border-default: var(--s2a-color-gray-800);
+    --s2a-color-border-subtle: var(--s2a-color-gray-300);
+    --s2a-color-border-strong: var(--s2a-color-gray-900);
+    --s2a-color-border-knockout: var(--s2a-color-gray-1000);
+    --s2a-color-border-inverse: var(--s2a-color-gray-25);
+    --s2a-color-border-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-border-disabled: var(--s2a-color-gray-400);
+    --s2a-color-border-utility-error: var(--s2a-color-red-900);
+    --s2a-color-content-default: var(--s2a-color-gray-1000);
+    --s2a-color-content-subtle: var(--s2a-color-transparent-black-64);
+    --s2a-color-content-strong: var(--s2a-color-gray-900);
+    --s2a-color-content-knockout: var(--s2a-color-gray-25);
+    --s2a-color-content-inverse: var(--s2a-color-content-knockout);
+    --s2a-color-content-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-content-disabled: var(--s2a-color-gray-400);
+    --s2a-color-content-utility-error: var(--s2a-color-red-900);
+    --s2a-color-content-heading: var(--s2a-color-content-default);
+    --s2a-color-content-subheading: var(--s2a-color-gray-1000);
+    --s2a-color-content-body-subtle: var(--s2a-color-content-subtle);
+    --s2a-color-content-body-strong: var(--s2a-color-content-strong);
+    --s2a-color-content-eyebrow: var(--s2a-color-transparent-black-64);
+    --s2a-color-content-label: var(--s2a-color-content-default);
+    --s2a-color-content-caption: var(--s2a-color-content-subtle);
+    --s2a-color-focus-ring-default: var(--s2a-color-blue-900);
+    --s2a-color-focus-ring-knockout: var(--s2a-color-gray-25);
+
+    /* Button */
+    --s2a-color-button-background-accent-solid-on-light-active: var(--s2a-color-blue-1100);
+    --s2a-color-button-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
+    --s2a-color-button-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
+    --s2a-color-button-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-button-background-primary-outlined-on-light-active: var(--s2a-color-gray-1000);
+    --s2a-color-button-background-primary-outlined-on-light-default: var(--s2a-color-transparent-black-00);
+    --s2a-color-button-background-primary-outlined-on-light-hover: var(--s2a-color-transparent-black-08);
+    --s2a-color-button-background-primary-solid-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-button-background-primary-solid-on-light-active: var(--s2a-color-gray-1000);
+    --s2a-color-button-background-primary-solid-on-light-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-background-primary-solid-on-light-hover: var(--s2a-color-transparent-black-64);
+    --s2a-color-button-background-primary-transparent-on-dark-active: var(--s2a-color-transparent-white-16);
+    --s2a-color-button-background-primary-transparent-on-dark-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-button-background-primary-transparent-on-dark-hover: var(--s2a-color-transparent-white-12);
+    --s2a-color-button-background-primary-transparent-on-light-active: var(--s2a-color-transparent-black-12);
+    --s2a-color-button-background-primary-transparent-on-light-default: var(--s2a-color-transparent-black-00);
+    --s2a-color-button-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-black-08);
+    --s2a-color-button-border-primary-outlined-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-outlined-on-light-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-border-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-solid-on-dark-hover: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-solid-on-light-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-outlined-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-outlined-knockout: var(--s2a-color-gray-25);
+    --s2a-color-button-content-primary-solid-default: var(--s2a-color-gray-25);
+    --s2a-color-button-content-primary-solid-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-transparent-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+
+    /* Icon Button */
+    --s2a-color-iconbutton-background-accent-solid-on-light-active: var(--s2a-color-blue-1100);
+    --s2a-color-iconbutton-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
+    --s2a-color-iconbutton-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-defatul: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-active: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-default: var(--s2a-color-transparent-black-00);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-hover: var(--s2a-color-transparent-black-08);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-solid-on-light-active: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-background-primary-solid-on-light-default: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-background-primary-solid-on-light-hover: var(--s2a-color-transparent-black-64);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-active: var(--s2a-color-transparent-white-16);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-hover: var(--s2a-color-transparent-white-12);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-active: var(--s2a-color-transparent-black-12);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-default: var(--s2a-color-transparent-black-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-black-08);
+    --s2a-color-iconbutton-border-primary-outlined-default: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-border-primary-outlined-on-dark: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-border-primary-solid-default: var(--s2a-color-transparent-white-12);
+    --s2a-color-iconbutton-content-primary-outlined-default: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-content-primary-outlined-knockout: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-solid-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-solid-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-content-primary-transparent-default: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+}
+
+
+/* =========================================
+   Semantic Color Tokens — Dark Mode
+   Source: tokens.semantic.dark.css
+   ========================================= */
+:root[data-theme="dark"] {
+    --s2a-color-background-default: var(--s2a-color-gray-900);
+    --s2a-color-background-subtle: var(--s2a-color-gray-700);
+    --s2a-color-background-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-background-knockout: var(--s2a-color-gray-1000);
+    --s2a-color-background-inverse: var(--s2a-color-gray-25);
+    --s2a-color-background-disabled: var(--s2a-color-gray-50);
+    --s2a-color-background-utility-error: var(--s2a-color-red-900);
+    --s2a-color-border-default: var(--s2a-color-gray-300);
+    --s2a-color-border-subtle: var(--s2a-color-gray-300);
+    --s2a-color-border-strong: var(--s2a-color-gray-25);
+    --s2a-color-border-knockout: var(--s2a-color-gray-25);
+    --s2a-color-border-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-border-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-border-disabled: var(--s2a-color-gray-400);
+    --s2a-color-border-utility-error: var(--s2a-color-red-900);
+    --s2a-color-content-default: var(--s2a-color-gray-25);
+    --s2a-color-content-subtle: var(--s2a-color-transparent-white-64);
+    --s2a-color-content-strong: var(--s2a-color-gray-600);
+    --s2a-color-content-knockout: var(--s2a-color-gray-25);
+    --s2a-color-content-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-content-brand: var(--s2a-color-brand-adobe-red);
+    --s2a-color-content-disabled: var(--s2a-color-gray-400);
+    --s2a-color-content-utility-error: var(--s2a-color-red-900);
+    --s2a-color-content-heading: var(--s2a-color-content-knockout);
+    --s2a-color-content-subheading: var(--s2a-color-content-knockout);
+    --s2a-color-content-body-subtle: var(--s2a-color-content-subtle);
+    --s2a-color-content-body-strong: var(--s2a-color-content-strong);
+    --s2a-color-content-eyebrow: var(--s2a-color-transparent-white-48);
+    --s2a-color-content-label: var(--s2a-color-content-knockout);
+    --s2a-color-content-caption: var(--s2a-color-content-subtle);
+    --s2a-color-focus-ring-default: var(--s2a-color-blue-500);
+    --s2a-color-focus-ring-knockout: var(--s2a-color-gray-25);
+
+    /* Button */
+    --s2a-color-button-background-accent-solid-on-light-active: var(--s2a-color-blue-1100);
+    --s2a-color-button-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
+    --s2a-color-button-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
+    --s2a-color-button-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-button-background-primary-outlined-on-light-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-outlined-on-light-default: var(--s2a-color-transparent-black-00);
+    --s2a-color-button-background-primary-outlined-on-light-hover: var(--s2a-color-transparent-black-08);
+    --s2a-color-button-background-primary-solid-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-button-background-primary-solid-on-light-active: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-light-default: var(--s2a-color-gray-25);
+    --s2a-color-button-background-primary-solid-on-light-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-button-background-primary-transparent-on-dark-active: var(--s2a-color-transparent-white-00);
+    --s2a-color-button-background-primary-transparent-on-dark-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-button-background-primary-transparent-on-dark-hover: var(--s2a-color-transparent-white-00);
+    --s2a-color-button-background-primary-transparent-on-light-active: var(--s2a-color-transparent-white-24);
+    --s2a-color-button-background-primary-transparent-on-light-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-button-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-white-12);
+    --s2a-color-button-border-primary-outlined-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-outlined-on-light-default: var(--s2a-color-gray-300);
+    --s2a-color-button-border-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-solid-on-dark-hover: var(--s2a-color-gray-25);
+    --s2a-color-button-border-primary-solid-on-light-default: var(--s2a-color-gray-300);
+    --s2a-color-button-content-primary-outlined-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-outlined-knockout: var(--s2a-color-gray-25);
+    --s2a-color-button-content-primary-solid-default: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-solid-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-button-content-primary-transparent-default: var(--s2a-color-gray-25);
+    --s2a-color-button-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+
+    /* Icon Button */
+    --s2a-color-iconbutton-background-accent-solid-on-light-active: var(--s2a-color-blue-1100);
+    --s2a-color-iconbutton-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
+    --s2a-color-iconbutton-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-defatul: var(--s2a-color-transparent-white-24);
+    --s2a-color-iconbutton-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-outlined-on-light-hover: var(--s2a-color-transparent-white-12);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-default: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-solid-on-dark-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-solid-on-light-active: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-solid-on-light-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-background-primary-solid-on-light-hover: var(--s2a-color-transparent-white-64);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-active: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-dark-hover: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-active: var(--s2a-color-transparent-white-24);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-default: var(--s2a-color-transparent-white-00);
+    --s2a-color-iconbutton-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-white-12);
+    --s2a-color-iconbutton-border-primary-outlined-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-border-primary-outlined-on-dark: var(--s2a-color-gray-700);
+    --s2a-color-iconbutton-border-primary-solid-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-outlined-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-outlined-knockout: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-solid-default: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-content-primary-solid-inverse: var(--s2a-color-gray-1000);
+    --s2a-color-iconbutton-content-primary-transparent-default: var(--s2a-color-gray-25);
+    --s2a-color-iconbutton-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+
+    /* =========================================
+       Responsive Tokens
+       Source: tokens.responsive.sm/md/lg/xl.css
+       ========================================= */
+
+    /* Mobile — base (no media query) */
+    --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+    --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-md);
+    --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-lg);
+    --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-xl);
+    --s2a-viewport-vertical-padding-md: var(--s2a-spacing-2xl);
+    --s2a-viewport-vertical-padding-lg: var(--s2a-spacing-4xl);
+    --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm);
+    --s2a-layout-guide-gap: var(--s2a-spacing-xs);
+    --s2a-typography-font-size-super: var(--s2a-font-size-7xl);
+    --s2a-typography-font-size-heading-1: var(--s2a-font-size-5xl);
+    --s2a-typography-font-size-heading-2: var(--s2a-font-size-3xl);
+    --s2a-typography-font-size-heading-3: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-heading-4: var(--s2a-font-size-xl);
+    --s2a-typography-font-size-heading-5: var(--s2a-font-size-lg);
+    --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
+    --s2a-typography-font-size-body-lg: var(--s2a-font-size-md);
+    --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
+    --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
+    --s2a-typography-font-size-body-xs: var(--s2a-font-size-xs);
+    --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
+    --s2a-typography-font-size-label: var(--s2a-font-size-sm);
+    --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+    --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
+    --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-lg);
+    --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-3xl);
+    --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-5xl);
+    --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
+    --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+    --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);
+    --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-xl);
+    --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-lg);
+    --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-md);
+    --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-sm);
+    --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+    --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+    --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-sm);
+    --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
+    --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
+    --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
+    --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
+    --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
+    --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+    --s2a-router-card-width-resting: 243px;
+    --s2a-router-card-width-expanded: 409px;
+    --s2a-router-card-width-min: 200px;
+    --s2a-router-card-width-max: 409px;
+    --s2a-router-card-height-max: 510px;
+    --s2a-router-card-media-height: 325px;
+    --s2a-router-card-gap: var(--s2a-spacing-8);
+    --s2a-router-card-padding: var(--s2a-spacing-lg);
+    --s2a-app-card-min-height: 160px;
+    --s2a-app-card-max-height: 200px;
+    --s2a-app-card-border-radius: var(--s2a-border-radius-xs);
+    --s2a-app-card-padding: var(--s2a-spacing-16);
+    --s2a-app-card-gap: var(--s2a-spacing-xl);
+    --s2a-app-card-padding-vertical: var(--s2a-spacing-lg);
+    --s2a-app-card-padding-horizontal: var(--s2a-spacing-xs);
+    --s2a-product-lockup-gap-block-start: var(--s2a-spacing-8);
+    --s2a-product-lockup-gap-block: var(--s2a-spacing-sm);
+    --s2a-product-lockup-gap-inline-start: var(--s2a-spacing-8);
+    --s2a-product-lockup-gap-inline: var(--s2a-spacing-8);
+    --s2a-layout-rich-media-content-measure-narrow: 320px;
+    --s2a-layout-rich-media-content-measure-wide: 375px;
+    --s2a-layout-rich-media-content-measure-none: 375px;
+}
+
+/* Tablet — 1024px+ */
+@media (min-width: 1024px) {
+    :root {
+        --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+        --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
+        --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-2xl);
+        --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-4xl);
+        --s2a-viewport-vertical-padding-md: var(--s2a-layout-sm);
+        --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg);
+        --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl);
+        --s2a-layout-guide-gap: var(--s2a-spacing-xs);
+        --s2a-typography-font-size-super: var(--s2a-font-size-9xl);
+        --s2a-typography-font-size-heading-1: var(--s2a-font-size-7xl);
+        --s2a-typography-font-size-heading-2: var(--s2a-font-size-6xl);
+        --s2a-typography-font-size-heading-3: var(--s2a-font-size-3xl);
+        --s2a-typography-font-size-heading-4: var(--s2a-font-size-2xl);
+        --s2a-typography-font-size-heading-5: var(--s2a-font-size-xl);
+        --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
+        --s2a-typography-font-size-body-lg: var(--s2a-font-size-lg);
+        --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
+        --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
+        --s2a-typography-font-size-label: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+        --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
+        --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+        --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-xl);
+        --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+        --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+        --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+        --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
+        --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);
+        --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-3xl);
+        --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-2xl);
+        --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
+        --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+        --s2a-router-card-width-resting: 243px;
+        --s2a-router-card-width-expanded: 409px;
+        --s2a-router-card-width-min: 200px;
+        --s2a-router-card-width-max: 409px;
+        --s2a-router-card-height-max: 510px;
+        --s2a-router-card-media-height: 325px;
+        --s2a-router-card-gap: var(--s2a-spacing-8);
+        --s2a-router-card-padding: var(--s2a-spacing-lg);
+        --s2a-app-card-min-height: 160px;
+        --s2a-app-card-max-height: 200px;
+        --s2a-app-card-border-radius: var(--s2a-border-radius-md);
+        --s2a-app-card-padding: var(--s2a-spacing-24);
+        --s2a-app-card-gap: var(--s2a-spacing-xl);
+        --s2a-app-card-padding-vertical: var(--s2a-spacing-lg);
+        --s2a-app-card-padding-horizontal: var(--s2a-spacing-lg);
+        --s2a-product-lockup-gap-block-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-block: var(--s2a-spacing-sm);
+        --s2a-product-lockup-gap-inline-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-inline: var(--s2a-spacing-16);
+        --s2a-layout-rich-media-content-measure-narrow: 456px;
+        --s2a-layout-rich-media-content-measure-wide: 848px;
+        --s2a-layout-rich-media-content-measure-none: 848px;
+    }
+}
+
+/* Desktop — 1280px+ */
+@media (min-width: 1280px) {
+    :root {
+        --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+        --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
+        --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
+        --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
+        --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
+        --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
+        --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
+        --s2a-layout-guide-gap: var(--s2a-spacing-xs);
+        --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
+        --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+        --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+        --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+        --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+        --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+        --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
+        --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
+        --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
+        --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
+        --s2a-typography-font-size-label: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+        --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
+        --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+        --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+        --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+        --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+        --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-3xl);
+        --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
+        --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
+        --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+        --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+        --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+        --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+        --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+        --s2a-router-card-width-resting: 294px;
+        --s2a-router-card-width-expanded: 496px;
+        --s2a-router-card-width-min: 243px;
+        --s2a-router-card-width-max: 496px;
+        --s2a-router-card-height-max: 576px;
+        --s2a-router-card-media-height: 394px;
+        --s2a-router-card-gap: var(--s2a-spacing-8);
+        --s2a-router-card-padding: var(--s2a-spacing-24);
+        --s2a-app-card-min-height: 160px;
+        --s2a-app-card-max-height: 200px;
+        --s2a-app-card-border-radius: var(--s2a-border-radius-md);
+        --s2a-app-card-padding: var(--s2a-spacing-24);
+        --s2a-app-card-gap: var(--s2a-spacing-xl);
+        --s2a-app-card-padding-vertical: var(--s2a-spacing-lg);
+        --s2a-app-card-padding-horizontal: var(--s2a-spacing-lg);
+        --s2a-product-lockup-gap-block-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-block: var(--s2a-spacing-sm);
+        --s2a-product-lockup-gap-inline-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-inline: var(--s2a-spacing-16);
+        --s2a-layout-rich-media-content-measure-narrow: 512px;
+        --s2a-layout-rich-media-content-measure-wide: 1192px;
+        --s2a-layout-rich-media-content-measure-none: 1192px;
+    }
+}
+
+/* HD — 1441px+ */
+@media (min-width: 1441px) {
+    :root {
+        --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+        --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
+        --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
+        --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
+        --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
+        --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
+        --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
+        --s2a-layout-guide-gap: var(--s2a-spacing-xs);
+        --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
+        --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+        --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+        --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+        --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+        --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+        --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
+        --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
+        --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
+        --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
+        --s2a-typography-font-size-label: var(--s2a-font-size-sm);
+        --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+        --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
+        --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+        --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+        --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+        --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+        --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+        --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
+        --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+        --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
+        --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+        --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+        --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+        --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+        --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
+        --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
+        --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
+        --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+        --s2a-router-card-width-resting: 294px;
+        --s2a-router-card-width-expanded: 496px;
+        --s2a-router-card-width-min: 243px;
+        --s2a-router-card-width-max: 496px;
+        --s2a-router-card-height-max: 576px;
+        --s2a-router-card-media-height: 394px;
+        --s2a-router-card-gap: var(--s2a-spacing-8);
+        --s2a-router-card-padding: var(--s2a-spacing-24);
+        --s2a-app-card-min-height: 160px;
+        --s2a-app-card-max-height: 200px;
+        --s2a-app-card-border-radius: var(--s2a-border-radius-md);
+        --s2a-app-card-padding: var(--s2a-spacing-24);
+        --s2a-app-card-gap: var(--s2a-spacing-xl);
+        --s2a-app-card-padding-vertical: var(--s2a-spacing-lg);
+        --s2a-app-card-padding-horizontal: var(--s2a-spacing-lg);
+        --s2a-product-lockup-gap-block-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-block: var(--s2a-spacing-sm);
+        --s2a-product-lockup-gap-inline-start: var(--s2a-spacing-16);
+        --s2a-product-lockup-gap-inline: var(--s2a-spacing-16);
+        --s2a-layout-rich-media-content-measure-narrow: 512px;
+        --s2a-layout-rich-media-content-measure-wide: 1480px;
+        --s2a-layout-rich-media-content-measure-none: 1480px;
+    }
+}
+
+
+.sessions-guide[data-theme="dark"] {
+  --s2a-color-background-default: #0d0d0d;
+  --s2a-color-background-subtle: #1a1a1a;
+  --s2a-color-content-default: #fff;
+  --s2a-color-content-subtle: rgb(255 255 255 / 64%);
+  --s2a-color-border-default: #fff;
+  --s2a-color-border-subtle: rgb(255 255 255 / 16%);
+}

--- a/event-libs/v1/libs.js
+++ b/event-libs/v1/libs.js
@@ -25,6 +25,7 @@ const EVENT_BLOCKS = [
 ];
 
 const EVENT_BLOCKS_C2 = [
+  'mobile-rider',
 ];
 
 // Import only the most essential utilities that are always needed

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -587,17 +587,22 @@ function prebuildAutoBlock(blockName, link) {
 export function processAutoBlockLinks(parent) {
   // selfInit: true — block lives inside an already-loaded parent (e.g. marquee);
   // Milo won't re-scan it, so we import and call init() directly with the anchor.
+  // c2: true — this block has a C2 copy under v1/c2/blocks/, so on a
+  // `foundation: c2` page load it from there instead of the classic v1/blocks/.
+  const isC2 = getMetadata('foundation') === 'c2';
   const autoBlockIdentifiers = {
     'chrono-box': { pattern: 'schedule-maker' },
-    'mobile-rider': { pattern: 'mobilerider.com', selfInit: true },
+    'mobile-rider': { pattern: 'mobilerider.com', selfInit: true, c2: true },
   };
 
-  Object.entries(autoBlockIdentifiers).forEach(([blockName, { pattern, selfInit }]) => {
+  Object.entries(autoBlockIdentifiers).forEach(([blockName, { pattern, selfInit, c2 }]) => {
     const links = parent.querySelectorAll(`a[href*="${pattern}"]`);
     Promise.all([...links].map(async (link) => {
       if (selfInit) {
         link.classList.add(blockName, 'link-block');
-        const { default: initBlock } = await import(`../blocks/${blockName}/${blockName}.js`);
+        // Route to the C2 copy only when the page is C2 *and* the block has one;
+        const blocksDir = (isC2 && c2) ? '../c2/blocks' : '../blocks';
+        const { default: initBlock } = await import(`${blocksDir}/${blockName}/${blockName}.js`);
         await initBlock(link);
         return;
       }

--- a/test/unit/blocks/mobile-rider/drawer.test.js
+++ b/test/unit/blocks/mobile-rider/drawer.test.js
@@ -1,12 +1,20 @@
 /* eslint-disable no-unused-vars */
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import createDrawer from '../../../../event-libs/v1/blocks/mobile-rider/drawer.js';
 
-describe('Mobile Rider Drawer', () => {
-  let mockLana;
+// Runs the full drawer suite against a given drawer.js implementation - the
+// classic block and the C2 copy - so a regression in either is caught
+// directly instead of relying on the other variant's coverage.
+function runDrawerSuite(modulePath, variantLabel) {
+  describe(`Mobile Rider Drawer (${variantLabel})`, () => {
+    let createDrawer;
+    let mockLana;
 
-  beforeEach(() => {
+    before(async () => {
+      ({ default: createDrawer } = await import(modulePath));
+    });
+
+    beforeEach(() => {
     // Mock lana
     mockLana = { log: sinon.stub() };
     globalThis.lana = mockLana;
@@ -428,4 +436,8 @@ describe('Mobile Rider Drawer', () => {
       expect(() => drawer.remove()).to.not.throw();
     });
   });
-});
+  });
+}
+
+runDrawerSuite('../../../../event-libs/v1/blocks/mobile-rider/drawer.js', 'classic');
+runDrawerSuite('../../../../event-libs/v1/c2/blocks/mobile-rider/drawer.js', 'C2');

--- a/test/unit/blocks/mobile-rider/mobile-rider.test.js
+++ b/test/unit/blocks/mobile-rider/mobile-rider.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import init from '../../../../event-libs/v1/blocks/mobile-rider/mobile-rider.js';
 
 const defaultHtml = `
 <div class="mobile-rider">
@@ -36,11 +35,21 @@ const defaultHtml = `
 </div>
 `;
 
-describe('Mobile Rider Module', () => {
-  let mockLana;
-  let riderInstance = null;
+// Runs the full behavior suite against a given mobile-rider.js implementation
+// - the classic block and the C2 copy - so a regression in either (a broken
+// drawer import, a broken ASL listener, etc.) is caught directly instead of
+// relying on the other variant's coverage or an indirect routing test.
+function runMobileRiderSuite(modulePath, variantLabel) {
+  describe(`Mobile Rider Module (${variantLabel})`, () => {
+    let init;
+    let mockLana;
+    let riderInstance = null;
 
-  beforeEach(() => {
+    before(async () => {
+      ({ default: init } = await import(modulePath));
+    });
+
+    beforeEach(() => {
     mockLana = { log: sinon.stub() };
     globalThis.lana = mockLana;
 
@@ -873,4 +882,8 @@ describe('Mobile Rider Module', () => {
       expect(instance).to.not.be.null;
     });
   });
-});
+  });
+}
+
+runMobileRiderSuite('../../../../event-libs/v1/blocks/mobile-rider/mobile-rider.js', 'classic');
+runMobileRiderSuite('../../../../event-libs/v1/c2/blocks/mobile-rider/mobile-rider.js', 'C2');

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -1848,6 +1848,29 @@ describe('decorateEvent - Array Iteration', () => {
       await new Promise((resolve) => { setTimeout(resolve, 50); });
     });
 
+    it('routes the MR auto-block to the C2 copy on a foundation:c2 page', async () => {
+      // The block injects its own CSS from its module path, so the injected
+      // link's href reveals which copy (classic vs c2/) actually loaded.
+      document.getElementById('mobile-rider-css')?.remove();
+      setMetadata('foundation', 'c2');
+      try {
+        const parent = document.createElement('div');
+        const link = document.createElement('a');
+        link.href = 'https://assets.mobilerider.com/embed?videoId=c2test';
+        parent.appendChild(link);
+
+        processAutoBlockLinks(parent);
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+        const cssLink = document.getElementById('mobile-rider-css');
+        expect(cssLink, 'block CSS injected — the module ran').to.not.be.null;
+        expect(cssLink.href, 'loaded from the c2/ path').to.contain('/c2/blocks/mobile-rider/');
+      } finally {
+        setMetadata('foundation', '');
+        document.getElementById('mobile-rider-css')?.remove();
+      }
+    });
+
     function encodeSchedule(schedule) {
       return window.btoa(unescape(encodeURIComponent(JSON.stringify(schedule))));
     }


### PR DESCRIPTION
Rounds the Mobile Rider (MR) video player's corners on the MAX 2026 (C2) Homepage, replacing the squared C1 corners — desktop only, per [MWPW-200845](https://jira.corp.adobe.com/browse/MWPW-200845). Ships as a new C2 copy of the block rather than editing the classic one.
New C2 copy of the block at event-libs/v1/c2/blocks/mobile-rider/ (js/css/drawer), loaded only on foundation: c2 pages — the classic block at v1/blocks/mobile-rider/ is unmodified and still serves non-C2 pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-200845

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/drafts/hnv/mobilerider?martech=off
- After: https://main--da-events--adobecom.aem.page/drafts/hnv/mobilerider?martech=off&eventlibs=mobile-rider-v2
