### PR TITLE
Expose openSessionGuideDetail for cross-block use

### DIFF
--- a/event-libs/v1/blocks/sessions-guide/components/DrawerShell.js
+++ b/event-libs/v1/blocks/sessions-guide/components/DrawerShell.js
@@ -1,14 +1,29 @@
 import { html, useEffect, useRef, useState } from '../../../deps/htm-preact.js';
 import { useSessionGuide } from '../store/index.js';
-import { sessions, sessionsStatus, auth } from '../../../utils/session-store.js';
+import {
+  sessions, sessionsStatus, auth, sessionGuideRequest,
+} from '../../../utils/session-store.js';
 import { DrawerHeader } from './DrawerHeader.js';
 import { ViewRouter } from './ViewRouter.js';
 import { SessionDetailOverlay } from './SessionDetailOverlay.js';
 import { FilterPanel } from './FilterPanel.js';
-import { setSessionsParam, clearSessionParams } from '../utils/url.js';
+import { setSessionParam, setSessionsParam, clearSessionParams } from '../utils/url.js';
 
 // No top gap on mobile/tablet (drawer covers the full screen); 20px gap on desktop.
 const getTopMargin = () => (window.matchMedia('(max-width: 1279px)').matches ? 0 : 20);
+
+// Pure decision logic for the openSessionGuideDetail(sessionId) external API, kept
+// separate from the useEffect below so it's directly unit-testable.
+export function resolveSessionGuideRequest(request, { sessionsStatusValue, sessionsValue, authValue }) {
+  if (!request || sessionsStatusValue !== 'ready') return null;
+  const found = sessionsValue.find((s) => s.id === request.sessionId);
+  if (!found) return { found: false, sessionId: request.sessionId };
+  return {
+    found: true,
+    sessionId: found.id,
+    defaultView: authValue.isRegistered ? 'my-sessions' : 'live-upcoming',
+  };
+}
 
 export function DrawerShell() {
   const { state, dispatch } = useSessionGuide();
@@ -147,6 +162,27 @@ export function DrawerShell() {
     const found = sessions.value.find((s) => s.rfCode === rfCode || s.id === sessionParam);
     if (found) dispatch({ type: 'SET_ACTIVE_SESSION', sessionId: found.id });
   }, [sessionsStatus.value]);
+
+  // External API: other blocks call openSessionGuideDetail(sessionId) (session-store.js) to
+  // open us straight to a session's detail view. sessions/sessionsStatus are the same
+  // page-level signals a caller's own session data comes from, so by the time a card is
+  // clickable, sessions are already 'ready' here too — no buffering needed for a request
+  // that arrives before load.
+  useEffect(() => sessionGuideRequest.subscribe((request) => {
+    const result = resolveSessionGuideRequest(request, {
+      sessionsStatusValue: sessionsStatus.value,
+      sessionsValue: sessions.value,
+      authValue: auth.value,
+    });
+    if (!result) return;
+    if (!result.found) {
+      window.lana?.log(`[sessions-guide] openSessionGuideDetail: session "${result.sessionId}" not found`);
+      return;
+    }
+    dispatch({ type: 'SET_DRAWER', drawer: 'expanded', defaultView: result.defaultView });
+    dispatch({ type: 'SET_ACTIVE_SESSION', sessionId: result.sessionId });
+    history.pushState({}, '', setSessionParam(result.sessionId));
+  }), []);
 
   // Keep sessionsRef current so the popstate handler always sees the latest list
   const sessionsRef = useRef(sessions.value);

--- a/event-libs/v1/blocks/sessions-guide/components/DrawerShell.js
+++ b/event-libs/v1/blocks/sessions-guide/components/DrawerShell.js
@@ -12,6 +12,10 @@ import { setSessionParam, setSessionsParam, clearSessionParams } from '../utils/
 // No top gap on mobile/tablet (drawer covers the full screen); 20px gap on desktop.
 const getTopMargin = () => (window.matchMedia('(max-width: 1279px)').matches ? 0 : 20);
 
+// The view to land on when opening the drawer fresh, shared by every open path below
+// (mount deep-link, popstate, manual open, external openSessionGuideDetail request).
+const getDefaultView = (isRegistered) => (isRegistered ? 'my-sessions' : 'live-upcoming');
+
 // Pure decision logic for the openSessionGuideDetail(sessionId) external API, kept
 // separate from the useEffect below so it's directly unit-testable.
 export function resolveSessionGuideRequest(request, { sessionsStatusValue, sessionsValue, authValue }) {
@@ -21,7 +25,7 @@ export function resolveSessionGuideRequest(request, { sessionsStatusValue, sessi
   return {
     found: true,
     sessionId: found.id,
-    defaultView: authValue.isRegistered ? 'my-sessions' : 'live-upcoming',
+    defaultView: getDefaultView(authValue.isRegistered),
   };
 }
 
@@ -145,7 +149,7 @@ export function DrawerShell() {
       dispatch({
         type: 'SET_DRAWER',
         drawer: 'expanded',
-        defaultView: auth.value.isRegistered ? 'my-sessions' : 'live-upcoming',
+        defaultView: getDefaultView(auth.value.isRegistered),
       });
     }
   }, []);
@@ -198,12 +202,10 @@ export function DrawerShell() {
         const lastDash = sessionParam.lastIndexOf('-');
         const rfCode = lastDash >= 0 ? sessionParam.slice(lastDash + 1) : sessionParam;
         const found = sessionsRef.current.find((s) => s.rfCode === rfCode || s.id === sessionParam);
-        const defaultView = auth.value.isRegistered ? 'my-sessions' : 'live-upcoming';
-        dispatch({ type: 'SET_DRAWER', drawer: 'expanded', defaultView });
+        dispatch({ type: 'SET_DRAWER', drawer: 'expanded', defaultView: getDefaultView(auth.value.isRegistered) });
         dispatch({ type: 'SET_ACTIVE_SESSION', sessionId: found ? found.id : null });
       } else if (params.has('sessions')) {
-        const defaultView = auth.value.isRegistered ? 'my-sessions' : 'live-upcoming';
-        dispatch({ type: 'SET_DRAWER', drawer: 'expanded', defaultView });
+        dispatch({ type: 'SET_DRAWER', drawer: 'expanded', defaultView: getDefaultView(auth.value.isRegistered) });
         dispatch({ type: 'SET_ACTIVE_SESSION', sessionId: null });
       } else {
         dispatch({ type: 'CLOSE_DRAWER' });
@@ -228,7 +230,7 @@ export function DrawerShell() {
     dispatch({
       type: 'SET_DRAWER',
       drawer: isNarrow ? 'expanded' : 'peek',
-      defaultView: auth.value.isRegistered ? 'my-sessions' : 'live-upcoming',
+      defaultView: getDefaultView(auth.value.isRegistered),
     });
     history.pushState({}, '', setSessionsParam());
   }

--- a/event-libs/v1/utils/session-store.js
+++ b/event-libs/v1/utils/session-store.js
@@ -18,6 +18,10 @@ export const favorited = signal(new Set());
 export const scheduled = signal(new Set());
 export const auth = signal({ isLoggedIn: null, isRegistered: undefined, userFirstName: null });
 export const pendingActions = signal(new Set());
+// Set by openSessionGuideDetail() below; sessions-guide's DrawerShell subscribes to open
+// its detail view for the given session. A new object on every call (even repeat calls
+// for the same sessionId) so the signal always notifies.
+export const sessionGuideRequest = signal(null);
 
 let initialized = false;
 let apiConfig = null;
@@ -114,6 +118,15 @@ async function loadSessions() {
 
 export function getApiConfig() {
   return apiConfig;
+}
+
+// General-purpose entry point for any block to open Session Guide directly to a
+// session's detail view (e.g. a card click in Upcoming Sessions/Featured Sessions),
+// without duplicating Session Guide's internal drawer/URL logic. No-ops if the
+// sessions-guide block isn't authored/mounted on the current page — the caller is
+// expected to know it's present, same as it must for the session data itself.
+export function openSessionGuideDetail(sessionId) {
+  sessionGuideRequest.value = { sessionId };
 }
 
 // Idempotent — safe to call multiple times; no-ops after the first successful init

--- a/test/unit/blocks/sessions-guide/components/DrawerShell.test.js
+++ b/test/unit/blocks/sessions-guide/components/DrawerShell.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@esm-bundle/chai';
+import { resolveSessionGuideRequest } from '../../../../../event-libs/v1/blocks/sessions-guide/components/DrawerShell.js';
+
+const SESSION = { id: 'session-1', title: 'Building with AI' };
+
+function makeContext(overrides = {}) {
+  return {
+    sessionsStatusValue: 'ready',
+    sessionsValue: [SESSION],
+    authValue: { isLoggedIn: null, isRegistered: undefined, userFirstName: null },
+    ...overrides,
+  };
+}
+
+describe('resolveSessionGuideRequest', () => {
+  it('returns null for a null request', () => {
+    expect(resolveSessionGuideRequest(null, makeContext())).to.be.null;
+  });
+
+  it('returns null when sessions are not yet ready (drops requests fired before load)', () => {
+    const context = makeContext({ sessionsStatusValue: 'loading' });
+    expect(resolveSessionGuideRequest({ sessionId: 'session-1' }, context)).to.be.null;
+  });
+
+  it('returns found: false when the sessionId does not match any session', () => {
+    const result = resolveSessionGuideRequest({ sessionId: 'nope' }, makeContext());
+    expect(result).to.deep.equal({ found: false, sessionId: 'nope' });
+  });
+
+  it('resolves the matching session with defaultView live-upcoming when not registered', () => {
+    const result = resolveSessionGuideRequest({ sessionId: 'session-1' }, makeContext());
+    expect(result).to.deep.equal({ found: true, sessionId: 'session-1', defaultView: 'live-upcoming' });
+  });
+
+  it('resolves defaultView my-sessions when the user is registered', () => {
+    const context = makeContext({ authValue: { isLoggedIn: true, isRegistered: true, userFirstName: 'Daniel' } });
+    const result = resolveSessionGuideRequest({ sessionId: 'session-1' }, context);
+    expect(result.defaultView).to.equal('my-sessions');
+  });
+});

--- a/test/unit/utils/session-store.test.js
+++ b/test/unit/utils/session-store.test.js
@@ -1,0 +1,26 @@
+import { expect } from '@esm-bundle/chai';
+import { openSessionGuideDetail, sessionGuideRequest } from '../../../event-libs/v1/utils/session-store.js';
+
+describe('openSessionGuideDetail', () => {
+  afterEach(() => {
+    sessionGuideRequest.value = null;
+  });
+
+  it('sets sessionGuideRequest with the given sessionId', () => {
+    openSessionGuideDetail('session-1');
+    expect(sessionGuideRequest.value).to.deep.equal({ sessionId: 'session-1' });
+  });
+
+  it('notifies subscribers on repeat calls for the same sessionId', () => {
+    const seen = [];
+    const unsubscribe = sessionGuideRequest.subscribe((value) => seen.push(value));
+    openSessionGuideDetail('session-1');
+    openSessionGuideDetail('session-1');
+    unsubscribe();
+    // First notification is the subscribe-time current value (null), then one per call.
+    expect(seen).to.have.lengthOf(3);
+    expect(seen[1]).to.deep.equal({ sessionId: 'session-1' });
+    expect(seen[2]).to.deep.equal({ sessionId: 'session-1' });
+    expect(seen[1]).to.not.equal(seen[2]);
+  });
+});


### PR DESCRIPTION
## What
Adds a `sessionGuideRequest` signal and exported `openSessionGuideDetail(sessionId)` in `session-store.js`, so any block on the page can programmatically open the Session Guide widget directly to a specific session's detail view. `DrawerShell` subscribes to the signal and reacts by opening the drawer, setting the active session, and updating the URL — preserving today's shareable-link/back-button behavior.

## Why
MWPW-200852: Upcoming Sessions and Featured Sessions (still on unmerged branches) each need to open Session Guide to a specific session on card click, and were independently duplicating the same pushState+popstate hack to do it. This adds the single reusable entry point the ticket asks for, so future blocks don't need to reimplement Session Guide's internal drawer/URL logic.

Not included here: swapping Upcoming Sessions'/Featured Sessions' existing hacks over to this new method — those live on separate, unmerged branches owned by other tickets, so that's a follow-up coordination step.

## Test plan
- `npm test` — 916/916 pass, including new unit tests for `openSessionGuideDetail` (`test/unit/utils/session-store.test.js`) and the extracted decision logic `resolveSessionGuideRequest` (`test/unit/blocks/sessions-guide/components/DrawerShell.test.js`)
- `npm run lint` — clean
- Manually verified end-to-end in a real browser (this test suite mocks `useEffect` as a no-op for all block tests, so the actual signal→dispatch wiring can't be exercised by an automated test): mounted the widget with a seeded session, called `openSessionGuideDetail('session-1')` from the console, and confirmed the drawer opened with `sg-drawer--detail-open`, the correct session rendered in `SessionDetailOverlay`, and the URL updated to `?session=session-1`.