### PR TITLE
[MWPW-200847, MWPW-200846]:- Rounded Corners on (MPC/YouTube) Player

### DIFF
--- a/event-libs/v1/c2/styles/c2-global.css
+++ b/event-libs/v1/c2/styles/c2-global.css
@@ -2,46 +2,6 @@
 
 @import './tokens.css';
 
-/*
- * Global C2 styles — loaded once per page, only when `foundation: c2`
- * (see event-libs/scripts/scripts.js -> loadStyles, guarded by IS_C2).
- *
- * Unlike a block stylesheet (which loads only when its block is on the page),
- * this file is the home for page-wide C2 concerns that can't belong to any one
- * block. Rules here are additionally gated with
- * `:root:has(meta[name="foundation"][content="c2"])` — Milo's own idiom (see
- * libs/blocks/video/video.css) — so they stay inert on C1 pages even if this
- * file is ever loaded there.
- */
-
-/*
- * MWPW-200847 (MR) / MPC / YouTube rounded corners.
- *
- * MAX 2026 (C2) rounds every embedded video player on desktop; C1 kept them
- * squared, and mobile stays squared here too. YouTube and MPC (Adobe TV /
- * "Media Publishing Cloud") are Milo AUTO_BLOCKS we can't copy into our c2/
- * folder — but both render their iframe into Milo's shared `.milo-video`
- * wrapper (libs/blocks/youtube/youtube.js, libs/blocks/adobetv/adobetv.js), so
- * a single rule on `.milo-video` rounds both, wherever they appear on the page
- * (marquee, split-marquee, or anywhere else) — not just inside one block.
- *
- * Radius per the Figma SSOT (24px, matching the MR HP_Player). `overflow:
- * hidden` clips the iframe's square corners to the rounded wrapper. The 1024px
- * cutoff is the C2 "not mobile" boundary; below it the player keeps square
- * corners, per the ticket. Milo does NOT round `.milo-video` itself — its only
- * C2 video rounding is the 4px play-pause button (video.css), not the frame —
- * so this is additive, not an override.
- *
- * max-width matches the same Figma measurement as Mobile Rider's standalone
- * placement (1192px at 1440px, via the same C2 "rich media content measure"
- * token). Unlike .mobile-rider-container, .milo-video has no outer wrapper
- * element we control — youtube.js/adobetv.js insert it directly into the
- * page, not inside a block div we own — so max-width has to live on the same
- * element as border-radius/overflow: hidden. That combination broke <video>
- * clipping for Mobile Rider, but YouTube/MPC render as <iframe>, not <video>,
- * so that specific bug may not apply here. Verify this empirically (same way
- * the Mobile Rider bug was originally caught) before assuming it's safe.
- */
 @media (min-width: 1024px) {
   :root:has(meta[name="foundation"][content="c2"]) .milo-video {
     border-radius: var(--s2a-border-radius-24, 24px);

--- a/event-libs/v1/c2/styles/c2-global.css
+++ b/event-libs/v1/c2/styles/c2-global.css
@@ -1,0 +1,52 @@
+/* stylelint-disable selector-class-pattern */
+
+@import './tokens.css';
+
+/*
+ * Global C2 styles — loaded once per page, only when `foundation: c2`
+ * (see event-libs/scripts/scripts.js -> loadStyles, guarded by IS_C2).
+ *
+ * Unlike a block stylesheet (which loads only when its block is on the page),
+ * this file is the home for page-wide C2 concerns that can't belong to any one
+ * block. Rules here are additionally gated with
+ * `:root:has(meta[name="foundation"][content="c2"])` — Milo's own idiom (see
+ * libs/blocks/video/video.css) — so they stay inert on C1 pages even if this
+ * file is ever loaded there.
+ */
+
+/*
+ * MWPW-200847 (MR) / MPC / YouTube rounded corners.
+ *
+ * MAX 2026 (C2) rounds every embedded video player on desktop; C1 kept them
+ * squared, and mobile stays squared here too. YouTube and MPC (Adobe TV /
+ * "Media Publishing Cloud") are Milo AUTO_BLOCKS we can't copy into our c2/
+ * folder — but both render their iframe into Milo's shared `.milo-video`
+ * wrapper (libs/blocks/youtube/youtube.js, libs/blocks/adobetv/adobetv.js), so
+ * a single rule on `.milo-video` rounds both, wherever they appear on the page
+ * (marquee, split-marquee, or anywhere else) — not just inside one block.
+ *
+ * Radius per the Figma SSOT (24px, matching the MR HP_Player). `overflow:
+ * hidden` clips the iframe's square corners to the rounded wrapper. The 1024px
+ * cutoff is the C2 "not mobile" boundary; below it the player keeps square
+ * corners, per the ticket. Milo does NOT round `.milo-video` itself — its only
+ * C2 video rounding is the 4px play-pause button (video.css), not the frame —
+ * so this is additive, not an override.
+ *
+ * max-width matches the same Figma measurement as Mobile Rider's standalone
+ * placement (1192px at 1440px, via the same C2 "rich media content measure"
+ * token). Unlike .mobile-rider-container, .milo-video has no outer wrapper
+ * element we control — youtube.js/adobetv.js insert it directly into the
+ * page, not inside a block div we own — so max-width has to live on the same
+ * element as border-radius/overflow: hidden. That combination broke <video>
+ * clipping for Mobile Rider, but YouTube/MPC render as <iframe>, not <video>,
+ * so that specific bug may not apply here. Verify this empirically (same way
+ * the Mobile Rider bug was originally caught) before assuming it's safe.
+ */
+@media (min-width: 1024px) {
+  :root:has(meta[name="foundation"][content="c2"]) .milo-video {
+    border-radius: var(--s2a-border-radius-24, 24px);
+    overflow: hidden;
+    max-width: var(--s2a-layout-rich-media-content-measure-wide, 1192px);
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
Rounds the YouTube and MPC (Media Publishing Cloud/Adobe TV) video player corners on the MAX 2026 (C2) Homepage, matching the same treatment as Mobile Rider (MWPW-200847) — desktop only, per the corresponding YouTube and MPC tickets.
One shared rule covers both providers. YouTube (youtube.js) and MPC/Adobe TV (adobetv.js) are Milo's own AUTO_BLOCKS — we can't copy them into our c2/ folder the way we did with Mobile Rider. But both render their iframe into the same shared wrapper class, .milo-video, so a single CSS rule targeting .milo-video rounds both providers wherever they appear on the page (marquee, split-marquee, or elsewhere) — not scoped to one block.
New global C2 stylesheet: event-libs/v1/c2/styles/c2-global.css. This didn't exist before — a page-wide rule can't live inside any one block's own CSS (block CSS only loads when that block is present), so this is the first project-wide stylesheet for cross-block C2 concerns.
Resolves: [https://jira.corp.adobe.com/browse/MWPW-200847, https://jira.corp.adobe.com/browse/MWPW-200846)

Test URLs:
- Before: https://main--da-events--adobecom.aem.page/drafts/hnv/mobile-rider-anywhere?martech=off
- After: https://global-style-c2--da-events--adobecom.aem.page/drafts/hnv/mobile-rider-anywhere?martech=off&eventlibs=mpc-youtube-radius
