### PR TITLE
MWPW-194336: Session Guide Configurator (new DA app)

### DIFF
--- a/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
+++ b/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
@@ -27,9 +27,10 @@ That mechanism needs replacing, not extending:
   `v1/services/sessions/sessions-api.js`) over the block's own already-fetched
   session catalog.
 - Filter/order the result through `guideConfig.authoredFilterCategories`
-  (shape `{attributeId, displayName, enabled}[]`) — keep only `enabled`
-  entries, in authored order.
-- Substitute `displayName` for `label` when rendering category tabs.
+  (shape `{attributeId, label, displayName, enabled}[]` — `label` is the
+  original ESP label, unused at render time but kept so the configurator's
+  own editor can show it) — keep only `enabled` entries, in authored order.
+- Render `displayName` (not `label`) as the category tab text.
 - Look up each session's value for a category by `attributeId` against its
   `customAttributes[]` (same shape `getSessionTrack()` already reads for
   swimlanes — see item 3), not `s[id]` — sessions don't have flat
@@ -64,15 +65,19 @@ Needs:
 ## 3. Swimlane order + visibility — wire `swimlaneOrder` into `OnDemandView.js` (not started)
 
 `OnDemandView.js`'s `groupByTrack(available)` (in `utils/session-filters.js`)
-currently returns tracks in whatever order it derives them in — there's no
-authored ordering or hiding applied today. `guideConfig.swimlaneOrder` is
-`[{ track, enabled }]` (2026-08-04 — was a plain track-name array before
-disable support was added in the configurator). Needs:
+currently returns tracks in whatever order it derives them in, labeled with
+the raw track value — there's no authored ordering, hiding, or renaming
+applied today. `guideConfig.swimlaneOrder` is `[{ track, displayName, enabled }]`
+(2026-08-04 — was a plain track-name array before disable/rename support was
+added in the configurator; `track` is the immutable original value used to
+match sessions, `displayName` is the author's editable override). Needs:
 - `groupByTrack` (or a new wrapper) to accept `guideConfig.swimlaneOrder`,
   **drop any track whose entry has `enabled: false` entirely** (not just push
   it to the end — those sessions shouldn't render in this guide at all, same
   as an author fully deselecting a filter category), and sort the remaining
   tracks to match the enabled entries' order.
+- Render each swimlane's header using `displayName`, not the raw `track`
+  value.
 - Decide the fallback for any track present in the session data but *not*
   in `swimlaneOrder` at all (e.g. a new track added at ESP after this config
   was last authored/seeded) — likely append at the end in whatever order
@@ -108,7 +113,8 @@ inspection:
 - [ ] Each of the four `headings` strings renders in the right
       auth-state/post-event combination; a blank authored string falls back
       to the existing hardcoded copy.
-- [ ] `OnDemandView.js` renders track swimlanes in `swimlaneOrder`'s order; a
+- [ ] `OnDemandView.js` renders track swimlanes in `swimlaneOrder`'s order,
+      headed by each entry's `displayName` (not the raw `track` value); a
       disabled track (`enabled: false`) doesn't render at all; a track missing
       from `swimlaneOrder` entirely still renders (doesn't silently disappear).
 - [ ] Each `behaviorFlags` toggle set to `false` actually removes/disables

--- a/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
+++ b/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
@@ -61,17 +61,23 @@ Needs:
   falling back to the current hardcoded copy only if the authored string for
   that combination is blank.
 
-## 3. Swimlane order — wire `swimlaneOrder` into `OnDemandView.js` (not started)
+## 3. Swimlane order + visibility — wire `swimlaneOrder` into `OnDemandView.js` (not started)
 
 `OnDemandView.js`'s `groupByTrack(available)` (in `utils/session-filters.js`)
 currently returns tracks in whatever order it derives them in — there's no
-authored ordering applied today. Needs:
-- `groupByTrack` (or a new wrapper) to accept `guideConfig.swimlaneOrder`
-  (an array of track-name strings) and sort its output to match it.
+authored ordering or hiding applied today. `guideConfig.swimlaneOrder` is
+`[{ track, enabled }]` (2026-08-04 — was a plain track-name array before
+disable support was added in the configurator). Needs:
+- `groupByTrack` (or a new wrapper) to accept `guideConfig.swimlaneOrder`,
+  **drop any track whose entry has `enabled: false` entirely** (not just push
+  it to the end — those sessions shouldn't render in this guide at all, same
+  as an author fully deselecting a filter category), and sort the remaining
+  tracks to match the enabled entries' order.
 - Decide the fallback for any track present in the session data but *not*
-  in `swimlaneOrder` (e.g. a new track added at ESP after this config was
-  last authored/seeded) — likely append at the end in whatever order
-  `groupByTrack` would otherwise produce, rather than dropping the track.
+  in `swimlaneOrder` at all (e.g. a new track added at ESP after this config
+  was last authored/seeded) — likely append at the end in whatever order
+  `groupByTrack` would otherwise produce, rather than dropping it (dropping
+  is only correct for a track the author explicitly disabled).
 
 ## 4. Behavior flags — wire into their respective gating points (not started)
 
@@ -103,8 +109,8 @@ inspection:
       auth-state/post-event combination; a blank authored string falls back
       to the existing hardcoded copy.
 - [ ] `OnDemandView.js` renders track swimlanes in `swimlaneOrder`'s order; a
-      track missing from `swimlaneOrder` still renders (doesn't silently
-      disappear).
+      disabled track (`enabled: false`) doesn't render at all; a track missing
+      from `swimlaneOrder` entirely still renders (doesn't silently disappear).
 - [ ] Each `behaviorFlags` toggle set to `false` actually removes/disables
       the corresponding affordance across all three card/detail surfaces
       consistently (not just one of them).

--- a/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
+++ b/event-libs/session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md
@@ -1,0 +1,110 @@
+# MWPW-194336 handoff — consuming-side work this app's output requires
+
+This app (Session Guide Configurator) is authoring/export-only: it produces
+a config blob, base64-encodes it into a `?sgConfig=` URL, and `decorate.js`'s
+`prebuildAutoBlock` decodes that at page-decoration time into the
+`sessions-guide`/`sessions-guide-full-page` block's own
+`data-session-guide-config` attribute. `utils/parse-config.js` reads that
+attribute and puts `eventId`, `headings`, `behaviorFlags`, `swimlaneOrder`,
+and `authoredFilterCategories` onto `guideConfig` — but as of the Phase 7
+plumbing pass (2026-08-03), nothing downstream actually *reads* those four
+fields yet. `filterCategories` itself is deliberately left pointing at
+`FilterPanel.js`'s pre-existing legacy default, not the new authored shape —
+see item 1 for why. Everything below is what needs to change to make each
+field actually affect rendering. See `PLAN.md` §7 for the fuller narrative
+behind the filters design; this doc is the consolidated, trackable checklist
+(same role as `tier-1-event-configurator/MWPW-200314-HANDOFF.md` for that
+app).
+
+## 1. Filters — wire `authoredFilterCategories` into `FilterPanel.js` (not started)
+
+`FilterPanel.js` currently reads `guideConfig.filterCategories` (shape
+`{id, label}[]`, hardcoded to `track`/`type`) and derives each category's
+options by indexing sessions directly — `sessions.value.forEach((s) => s[id])`.
+That mechanism needs replacing, not extending:
+
+- Run the same `deriveFacetableAttributes()` (already shared, in
+  `v1/services/sessions/sessions-api.js`) over the block's own already-fetched
+  session catalog.
+- Filter/order the result through `guideConfig.authoredFilterCategories`
+  (shape `{attributeId, displayName, enabled}[]`) — keep only `enabled`
+  entries, in authored order.
+- Substitute `displayName` for `label` when rendering category tabs.
+- Look up each session's value for a category by `attributeId` against its
+  `customAttributes[]` (same shape `getSessionTrack()` already reads for
+  swimlanes — see item 3), not `s[id]` — sessions don't have flat
+  `track`/`type` properties; that was always the legacy authoring format's
+  own simplification, not a real session field.
+- Once this is live, delete `parse-config.js`'s `DEFAULT_FILTER_CATEGORIES`
+  fallback and the `filterCategories`/`authoredFilterCategories` split
+  entirely — `authoredFilterCategories` only exists as a separate field to
+  avoid breaking `FilterPanel.js` mid-migration; it shouldn't outlive this
+  item.
+
+## 2. Headings — wire `headings` into `DrawerHeader.js` (not started)
+
+`DrawerHeader.js` currently shows a single hardcoded fallback title
+(`"See what's happening at MAX"`) when the viewer isn't logged in, or a
+personalized `"{firstName}, see what's happening"` when they are —
+`guideConfig.title` was the old (now-removed) authoring-table override point
+for the logged-out case, and is no longer set by `parse-config.js` at all.
+
+The new config carries four heading strings —
+`headings: { loggedOut, loggedIn, loggedOutPostEvent, loggedInPostEvent }` —
+selected by both the viewer's auth state *and* whether the event has ended.
+Needs:
+- A post-event signal available to `DrawerHeader.js` — check whether one
+  already exists on `state` (e.g. via the on-demand/live-view transition
+  logic in `store/index.js`'s `checkAutoTransition`) before building a new
+  one.
+- Select the right one of the four strings by `(isLoggedIn, isPostEvent)`,
+  falling back to the current hardcoded copy only if the authored string for
+  that combination is blank.
+
+## 3. Swimlane order — wire `swimlaneOrder` into `OnDemandView.js` (not started)
+
+`OnDemandView.js`'s `groupByTrack(available)` (in `utils/session-filters.js`)
+currently returns tracks in whatever order it derives them in — there's no
+authored ordering applied today. Needs:
+- `groupByTrack` (or a new wrapper) to accept `guideConfig.swimlaneOrder`
+  (an array of track-name strings) and sort its output to match it.
+- Decide the fallback for any track present in the session data but *not*
+  in `swimlaneOrder` (e.g. a new track added at ESP after this config was
+  last authored/seeded) — likely append at the end in whatever order
+  `groupByTrack` would otherwise produce, rather than dropping the track.
+
+## 4. Behavior flags — wire into their respective gating points (not started)
+
+`behaviorFlags: { enableScheduling, enableFavoriting, enableWatchNowCtas, enableBrandConciergeRibbon }`
+— none of these are read anywhere yet. Concrete gating points found by
+inspection:
+
+- **`enableScheduling`** → the "Add to schedule"/"Scheduled" buttons in
+  `LiveCard.js`, `SessionCard.js`, and `SessionDetailOverlay.js` (all call
+  `handleSchedule`/`scheduleWithFeedback`). When disabled, hide the button
+  (or the whole schedule affordance) rather than disabling it — TBD with
+  design.
+- **`enableFavoriting`** → the favorite/heart buttons in the same three
+  files (`handleFavorite`/`favoriteWithFeedback`).
+- **`enableWatchNowCtas`** → the "Watch now" button in `LiveCard.js` (and
+  `SessionDetailOverlay.js`'s live/on-demand variant of the same CTA).
+- **`enableBrandConciergeRibbon`** → **no such component exists in the
+  codebase yet.** This flag is forward-looking — whoever picks this item up
+  needs to confirm with product/design whether the ribbon is being built as
+  part of this same handoff or is a separate, not-yet-scoped feature before
+  wiring the flag to anything.
+
+## Test-plan items relevant to the consuming side
+
+- [ ] A session guide config with a non-default `filterCategories`
+      selection (some categories disabled, one renamed, reordered) actually
+      changes what `FilterPanel.js` shows and in what order.
+- [ ] Each of the four `headings` strings renders in the right
+      auth-state/post-event combination; a blank authored string falls back
+      to the existing hardcoded copy.
+- [ ] `OnDemandView.js` renders track swimlanes in `swimlaneOrder`'s order; a
+      track missing from `swimlaneOrder` still renders (doesn't silently
+      disappear).
+- [ ] Each `behaviorFlags` toggle set to `false` actually removes/disables
+      the corresponding affordance across all three card/detail surfaces
+      consistently (not just one of them).

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -205,11 +205,17 @@ authoring library, full fidelity):
   behaviorFlags: {
     enableScheduling, enableFavoriting, enableWatchNowCtas, enableBrandConciergeRibbon,
   },
-  filterCategories,  // [{ attributeId, displayName, enabled, order }] — see §7, no values/counts persisted
-  swimlaneOrder,     // [{ track, enabled }] — author-chosen order + per-track show/hide
+  filterCategories,  // [{ attributeId, label, displayName, enabled, order }] — see §7, no
+                      // values/counts persisted. `label` is the immutable original ESP
+                      // label (2026-08-04: kept alongside `displayName` so the editor can
+                      // always show what's being overridden, even after a rename).
+  swimlaneOrder,     // [{ track, displayName, enabled }] — author-chosen order + per-track
+                      // show/hide/rename. `track` is the immutable original value (also
+                      // used to match sessions to swimlanes); `displayName` defaults to it
+                      // and is author-editable, same rename pattern as filterCategories
                       // (2026-08-04: added `enabled` so authors can drop a track from the
-                      // guide entirely, not just reorder it — same shape/reasoning as
-                      // filterCategories above, minus displayName since tracks aren't renamed here)
+                      // guide entirely, not just reorder it, then added `displayName` for
+                      // the same rename capability filterCategories already had).
 }
 ```
 
@@ -292,7 +298,7 @@ straight onto `guideConfig`, present but not read by anything yet. Full checklis
 wiring each one up: `MWPW-194336-CONSUMPTION-HANDOFF.md`.
 
 **Naming-collision guard:** the incoming authored `filterCategories` shape
-(`{attributeId, displayName, enabled}`, §7) does *not* overwrite `guideConfig.filterCategories`
+(`{attributeId, label, displayName, enabled}`, §7) does *not* overwrite `guideConfig.filterCategories`
 — that key is left as `FilterPanel.js`'s existing legacy default
 (`[{id: 'track', label: 'Channel'}, {id: 'type', label: 'Session Type'}]`), since
 `FilterPanel.js` still indexes sessions directly by `id` and would silently render empty
@@ -380,8 +386,11 @@ export function deriveFacetableAttributes(sessions) {
 fetched in Phase 2, shows every result as a pre-enabled candidate (the "starting
 point"), lets the author unselect / set a **display name** (defaulting to `label`,
 author-editable) / reorder. Saves only the decisions —
-`filterCategories: [{ attributeId, displayName, enabled, order }]` (§5) — no values, no
-counts; those are never persisted, only ever derived live.
+`filterCategories: [{ attributeId, label, displayName, enabled, order }]` (§5, `label`
+added 2026-08-04 so the editor UI can always show the original name next to the
+editable one) — no values, no counts; those are never persisted, only ever derived
+live. Same rename + "show the original alongside it" treatment was extended to
+`swimlaneOrder` the same day, so both editors behave consistently (§5a).
 
 **Consuming side (tracked in `MWPW-194336-CONSUMPTION-HANDOFF.md` item 1):** the sessions-guide block already fetches the
 full session catalog to render itself. It would run the *same*

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -80,7 +80,10 @@ there:**
   URL copy when that API isn't available). Link text is `Session Guide: {display
   title} – {updated date}` (date omitted for an unsaved config). Pasting into DA's
   rich-text editor drops in a working link with readable text instead of a wall of
-  base64 — `utils.js`'s `copySessionGuideConfigLink()`.
+  base64 — `utils.js`'s `copySessionGuideConfigLink()`. Available from two call
+  sites sharing the same logic: `ConfigEditor.js`'s action bar (the config currently
+  open, saved or not) and `Library.js`'s per-row actions (any already-saved config,
+  no need to open it in the editor first).
 
 **The manual authoring-table experience is retired entirely, not kept as a fallback —
 this was the one real design fork, and it's resolved.** `chrono-box`'s builder doesn't

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -73,6 +73,14 @@ there:**
   `prebuildAutoBlock` that decodes the URL, cross-checks `config.eventId` against the
   page's own `event-id` metadata and warns on mismatch (same pattern as
   `MWPW-200314` item 4), then builds the block element.
+- Copy Link (2026-08-04): copies a rich hyperlink, not the bare URL string — same
+  technique as Schedule Maker's `ScheduleURLUtility.copyScheduleToClipboard()` (build a
+  real `<a>` element, wrap its `outerHTML` in a `text/html` `Blob`, write via
+  `navigator.clipboard.write([new ClipboardItem(...)])`, falling back to a plain-text
+  URL copy when that API isn't available). Link text is `Session Guide: {display
+  title} – {updated date}` (date omitted for an unsaved config). Pasting into DA's
+  rich-text editor drops in a working link with readable text instead of a wall of
+  base64 — `utils.js`'s `copySessionGuideConfigLink()`.
 
 **The manual authoring-table experience is retired entirely, not kept as a fallback —
 this was the one real design fork, and it's resolved.** `chrono-box`'s builder doesn't

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -283,10 +283,10 @@ block), and picks `sessions-guide` vs. `sessions-guide-full-page` block class fr
 old table format, per the earlier "skip manual authoring altogether" decision (§3a).
 
 Only `surface`/`theme`/`userTz`/`registerUrl` are actually consumed by the render tree
-today. `eventId`, `headings`, `behaviorFlags`, `swimlaneOrder` are new fields carried
-straight onto `guideConfig`, present but not read by anything yet — wiring
-`DrawerHeader.js` (headings), `OnDemandView.js` (swimlaneOrder), or the behavior flags
-into their respective call sites is separate work.
+today. `eventId`, `headings`, `behaviorFlags`, `swimlaneOrder`, and
+`authoredFilterCategories` (see naming-collision note below) are new fields carried
+straight onto `guideConfig`, present but not read by anything yet. Full checklist for
+wiring each one up: `MWPW-194336-CONSUMPTION-HANDOFF.md`.
 
 **Naming-collision guard:** the incoming authored `filterCategories` shape
 (`{attributeId, displayName, enabled}`, §7) does *not* overwrite `guideConfig.filterCategories`
@@ -294,7 +294,7 @@ into their respective call sites is separate work.
 (`[{id: 'track', label: 'Channel'}, {id: 'type', label: 'Session Type'}]`), since
 `FilterPanel.js` still indexes sessions directly by `id` and would silently render empty
 option lists if handed ESP `attributeId`s instead. The new authored shape is carried
-under `guideConfig.authoredFilterCategories` until §7's consuming-side handoff item
+under `guideConfig.authoredFilterCategories` until the consuming-side handoff (item 1)
 rewires `FilterPanel.js` to read from it (and at that point the legacy key/default can
 be deleted outright, not kept as a fallback).
 
@@ -380,7 +380,7 @@ author-editable) / reorder. Saves only the decisions —
 `filterCategories: [{ attributeId, displayName, enabled, order }]` (§5) — no values, no
 counts; those are never persisted, only ever derived live.
 
-**Consuming side (the handoff item):** the sessions-guide block already fetches the
+**Consuming side (tracked in `MWPW-194336-CONSUMPTION-HANDOFF.md` item 1):** the sessions-guide block already fetches the
 full session catalog to render itself. It would run the *same*
 `deriveFacetableAttributes()`, filter/order the result through the config's saved
 `filterCategories`, substitute `displayName` for `label`, and render the panel — same
@@ -405,6 +405,7 @@ retrofitted later.
 
 - The actual promotion of shared components (§5a) into a common location both apps
   import from — the decision is made, the concrete target location isn't picked yet.
-- The sessions-guide consuming-side handoff item itself (§7's last paragraph) — the
-  data shape and aggregation logic it needs to use are fully specified, but the actual
-  `FilterPanel.js` rework isn't scheduled or designed as its own piece of work yet.
+- The sessions-guide consuming-side handoff itself — data shapes and aggregation logic
+  are fully specified, but none of `FilterPanel.js`/`DrawerHeader.js`/`OnDemandView.js`/
+  the behavior-flag gating points are scheduled or designed as their own piece of work
+  yet. Full checklist: `MWPW-194336-CONSUMPTION-HANDOFF.md`.

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -206,7 +206,10 @@ authoring library, full fidelity):
     enableScheduling, enableFavoriting, enableWatchNowCtas, enableBrandConciergeRibbon,
   },
   filterCategories,  // [{ attributeId, displayName, enabled, order }] — see §7, no values/counts persisted
-  swimlaneOrder,     // array of track/channel identifiers, author-chosen order
+  swimlaneOrder,     // [{ track, enabled }] — author-chosen order + per-track show/hide
+                      // (2026-08-04: added `enabled` so authors can drop a track from the
+                      // guide entirely, not just reorder it — same shape/reasoning as
+                      // filterCategories above, minus displayName since tracks aren't renamed here)
 }
 ```
 

--- a/event-libs/session-guide-configurator/PLAN.md
+++ b/event-libs/session-guide-configurator/PLAN.md
@@ -1,0 +1,410 @@
+# Session Guide Configurator — Plan
+
+## 1. Ticket & rescoping context
+
+Source ticket: [MWPW-194336](https://jira.corp.adobe.com/browse/MWPW-194336) — but per
+Daniel this was written broadly/prematurely and needed a fresh review pass before any
+real planning could start (the placeholder this file replaced said as much). That
+review pass happened 2026-07-28: walked every AC section against current code and
+against what this tool should actually do today, with Daniel confirming/correcting each
+one. This doc records the outcome.
+
+**Concrete sign the raw ticket needed a rewrite, not just a trim:** its Export & Embed
+section (and the Figma file title) refers to a "Calendar Configurator," a "Calendar
+component URL," and an embed snippet `{{<calendar-block>}}` — none of which are this
+tool. That section was very likely cloned from a different tool's ticket template and
+never fully re-worded for Session Guide. Treat any section that still reads oddly
+generic the same way — a signal to double-check, not a spec to follow literally.
+
+## 2. Relationship to the Tier 1 Event Configurator
+
+- **Tier 1 Event Configurator** (MWPW-201380, `tier-1-event-configurator/PLAN.md`) owns
+  page-wide, cross-surface Tier 1 settings authored once per event and consumed by any
+  surface: track icons/colors, `allowDoubleBooking`, `featuredSessions` (see
+  `MWPW-200314-HANDOFF.md` for how sessions-guide currently consumes these).
+- **Session Guide Configurator** owns settings specific to the sessions-guide block
+  instance itself: page mode, theme, headings, its own behavior flags, filters,
+  swimlane order.
+- **Tier 1 only, for now.** Tier 1 Event Configurator is itself scoped to Tier 1 events
+  only, so a Session Guide config that links to one couldn't support Tier 2 anyway.
+  Revisit if/when Tier 2 support is actually requested — don't design for it
+  speculatively before then.
+- **Each Session Guide config links to one specific event's existing Tier 1 config** —
+  that's how it sources its event/ESP connection rather than re-authoring one, and how
+  it defers to Tier-1-owned settings instead of duplicating them.
+- **Many-to-one, not one-to-one: an event can have multiple Session Guide configs**
+  (corrected 2026-07-28, per Daniel) — e.g. testing variants, or a widget version and a
+  page version of the same event's guide. Unlike Tier 1's one-row-per-event sheet,
+  Session Guide's rows are keyed by their own config ID, with `eventId` as a reference
+  field, not the primary key.
+
+## 3. Precedent — two different apps, blended
+
+- **App shape** (UI approach, no-build-step Preact + HTM, small custom design system
+  instead of Spectrum Web Components, DA-sheet-backed saved-config library): Tier 1
+  Event Configurator.
+- **Output/consumption model:** Schedule Maker → `chrono-box`, *not* Tier 1 Event
+  Configurator's "paste JSON into a metadata row" approach. Schedule Maker's Copy Link
+  encodes its data into a base64 URL param (`ScheduleURLUtility` in
+  `schedule-maker/utils.js`); `decorate.js`'s `processAutoBlockLinks`/`prebuildAutoBlock`
+  (`event-libs/v1/utils/decorate.js:508-587`) scans the page for `<a>` links matching a
+  registered URL pattern, decodes the param, transforms it into the target block's DOM
+  shape, and replaces the link with the real block element at decoration time — no
+  manual block/metadata authoring at all. Session Guide Configurator will add its own
+  `sessions-guide` entry to both `autoBlockIdentifiers` and `prebuildAutoBlock`'s builder
+  map, following this exact pattern.
+- **Saved configs sheet:** own file, sibling to Tier 1's —
+  `/tools/da-apps/session-guide-configurator/configs.json` (Tier 1's is at
+  `/tools/da-apps/tier-1-event-configurator/configs.json`) — not merged into it, since
+  the row shapes differ.
+
+## 3a. URL encoding + consumption (confirmed 2026-07-29, per Daniel)
+
+**Encode/decode plumbing already exists and is fully generic — nothing new to build
+there:**
+- Decode: `parseEncodedConfig()` (`event-libs/v1/utils/utils.js:146`) — already shared,
+  already used by `chrono-box`'s builder, returns `null` gracefully on bad input.
+- Encode: same technique as Schedule Maker's `ScheduleURLUtility.createScheduleURL()` —
+  `btoa(unescape(encodeURIComponent(JSON.stringify(configBlob))))` as a URL param on
+  `https://da.live/app/{org}/{repo}/tools/da-apps/session-guide-configurator` (own param
+  name, e.g. `?sgConfig=`, not `?schedule=`).
+- Registration: add `'sessions-guide': { pattern: 'session-guide-configurator' }` to
+  `decorate.js`'s `autoBlockIdentifiers`, plus a matching builder function in
+  `prebuildAutoBlock` that decodes the URL, cross-checks `config.eventId` against the
+  page's own `event-id` metadata and warns on mismatch (same pattern as
+  `MWPW-200314` item 4), then builds the block element.
+
+**The manual authoring-table experience is retired entirely, not kept as a fallback —
+this was the one real design fork, and it's resolved.** `chrono-box`'s builder doesn't
+reconstruct an authoring table at all; it writes a purpose-built shape (`data-schedule-
+id`/`data-schedule-title` attributes + a hidden div holding raw JSON) that `chrono-
+box.js` parses directly. Session Guide follows the same precedent: the built block
+carries a new `data-session-guide-config="<json>"` attribute, and `sessions-guide.js`/
+`sessions-guide-full-page.js`'s `init()` reads **only** that — `utils/parse-config.js`'s
+`parseSessionsGuideConfig()` (the current `event-title`/`filter-categories`/etc.
+authoring-table parse) is not called at all for the new flow, and is not kept as a
+fallback path. **Confirmed clean, not a migration:** verified 2026-07-29 that no real
+page exists today with a manually-authored sessions-guide block outside `demo.html` and
+the test mocks — `sessions-guide` is registered in `libs.js`'s `EVENT_BLOCKS` but
+nothing in production actually authors it the old way.
+
+**Follow-up implied by this, tracked in §7:** `demo.html`, `mocks/default.html`, and any
+tests that construct a sessions-guide block via authoring-table markup will need
+updating to the new attribute-based shape once this ships — parse-config.js's own
+mechanism can most likely be deleted outright rather than left as dead code, but that's
+a call for whoever actually implements this.
+
+## 4. Scope decisions from the section-by-section AC review (2026-07-28, per Daniel)
+
+Numbered to match the original ticket's AC sections, so anyone cross-checking back
+against MWPW-194336 can follow along.
+
+1. **Entry Point & Landing Page.** No Tier 1/Tier 2 dual-CTA — Tier 2 is out of scope
+   entirely (see §2), so this is a single creation flow. Searchable "Saved
+   configurations" grid stays, same shape as Tier 1 Event Configurator's library.
+   **New requirement (2026-07-29, from a PM follow-up conversation): Duplicate.** Not in
+   the original ticket at all. Each row gets a Duplicate action that clones all of its
+   settings as-is **onto the same event** — no event re-picking step, unlike Tier 1
+   Event Configurator's cross-event Duplicate (which exists because that tool is
+   one-row-per-event; this one isn't, see §2). The only thing that must change on the
+   copy is its **Component name**, so it's distinguishable from the original in the
+   list. Primary use cases: creating a widget-version + full-page-version pair for the
+   same event, and testing variants.
+2. **Data Source.** No Rainfocus connection step (Event ID + API Key + Test Connection)
+   — dropped entirely. If Rainfocus is ever needed again, that's a global Tier 1
+   concern, not this tool's. Data source is **ESP**, via the same `EventPicker`/
+   `ManualEventLookup` pattern already built for Tier 1 Event Configurator (reuses DA's
+   own SDK token — no separate connection step needed).
+3. **Configuration — Component & Event Info.** Reduced to **Page mode**, **Theme**, and
+   **Component name**. Event name, date range, and timezone are dropped — deferred to
+   the linked Tier 1 config/ESP data. Component name is back in scope, though
+   (corrected 2026-07-28, alongside the many-configs-per-event correction in §2): since
+   an event can have multiple Session Guide configs, an author-set label is needed to
+   tell them apart in the saved-configs list — the linked event's own title alone isn't
+   unique per row anymore.
+4. **Headings.** Stays as-is: 4 variants — logged-out/live, logged-in/live,
+   logged-out/post-event, logged-in/post-event.
+5. **Filters. Designed 2026-07-29 — see §7 for the full field-level design.** No
+   per-value CRUD (values are always live-derived, never authored — confirmed
+   2026-07-29). Category-level select/unselect/rename/reorder is real work for this
+   app's own build, sourced from ESP's full custom-attribute data — **not** the old
+   Rainfocus assumption, and **not** a dedicated `/session-facets` call either (derived
+   from the session catalog already being fetched, see §7). Only the *consuming* side
+   (sessions-guide actually rendering these filters) is the handoff item — the
+   configurator-side design and build are in scope here, not deferred.
+6. **Swimlane Sorting (On-Demand).** Stays as-is: drag-and-drop reorder only: no
+   rename/remove (channel names/icons/colors are managed globally, outside this tool).
+   Driven by ESP's `Primary Track for Agenda (Digital Agenda)` custom attribute, which
+   is expected to be renamed for the MAX 2026 event. **Done 2026-07-28 as prep work:**
+   consolidated the duplicate hardcoded attribute-name string into one exported
+   `TRACK_ATTRIBUTE_NAME` constant in `sessions-api.js` (previously also duplicated,
+   with a stale "consolidate once MWPW-200314 lands" TODO, in
+   `tier-1-event-configurator/utils.js`) — makes the upcoming rename a one-line swap
+   instead of a multi-file hunt.
+7. **Behavior Flags.** `Enable scheduling`, `Enable favoriting`, `Enable Watch Now CTAs`,
+   and `Enable Brand Concierge Ribbon` stay as this tool's own toggles. `Enable
+   scheduling conflicting sessions` drops — inherited from the linked Tier 1 config's
+   `allowDoubleBooking` instead, not a Session Guide setting.
+8. **Featured Sessions.** Dropped entirely — fully owned by Tier 1 Event Configurator's
+   `featuredSessions` (page-wide by design, not session-guide-specific; see
+   `MWPW-200314-HANDOFF.md` item 3).
+9. **Preview.** **Deferred to v2.** Live rendering, viewport switching, "Refresh data,"
+   and the session detail view are a lot of work and need their own design pass — not
+   attempting this alongside the initial build.
+10. **Export & Embed.** The "Calendar component"/`{{<calendar-block>}}` language was
+    copy-paste drift (see §1) — corrected to Session Guide throughout. No separate
+    "Embed code" option. Single **"Copy link"** action, available directly from the
+    config editor (not gated on Preview, since that's deferred) — encodes the config
+    into a URL per §3's auto-block pattern.
+11. **Save & Draft State.** No draft/publish distinction — save-as-you-go, same model as
+    Tier 1 Event Configurator (a row is just saved or not).
+12. **General / Non-Functional.** Admin access: DA's own access control is sufficient,
+    no extra in-app permission gating needed. Rainfocus failure-handling bullet: moot
+    (§2). Required-field validation: stays in scope. Empty state for no saved configs:
+    stays in scope. Filter CRUD inline edit/confirm/delete pattern: stays (this tool's
+    own concern); the equivalent featured-session bullet is moot (§8, Tier 1's now).
+
+## 5. Data model (confirmed 2026-07-29, per Daniel — two distinct shapes)
+
+**Key architectural point this rests on:** sessions-guide's real session-fetching
+already depends on the *page itself* carrying an `event-id` meta tag (`decorate.js`'s
+outer gate — the same dependency Tier 1 Event Configurator's whole system already
+relies on). Any page with a sessions-guide block is already an "event page" with that
+tag present, from normal event-page setup — not something this tool needs to
+establish. So `eventId` here is mainly an **authoring-time** concern (picking the
+event, fetching its ESP data, looking up its linked Tier 1 config for reference); the
+page rendering the block doesn't strictly need the URL to carry it for anything to
+function. It's still carried in the URL payload anyway, purely to mirror
+`MWPW-200314` item 4's `eventId` mismatch check (catches "pasted the wrong Session
+Guide link onto the wrong event page" the same way item 4 catches a mispasted Tier 1
+`Config`).
+
+**1. Sheet row** (`/tools/da-apps/session-guide-configurator/configs.json` — the
+authoring library, full fidelity):
+```
+{
+  configId,          // primary key — own generated ID, not eventId (§2: many-per-event)
+  componentName,     // author-set label — distinguishes rows for the same event (§4.1, Duplicate)
+  eventId,           // reference to the linked event
+  backendEventTitle, // real ESP title, for list display/context
+  eventServiceEnv,   // which ESP tier this was authored against (mirrors Tier 1's row-level env fix)
+  updated,
+  config: { ...below },
+}
+```
+
+**2. The `config` blob** (also what gets URL-encoded for the copy-link, §4.10):
+```
+{
+  eventId,           // carried for the mismatch-check pattern above, not fetching
+  surface,           // 'widget' | 'page'
+  theme,             // 'light' | 'dark'
+  headings: {
+    loggedOut, loggedIn, loggedOutPostEvent, loggedInPostEvent,
+  },
+  behaviorFlags: {
+    enableScheduling, enableFavoriting, enableWatchNowCtas, enableBrandConciergeRibbon,
+  },
+  filterCategories,  // [{ attributeId, displayName, enabled, order }] — see §7, no values/counts persisted
+  swimlaneOrder,     // array of track/channel identifiers, author-chosen order
+}
+```
+
+**Explicitly not part of this config at all** — inherited live from the page's own
+`tier-1-event-config` metadata at render time, same as today: track icons/colors,
+`allowDoubleBooking`, `featuredSessions` (see §2).
+
+(URL-encoding format is resolved — see §3a. `filterCategories`'s shape is resolved —
+see §7.)
+
+## 5a. App shape & build phases (confirmed 2026-07-29, per Daniel)
+
+**Component tree**, adapted from Tier 1 Event Configurator's file structure:
+```
+session-guide-configurator/
+  session-guide-configurator.js     # DA app entry
+  SessionGuideConfigurator.js       # root component, routes Library <-> ConfigEditor
+  constants.js
+  utils.js
+  context/
+    ConfigsContext.js               # sheet CRUD + active config state (keyed by configId, not eventId)
+    DAContext.js                    # DA SDK auth
+    EventEnvContext.js              # ESP tier picker
+    NavigationContext.js
+  components/
+    EventPicker.js / ManualEventLookup.js
+    HeadingsEditor.js               # new -- 4 heading fields
+    SwimlaneOrderEditor.js          # new -- drag-and-drop reorder, mirrors FeaturedSessionsEditor.js's pattern
+    Modal.js / SearchInput.js / LoadingInline.js
+  pages/
+    Library.js                      # list + search + Duplicate (clones in-place, no event re-pick)
+    ConfigEditor.js                 # Page mode, Theme, Component name, Headings, Behavior Flags, Swimlanes, Copy Link
+  scripts/
+    da-controller.js                # own sheet CRUD + a read-only lookup into Tier 1's sheet by eventId
+```
+
+**Shared components, not a third copy-paste.** `EventPicker.js`, `ManualEventLookup.js`,
+`Modal.js`, `SearchInput.js`, and `LoadingInline.js` already exist verbatim in Tier 1
+Event Configurator. Rather than duplicating them again, promote them to a shared
+location both apps import from. This isn't a hypothetical risk — the
+`TRACK_ATTRIBUTE_NAME` fix (§4.6) was exactly this failure mode (two independently-
+drifting copies of the same thing) caught and fixed after the fact; doing it right the
+first time here avoids a repeat.
+
+**Build phases:**
+1. **Scaffold** — DA app entry, contexts, sheet CRUD skeleton, empty Library/ConfigEditor
+   shells.
+2. **Event linkage** — `EventPicker`/`ManualEventLookup` (shared), ESP session fetch,
+   read-only lookup + display of the linked Tier 1 config.
+3. **Core config fields** — Page mode, Theme, Component name, Headings, Behavior Flags.
+4. **Filters (design finalized 2026-07-29, see §7)** — the shared
+   `deriveFacetableAttributes()` utility, and the configurator's own Filters step
+   (select/unselect/rename/reorder over its output). **In scope for this build**, not
+   deferred — only the sessions-guide block actually *rendering* these filters is the
+   handoff item (§7).
+5. **Swimlane ordering** — drag-and-drop, sourced from ESP track data
+   (`TRACK_ATTRIBUTE_NAME`).
+6. **Duplicate + Delete + validation** — mirrors Tier 1 Event Configurator's own Phase 4
+   precedent.
+7. **Export** — the URL-encoding util, Copy Link action, the `decorate.js` auto-block
+   builder, and the `sessions-guide.js` consumption-side change (§3a) — this is the
+   general plumbing so *any* field reaches the page at all, distinct from the
+   filters-specific rendering handoff item above.
+
+**Preview isn't in this list at all** — v2 (§6).
+
+**Phase 7 plumbing, implemented (2026-08-03, per Daniel — "Lets make that separate
+work"):** `decorate.js`'s `prebuildAutoBlock` gained a `sessions-guide` builder —
+decodes `?sgConfig=` via the shared `parseEncodedConfig()`, cross-checks
+`config.eventId` against the page's `event-id` metadata (logs on mismatch, doesn't
+block), and picks `sessions-guide` vs. `sessions-guide-full-page` block class from
+`config.surface`. `utils/parse-config.js` was rewritten to read
+`data-session-guide-config` instead of parsing an authoring table — no fallback to the
+old table format, per the earlier "skip manual authoring altogether" decision (§3a).
+
+Only `surface`/`theme`/`userTz`/`registerUrl` are actually consumed by the render tree
+today. `eventId`, `headings`, `behaviorFlags`, `swimlaneOrder` are new fields carried
+straight onto `guideConfig`, present but not read by anything yet — wiring
+`DrawerHeader.js` (headings), `OnDemandView.js` (swimlaneOrder), or the behavior flags
+into their respective call sites is separate work.
+
+**Naming-collision guard:** the incoming authored `filterCategories` shape
+(`{attributeId, displayName, enabled}`, §7) does *not* overwrite `guideConfig.filterCategories`
+— that key is left as `FilterPanel.js`'s existing legacy default
+(`[{id: 'track', label: 'Channel'}, {id: 'type', label: 'Session Type'}]`), since
+`FilterPanel.js` still indexes sessions directly by `id` and would silently render empty
+option lists if handed ESP `attributeId`s instead. The new authored shape is carried
+under `guideConfig.authoredFilterCategories` until §7's consuming-side handoff item
+rewires `FilterPanel.js` to read from it (and at that point the legacy key/default can
+be deleted outright, not kept as a fallback).
+
+## 6. Explicitly out of scope / deferred
+
+- Tier 2 support (§2, §4.1) — revisit only if actually requested later.
+- Live Preview (§4.9) — v2.
+- Draft/publish state (§4.11) — not doing draft states.
+- Embed code snippet (§4.10) — dropped, copy-link only.
+- Rainfocus connection (§4.2) — dropped entirely, ESP only.
+
+## 7. Filters — field-level design (confirmed 2026-07-29, per Daniel)
+
+**Scope split, decided explicitly:** the shared aggregation utility and the
+configurator's own Filters step (select/unselect/rename/reorder) are real work for
+*this* app's build (Phase 4, §5a) — not deferred. Only the *consuming* side —
+sessions-guide's `FilterPanel.js` actually rendering filters built from this data — is
+tracked as a separate handoff item, since that's a rework of existing block code, not
+new configurator build.
+
+**No per-value CRUD.** Filter *values* (e.g. "Design," "Video," "Photography" within a
+"Track" category) are never authored — always derived live, matching the "just sorting
+the filters, not the options within it" requirement. If per-value ordering is ever
+requested later, that's one new optional field on the category object (e.g.
+`valueOrder`), not a restructure.
+
+**Real ESP contract, verified against the `events-service-platform` repo's actual route
+code and `tier-1-event-configurator/ESP-SESSION-ENDPOINTS.md`'s existing findings:** every
+session's resolved `customAttributes[]` already carries `attributeId`, `name`, `label`,
+`inputType`, `enabled`, and `values: [{ valueId, label, value, ordinal }]` — the same
+data `/session-facets` returns, just at the session level. Free-text attributes have no
+`valueId` and are never facetable. On a real sample event, only 14 of 28 raw custom
+attributes were actually facetable (`enabled !== false` + `single-select`/
+`multi-select` + has a `valueId`) — the rest are internal/technical fields (`MPC ID`,
+`SkinID`, SEO fields, etc.) that shouldn't be shown as filter candidates at all.
+
+**Decided: derive from the already-fetched session catalog, skip the dedicated
+`/session-facets` call entirely.** Both consumers (the configurator's Phase 2 event-
+linkage fetch, and the sessions-guide block's own render-time fetch) already have the
+full session catalog in memory for other reasons, so a separate facets call would be a
+genuinely unnecessary round-trip with no fidelity gain — label, ordinal, and the
+enabled-attribute gate are already present per-session via the same
+`resolveCustomAttributes()` logic ESP's own facets endpoint reads from.
+
+**New shared utility** (one function, imported by both this app and sessions-guide —
+not duplicated, per the `TRACK_ATTRIBUTE_NAME` lesson in §5a):
+```js
+// Derives facetable custom attributes + their distinct values from an already-fetched
+// session catalog. Mirrors the same enabled/inputType/valueId gate ESP's own
+// /session-facets applies server-side, so results match it field-for-field, without
+// the extra network round-trip.
+export function deriveFacetableAttributes(sessions) {
+  const attributeMap = new Map(); // attributeId -> { attributeId, label, values: Map<valueId, {...}> }
+  for (const session of sessions) {
+    for (const attr of session.customAttributes || []) {
+      if (attr.enabled === false) continue;
+      if (!['single-select', 'multi-select'].includes(attr.inputType)) continue;
+      if (!attributeMap.has(attr.attributeId)) {
+        attributeMap.set(attr.attributeId, { attributeId: attr.attributeId, label: attr.label, values: new Map() });
+      }
+      const group = attributeMap.get(attr.attributeId);
+      for (const v of attr.values || []) {
+        if (!v.valueId) continue; // free-text values aren't indexable
+        if (!group.values.has(v.valueId)) {
+          group.values.set(v.valueId, { valueId: v.valueId, label: v.label, ordinal: v.ordinal, count: 0 });
+        }
+        group.values.get(v.valueId).count += 1;
+      }
+    }
+  }
+  return [...attributeMap.values()].map((g) => ({
+    attributeId: g.attributeId,
+    label: g.label,
+    values: [...g.values.values()].sort((a, b) => a.ordinal - b.ordinal),
+  }));
+}
+```
+
+**Configurator's Filters step (Phase 4):** runs this over the session list already
+fetched in Phase 2, shows every result as a pre-enabled candidate (the "starting
+point"), lets the author unselect / set a **display name** (defaulting to `label`,
+author-editable) / reorder. Saves only the decisions —
+`filterCategories: [{ attributeId, displayName, enabled, order }]` (§5) — no values, no
+counts; those are never persisted, only ever derived live.
+
+**Consuming side (the handoff item):** the sessions-guide block already fetches the
+full session catalog to render itself. It would run the *same*
+`deriveFacetableAttributes()`, filter/order the result through the config's saved
+`filterCategories`, substitute `displayName` for `label`, and render the panel — same
+function, same data, no extra call, on both sides. `FilterPanel.js`/
+`utils/parse-config.js`'s current mechanism (authored `[{id, label}]` + live-scanning
+loaded sessions by property name) gets replaced by this, not extended.
+
+**Also unblocked by this same investigation:** confirmed `attributeId` is stable and
+distinct from `name`/`label` on the real ESP contract — meaning keying
+`filterCategories` by `attributeId` (not name) makes this mechanism naturally immune to
+the upcoming MAX 2026 rename of "Primary Track for Agenda," the same way the
+`TRACK_ATTRIBUTE_NAME` fix (§4.6) protects the swimlane/track-icon code that's
+necessarily still name-keyed (ESP's raw attribute lookup has no ID-based path there
+today). Worth this filters mechanism being ID-keyed from the start rather than
+retrofitted later.
+
+- **`TRACK_ATTRIBUTE_NAME` consolidation** — done 2026-07-28 (§4.6). Not itself
+  build-work for this app, but directly unblocks the upcoming MAX 2026 custom-attribute
+  rename with a one-line change instead of a repo-wide hunt.
+
+## 8. Open questions / not yet designed
+
+- The actual promotion of shared components (§5a) into a common location both apps
+  import from — the decision is made, the concrete target location isn't picked yet.
+- The sessions-guide consuming-side handoff item itself (§7's last paragraph) — the
+  data shape and aggregation logic it needs to use are fully specified, but the actual
+  `FilterPanel.js` rework isn't scheduled or designed as its own piece of work yet.

--- a/event-libs/session-guide-configurator/SessionGuideConfigurator.js
+++ b/event-libs/session-guide-configurator/SessionGuideConfigurator.js
@@ -1,0 +1,96 @@
+import { useEffect, html } from '../v1/deps/htm-preact.js';
+import Library from './pages/Library.js';
+import ConfigEditor from './pages/ConfigEditor.js';
+import { useNavigation } from './context/NavigationContext.js';
+import { useConfigs } from './context/ConfigsContext.js';
+import { useDA } from './context/DAContext.js';
+import { useEventEnv } from './context/EventEnvContext.js';
+import { PAGES, EVENT_SERVICE_ENV_OPTIONS } from './constants.js';
+
+const TOAST_TIMEOUT_MS = 6000;
+
+export default function SessionGuideConfigurator() {
+  const { isLoading: isDaLoading, error: daError } = useDA();
+  const { activePage } = useNavigation();
+  const { envName } = useEventEnv();
+  const {
+    toastError, clearToastError, toastSuccess, clearToastSuccess, isInitialLoading, error,
+  } = useConfigs();
+
+  const envLabel = EVENT_SERVICE_ENV_OPTIONS.find((opt) => opt.value === envName)?.label || envName;
+
+  // sp-toast owned its own auto-dismiss timeout; a plain div needs its own.
+  useEffect(() => {
+    if (!toastError) return undefined;
+    const timer = setTimeout(clearToastError, TOAST_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [toastError, clearToastError]);
+
+  useEffect(() => {
+    if (!toastSuccess) return undefined;
+    const timer = setTimeout(clearToastSuccess, TOAST_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [toastSuccess, clearToastSuccess]);
+
+  if (isDaLoading) {
+    return html`
+      <div class="sgc-app">
+        <div class="sgc-loading">
+          <div class="sgc-spinner" role="status" aria-label="Initializing…"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (daError) {
+    return html`
+      <div class="sgc-app">
+        <div class="sgc-error">
+          <p>${daError}</p>
+        </div>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="sgc-app">
+      ${envName !== 'prod' && html`
+        <div class="sgc-env-banner" role="status">
+          <strong>Non-production environment: ${envLabel}.</strong>
+          ESP calls are targeting ${envName}, not prod — set via the manual Event ID lookup's environment picker.
+        </div>
+      `}
+
+      ${isInitialLoading && html`
+        <div class="sgc-loading">
+          <div class="sgc-spinner" role="status" aria-label="Loading config library…"></div>
+        </div>
+      `}
+
+      ${!isInitialLoading && html`
+        <div class="sgc-content">
+          ${error && html`
+            <div class="sgc-access-error">
+              <p>${error}</p>
+            </div>
+          `}
+          ${!error && activePage === PAGES.library && html`<${Library} />`}
+          ${!error && activePage === PAGES.editor && html`<${ConfigEditor} />`}
+        </div>
+      `}
+
+      ${toastError && html`
+        <div class="sgc-toast sgc-toast--error" role="alert">
+          <span class="sgc-toast__message">${toastError}</span>
+          <button type="button" class="sgc-btn sgc-btn--icon" onClick=${clearToastError} aria-label="Dismiss">✕</button>
+        </div>
+      `}
+      ${toastSuccess && html`
+        <div class="sgc-toast sgc-toast--success" role="status">
+          <span class="sgc-toast__message">${toastSuccess}</span>
+          <button type="button" class="sgc-btn sgc-btn--icon" onClick=${clearToastSuccess} aria-label="Dismiss">✕</button>
+        </div>
+      `}
+    </div>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/EventPicker.js
+++ b/event-libs/session-guide-configurator/components/EventPicker.js
@@ -1,0 +1,102 @@
+import {
+  useState, useEffect, useMemo, useCallback, html,
+} from '../../v1/deps/htm-preact.js';
+import { listAllEvents } from '../../v1/utils/esp-controller.js';
+import Modal from './Modal.js';
+import SearchInput from './SearchInput.js';
+import LoadingInline from './LoadingInline.js';
+
+// Candidate for promotion to a shared location (identical to Tier 1 Event
+// Configurator's own EventPicker.js aside from the class prefix) — see PLAN.md §8.
+const PUBLISH_FILTERS = ['all', 'published', 'draft'];
+const PUBLISH_FILTER_LABELS = { all: 'All', published: 'Published', draft: 'Draft' };
+
+export default function EventPicker({
+  isOpen, onClose, onSelect, onError, title = 'Select an event',
+}) {
+  const [events, setEvents] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState('');
+  const [publishFilter, setPublishFilter] = useState('all');
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    listAllEvents()
+      .then((result) => {
+        if (cancelled) return;
+        if (!result.ok) {
+          const message = result.error || 'Failed to load events';
+          setError(message);
+          // Caller (Library.js) fails over to ManualEventLookup on any
+          // failure — no need to classify the error here too.
+          onError?.(message);
+          return;
+        }
+        setEvents(result.data);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [isOpen, onError]);
+
+  const filteredEvents = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return events.filter((event) => {
+      if (publishFilter === 'published' && !event.published) return false;
+      if (publishFilter === 'draft' && event.published) return false;
+      if (!term) return true;
+      const title = (event.enTitle || '').toLowerCase();
+      return title.includes(term) || (event.eventId || '').toLowerCase().includes(term);
+    });
+  }, [events, search, publishFilter]);
+
+  const handleSearch = useCallback((e) => setSearch(e.target.value), []);
+
+  return html`
+    <${Modal} isOpen=${isOpen} onClose=${onClose} title=${title} showActions=${false} size="large">
+      <div class="sgc-event-picker">
+        <div class="sgc-event-picker__controls">
+          <${SearchInput} \
+            id="sgc-event-picker-search" \
+            placeholder="Search by title or Event ID" \
+            value=${search} \
+            onInput=${handleSearch} \
+            className="sgc-event-picker__search" \
+          />
+          <div class="sgc-event-picker__publish-filter">
+            ${PUBLISH_FILTERS.map((f) => html`
+              <button \
+                type="button" \
+                key=${f} \
+                class="sgc-event-picker__publish-filter-btn ${f === publishFilter ? 'is-active' : ''}" \
+                onClick=${() => setPublishFilter(f)} \
+              >
+                ${PUBLISH_FILTER_LABELS[f]}
+              </button>
+            `)}
+          </div>
+        </div>
+        ${isLoading && html`<${LoadingInline} label="Loading events…" />`}
+        ${error && html`<p class="sgc-event-picker__status sgc-event-picker__status--error">${error}</p>`}
+        ${!isLoading && !error && html`
+          <ul class="sgc-event-picker__list">
+            ${filteredEvents.map((event) => html`
+              <li key=${event.eventId}>
+                <button type="button" class="sgc-event-picker__item-btn" onClick=${() => onSelect(event)}>
+                  <span class="sgc-event-picker__item-title">${event.enTitle || event.eventId}</span>
+                  <span class="sgc-event-picker__item-meta">${event.eventId} · ${event.published ? 'Published' : 'Draft'}</span>
+                </button>
+              </li>
+            `)}
+            ${filteredEvents.length === 0 && html`<li class="sgc-event-picker__empty">No events match.</li>`}
+          </ul>
+        `}
+      </div>
+    </${Modal}>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/EventPicker.js
+++ b/event-libs/session-guide-configurator/components/EventPicker.js
@@ -6,8 +6,6 @@ import Modal from './Modal.js';
 import SearchInput from './SearchInput.js';
 import LoadingInline from './LoadingInline.js';
 
-// Candidate for promotion to a shared location (identical to Tier 1 Event
-// Configurator's own EventPicker.js aside from the class prefix) — see PLAN.md §8.
 const PUBLISH_FILTERS = ['all', 'published', 'draft'];
 const PUBLISH_FILTER_LABELS = { all: 'All', published: 'Published', draft: 'Draft' };
 
@@ -31,8 +29,7 @@ export default function EventPicker({
         if (!result.ok) {
           const message = result.error || 'Failed to load events';
           setError(message);
-          // Caller (Library.js) fails over to ManualEventLookup on any
-          // failure — no need to classify the error here too.
+          // Caller handles fallback for any failure; no need to classify the error here.
           onError?.(message);
           return;
         }

--- a/event-libs/session-guide-configurator/components/FiltersEditor.js
+++ b/event-libs/session-guide-configurator/components/FiltersEditor.js
@@ -7,7 +7,9 @@ import {
 // the "starting point" requirement). No per-value CRUD — filter *options* are always
 // live-derived from ESP, never authored (PLAN.md §7). Same reorder mechanics as
 // SwimlaneOrderEditor.js/Tier 1's FeaturedSessionsEditor.js, plus a per-row enable
-// checkbox and editable display-name input.
+// checkbox and editable display-name input. The original ESP `label` (kept alongside
+// `displayName` by seedFilterCategories) is always shown next to the editable field so
+// authors know what they're overriding.
 function DragHandleIcon() {
   return html`
     <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
@@ -197,7 +199,7 @@ export default function FiltersEditor({ categories, onChange }) {
     <ul class="sgc-filters-editor__list" ref=${listRef}>
       ${rows.map((row, index) => html`
         <li \
-          class="sgc-filters-editor__row ${row.attributeId === draggedId ? 'is-dragging' : ''}" \
+          class="sgc-filters-editor__row ${row.attributeId === draggedId ? 'is-dragging' : ''} ${!row.enabled ? 'is-disabled' : ''}" \
           key=${row.attributeId} \
           ref=${(node) => setItemRef(row.attributeId, node)} \
         >
@@ -217,6 +219,7 @@ export default function FiltersEditor({ categories, onChange }) {
               onChange=${(e) => updateRow(row.attributeId, { enabled: e.target.checked })}
             />
           </label>
+          <span class="sgc-filters-editor__original" title="Original name">${row.label}</span>
           <input
             type="text"
             class="sgc-field sgc-filters-editor__name-input"

--- a/event-libs/session-guide-configurator/components/FiltersEditor.js
+++ b/event-libs/session-guide-configurator/components/FiltersEditor.js
@@ -2,14 +2,8 @@ import {
   useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect, html,
 } from '../../v1/deps/htm-preact.js';
 
-// Select/unselect + rename + reorder over deriveFacetableAttributes(sessions)'s output
-// (ConfigsContext.js's seedFilterCategories seeds `categories`, enabled by default —
-// the "starting point" requirement). No per-value CRUD — filter *options* are always
-// live-derived from ESP, never authored (PLAN.md §7). Same reorder mechanics as
-// SwimlaneOrderEditor.js/Tier 1's FeaturedSessionsEditor.js, plus a per-row enable
-// checkbox and editable display-name input. The original ESP `label` (kept alongside
-// `displayName` by seedFilterCategories) is always shown next to the editable field so
-// authors know what they're overriding.
+// Filter options themselves are always derived from ESP data, not authored here —
+// this only supports enabling/disabling, renaming, and reordering.
 function DragHandleIcon() {
   return html`
     <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
@@ -28,11 +22,8 @@ export default function FiltersEditor({ categories, onChange }) {
   const [announcement, setAnnouncement] = useState('');
 
   const rows = categories || [];
-  // Memoized so the FLIP effect's prevOrder !== rowIds check reflects a real order
-  // change, not a fresh array recreated every render (same reasoning as Tier 1's
-  // FeaturedSessionsEditor.js's featuredIds memo). Depends on the categories prop
-  // itself, not the locally-rebound `rows`, since `rows` is a fresh [] literal on
-  // every render whenever categories is falsy.
+  // Depends on `categories`, not `rows` — `rows` is a fresh [] literal on every render
+  // when categories is falsy, which would defeat the FLIP effect's identity check below.
   const rowIds = useMemo(() => rows.map((r) => r.attributeId), [categories]);
 
   const getTitleFor = useCallback(

--- a/event-libs/session-guide-configurator/components/FiltersEditor.js
+++ b/event-libs/session-guide-configurator/components/FiltersEditor.js
@@ -1,0 +1,230 @@
+import {
+  useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect, html,
+} from '../../v1/deps/htm-preact.js';
+
+// Select/unselect + rename + reorder over deriveFacetableAttributes(sessions)'s output
+// (ConfigsContext.js's seedFilterCategories seeds `categories`, enabled by default —
+// the "starting point" requirement). No per-value CRUD — filter *options* are always
+// live-derived from ESP, never authored (PLAN.md §7). Same reorder mechanics as
+// SwimlaneOrderEditor.js/Tier 1's FeaturedSessionsEditor.js, plus a per-row enable
+// checkbox and editable display-name input.
+function DragHandleIcon() {
+  return html`
+    <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
+      <circle cx="2" cy="2" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="2" r="1.5" fill="currentColor" />
+      <circle cx="2" cy="8" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+      <circle cx="2" cy="14" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="14" r="1.5" fill="currentColor" />
+    </svg>
+  `;
+}
+
+export default function FiltersEditor({ categories, onChange }) {
+  const [draggedId, setDraggedId] = useState(null);
+  const [announcement, setAnnouncement] = useState('');
+
+  const rows = categories || [];
+  // Memoized so the FLIP effect's prevOrder !== rowIds check reflects a real order
+  // change, not a fresh array recreated every render (same reasoning as Tier 1's
+  // FeaturedSessionsEditor.js's featuredIds memo). Depends on the categories prop
+  // itself, not the locally-rebound `rows`, since `rows` is a fresh [] literal on
+  // every render whenever categories is falsy.
+  const rowIds = useMemo(() => rows.map((r) => r.attributeId), [categories]);
+
+  const getTitleFor = useCallback(
+    (attributeId) => rows.find((r) => r.attributeId === attributeId)?.displayName || attributeId,
+    [rows],
+  );
+
+  const updateRow = useCallback((attributeId, updates) => {
+    onChange(rows.map((r) => (r.attributeId === attributeId ? { ...r, ...updates } : r)));
+  }, [rows, onChange]);
+
+  const reorder = useCallback((nextIds) => {
+    const byId = new Map(rows.map((r) => [r.attributeId, r]));
+    onChange(nextIds.map((id) => byId.get(id)));
+  }, [rows, onChange]);
+
+  const handleMove = useCallback((index, direction) => {
+    const target = index + direction;
+    if (target < 0 || target >= rowIds.length) return;
+    const next = [...rowIds];
+    [next[index], next[target]] = [next[target], next[index]];
+    reorder(next);
+    setAnnouncement(`Moved "${getTitleFor(next[target])}" to position ${target + 1} of ${next.length}`);
+  }, [rowIds, reorder, getTitleFor]);
+
+  const handleKeyDown = useCallback((e, index) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      handleMove(index, -1);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      handleMove(index, 1);
+    }
+  }, [handleMove]);
+
+  const listRef = useRef(null);
+  const itemRefs = useRef(new Map());
+  const dragInfo = useRef(null); // { attributeId, startClientY, startIndex, rowHeight }
+  const orderRef = useRef(rowIds);
+  orderRef.current = rowIds;
+
+  const setItemRef = useCallback((attributeId, node) => {
+    if (node) itemRefs.current.set(attributeId, node);
+    else itemRefs.current.delete(attributeId);
+  }, []);
+
+  const measureRowHeight = useCallback(() => {
+    const [firstNode] = itemRefs.current.values();
+    if (!firstNode || !listRef.current) return 0;
+    const rect = firstNode.getBoundingClientRect();
+    const styles = window.getComputedStyle(listRef.current);
+    const gap = parseFloat(styles.rowGap || styles.gap || '0') || 0;
+    return rect.height + gap;
+  }, []);
+
+  const handlePointerMoveRef = useRef(() => {});
+  const endDragRef = useRef(() => {});
+  const stableMove = useRef((e) => handlePointerMoveRef.current(e)).current;
+  const stableEnd = useRef((e) => endDragRef.current(e)).current;
+
+  const handlePointerDown = useCallback((e, attributeId) => {
+    if (e.button !== undefined && e.button !== 0) return;
+    const rowHeight = measureRowHeight();
+    const startIndex = orderRef.current.indexOf(attributeId);
+    if (!rowHeight || startIndex === -1) return;
+    dragInfo.current = {
+      attributeId, startClientY: e.clientY, startIndex, rowHeight,
+    };
+    setDraggedId(attributeId);
+    window.addEventListener('pointermove', stableMove);
+    window.addEventListener('pointerup', stableEnd);
+    window.addEventListener('pointercancel', stableEnd);
+  }, [measureRowHeight, stableMove, stableEnd]);
+
+  handlePointerMoveRef.current = (e) => {
+    const info = dragInfo.current;
+    if (!info) return;
+    const deltaY = e.clientY - info.startClientY;
+    const current = orderRef.current;
+    const currentIndex = current.indexOf(info.attributeId);
+    if (currentIndex === -1) return;
+    const rawTarget = info.startIndex + Math.round(deltaY / info.rowHeight);
+    const targetIndex = Math.min(Math.max(rawTarget, 0), current.length - 1);
+
+    if (targetIndex !== currentIndex) {
+      const next = [...current];
+      next.splice(currentIndex, 1);
+      next.splice(targetIndex, 0, info.attributeId);
+      orderRef.current = next;
+      reorder(next);
+    }
+
+    const draggedNode = itemRefs.current.get(info.attributeId);
+    if (draggedNode) {
+      const visualOffset = deltaY - (targetIndex - info.startIndex) * info.rowHeight;
+      draggedNode.style.transform = `translateY(${visualOffset}px)`;
+    }
+  };
+
+  endDragRef.current = () => {
+    const info = dragInfo.current;
+    if (!info) return;
+    window.removeEventListener('pointermove', stableMove);
+    window.removeEventListener('pointerup', stableEnd);
+    window.removeEventListener('pointercancel', stableEnd);
+    const node = itemRefs.current.get(info.attributeId);
+    if (node) {
+      node.style.transition = 'transform 0.15s ease';
+      node.style.transform = '';
+      setTimeout(() => { if (node) node.style.transition = ''; }, 160);
+    }
+    const finalIndex = orderRef.current.indexOf(info.attributeId);
+    if (finalIndex !== info.startIndex) {
+      setAnnouncement(`Moved "${getTitleFor(info.attributeId)}" to position ${finalIndex + 1} of ${orderRef.current.length}`);
+    }
+    dragInfo.current = null;
+    setDraggedId(null);
+  };
+
+  useEffect(() => () => {
+    window.removeEventListener('pointermove', stableMove);
+    window.removeEventListener('pointerup', stableEnd);
+    window.removeEventListener('pointercancel', stableEnd);
+  }, [stableMove, stableEnd]);
+
+  const prevOrderRef = useRef(rowIds);
+  useLayoutEffect(() => {
+    const prevOrder = prevOrderRef.current;
+    if (prevOrder !== rowIds) {
+      const rowHeight = measureRowHeight();
+      if (rowHeight) {
+        const movedNodes = [];
+        prevOrder.forEach((attributeId) => {
+          if (attributeId === dragInfo.current?.attributeId) return;
+          const oldIndex = prevOrder.indexOf(attributeId);
+          const newIndex = rowIds.indexOf(attributeId);
+          if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
+          const node = itemRefs.current.get(attributeId);
+          if (!node) return;
+          node.style.transition = 'none';
+          node.style.transform = `translateY(${(oldIndex - newIndex) * rowHeight}px)`;
+          movedNodes.push(node);
+        });
+
+        if (movedNodes.length > 0) {
+          // eslint-disable-next-line no-unused-expressions
+          document.body.offsetHeight; // one shared reflow for the whole batch
+          movedNodes.forEach((node) => {
+            node.style.transition = 'transform 0.2s ease';
+            node.style.transform = '';
+          });
+        }
+      }
+    }
+    prevOrderRef.current = rowIds;
+  }, [rowIds, measureRowHeight]);
+
+  if (rows.length === 0) {
+    return html`<p class="sgc-filters-editor__empty">No facetable custom attributes found in this event's session catalog yet.</p>`;
+  }
+
+  return html`
+    <div aria-live="polite" class="sgc-sr-only">${announcement}</div>
+    <ul class="sgc-filters-editor__list" ref=${listRef}>
+      ${rows.map((row, index) => html`
+        <li \
+          class="sgc-filters-editor__row ${row.attributeId === draggedId ? 'is-dragging' : ''}" \
+          key=${row.attributeId} \
+          ref=${(node) => setItemRef(row.attributeId, node)} \
+        >
+          <button \
+            type="button" \
+            class="sgc-filters-editor__handle" \
+            aria-label="Reorder ${row.displayName}. Position ${index + 1} of ${rows.length}. Drag, or press arrow up/down." \
+            onPointerDown=${(e) => handlePointerDown(e, row.attributeId)} \
+            onKeyDown=${(e) => handleKeyDown(e, index)} \
+          >
+            <${DragHandleIcon} />
+          </button>
+          <label class="sgc-filters-editor__enable">
+            <input
+              type="checkbox"
+              checked=${row.enabled}
+              onChange=${(e) => updateRow(row.attributeId, { enabled: e.target.checked })}
+            />
+          </label>
+          <input
+            type="text"
+            class="sgc-field sgc-filters-editor__name-input"
+            value=${row.displayName}
+            onInput=${(e) => updateRow(row.attributeId, { displayName: e.target.value })}
+          />
+        </li>
+      `)}
+    </ul>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/LoadingInline.js
+++ b/event-libs/session-guide-configurator/components/LoadingInline.js
@@ -1,0 +1,6 @@
+import { html } from '../../v1/deps/htm-preact.js';
+
+// Candidate for promotion to a shared location — see PLAN.md §8.
+export default function LoadingInline({ label }) {
+  return html`<p class="sgc-loading-inline"><span class="sgc-spinner sgc-spinner--s"></span> ${label}</p>`;
+}

--- a/event-libs/session-guide-configurator/components/LoadingInline.js
+++ b/event-libs/session-guide-configurator/components/LoadingInline.js
@@ -1,6 +1,5 @@
 import { html } from '../../v1/deps/htm-preact.js';
 
-// Candidate for promotion to a shared location — see PLAN.md §8.
 export default function LoadingInline({ label }) {
   return html`<p class="sgc-loading-inline"><span class="sgc-spinner sgc-spinner--s"></span> ${label}</p>`;
 }

--- a/event-libs/session-guide-configurator/components/ManualEventLookup.js
+++ b/event-libs/session-guide-configurator/components/ManualEventLookup.js
@@ -1,0 +1,110 @@
+import { useState, useRef, html } from '../../v1/deps/htm-preact.js';
+import { getEspEvent } from '../../v1/utils/esp-controller.js';
+import Modal from './Modal.js';
+import { useEventEnv } from '../context/EventEnvContext.js';
+import { EVENT_SERVICE_ENV_OPTIONS } from '../constants.js';
+
+// Candidate for promotion to a shared location (identical to Tier 1 Event
+// Configurator's own ManualEventLookup.js aside from the class prefix) — see
+// PLAN.md §8.
+//
+// New Config/Duplicate's fallback when EventPicker's browse fails at
+// runtime (Library.js's browseFailed). Also the one place to target a
+// non-prod ESP tier — the choice persists for the rest of the session.
+export default function ManualEventLookup({
+  isOpen, onClose, onSelect, title = 'Enter an Event ID',
+}) {
+  const { envName, setEnv } = useEventEnv();
+  const [eventId, setEventId] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [foundEvent, setFoundEvent] = useState(null);
+  // Bumped on every lookup/env change so a stale response can't overwrite newer state.
+  const requestIdRef = useRef(0);
+
+  const reset = () => {
+    setEventId('');
+    setIsLoading(false);
+    setError(null);
+    setFoundEvent(null);
+  };
+
+  const handleEnvChange = (e) => {
+    requestIdRef.current += 1;
+    setEnv(e.target.value);
+    setError(null);
+    setFoundEvent(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleLookup = async () => {
+    const trimmed = eventId.trim();
+    if (!trimmed || isLoading) return;
+    const requestId = (requestIdRef.current += 1);
+    setIsLoading(true);
+    setError(null);
+    setFoundEvent(null);
+    const result = await getEspEvent(trimmed);
+    if (requestId !== requestIdRef.current) return;
+    setIsLoading(false);
+    if (!result.ok) {
+      setError(result.status === 404 ? 'No event found with that ID.' : (result.error?.message || 'Failed to look up event — please retry.'));
+      return;
+    }
+    setFoundEvent(result.data);
+  };
+
+  const handleUse = () => {
+    if (!foundEvent) return;
+    onSelect(foundEvent);
+    reset();
+  };
+
+  return html`
+    <${Modal} isOpen=${isOpen} onClose=${handleClose} title=${title} showActions=${false} size="small">
+      <div class="sgc-manual-lookup">
+        <p class="sgc-manual-lookup__hint">
+          Enter the Event ID exactly as it appears in ESP or the event page's own metadata.
+        </p>
+        <label class="sgc-manual-lookup__env-row">
+          <span class="sgc-manual-lookup__env-label">Environment</span>
+          <select class="sgc-field sgc-manual-lookup__env-select" value=${envName} onChange=${handleEnvChange}>
+            ${EVENT_SERVICE_ENV_OPTIONS.map((opt) => html`<option value=${opt.value} key=${opt.value}>${opt.label}</option>`)}
+          </select>
+        </label>
+        <div class="sgc-manual-lookup__row">
+          <input
+            type="text"
+            class="sgc-field sgc-manual-lookup__input"
+            placeholder="Event ID"
+            value=${eventId}
+            onInput=${(e) => setEventId(e.target.value)}
+            onKeyDown=${(e) => { if (e.key === 'Enter') handleLookup(); }}
+          />
+          <button
+            type="button"
+            class="sgc-btn sgc-btn--primary"
+            onClick=${handleLookup}
+            disabled=${isLoading || !eventId.trim()}
+          >
+            ${isLoading ? 'Looking up…' : 'Look up'}
+          </button>
+        </div>
+        ${error && html`<p class="sgc-manual-lookup__error">${error}</p>`}
+        ${foundEvent && html`
+          <div class="sgc-manual-lookup__result">
+            <p class="sgc-manual-lookup__result-title">${foundEvent.enTitle || foundEvent.eventId}</p>
+            <p class="sgc-manual-lookup__result-meta">
+              ${foundEvent.eventId} · ${foundEvent.published ? 'Published' : 'Draft'}
+            </p>
+            <button type="button" class="sgc-btn sgc-btn--primary" onClick=${handleUse}>Use this event</button>
+          </div>
+        `}
+      </div>
+    </${Modal}>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/ManualEventLookup.js
+++ b/event-libs/session-guide-configurator/components/ManualEventLookup.js
@@ -4,13 +4,6 @@ import Modal from './Modal.js';
 import { useEventEnv } from '../context/EventEnvContext.js';
 import { EVENT_SERVICE_ENV_OPTIONS } from '../constants.js';
 
-// Candidate for promotion to a shared location (identical to Tier 1 Event
-// Configurator's own ManualEventLookup.js aside from the class prefix) — see
-// PLAN.md §8.
-//
-// New Config/Duplicate's fallback when EventPicker's browse fails at
-// runtime (Library.js's browseFailed). Also the one place to target a
-// non-prod ESP tier — the choice persists for the rest of the session.
 export default function ManualEventLookup({
   isOpen, onClose, onSelect, title = 'Enter an Event ID',
 }) {

--- a/event-libs/session-guide-configurator/components/Modal.css
+++ b/event-libs/session-guide-configurator/components/Modal.css
@@ -1,0 +1,139 @@
+/* Candidate for promotion to a shared location (identical to Tier 1 Event
+   Configurator's own Modal.css aside from the custom-property/class prefix) —
+   see PLAN.md §8. */
+
+/* Modal Overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+  backdrop-filter: blur(2px);
+}
+
+/* Modal Container */
+.modal {
+  background: var(--sgc-color-surface, white);
+  border-radius: var(--sgc-border-radius-lg, 12px);
+  box-shadow: var(--sgc-shadow-lg, 0 20px 25px -5px rgb(0 0 0 / 10%), 0 10px 10px -5px rgb(0 0 0 / 4%));
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  outline: none;
+  animation: modal-slide-in 0.2s ease-out;
+  font-family: var(--sgc-font-family, inherit);
+}
+
+.modal-small {
+  width: 100%;
+  max-width: 480px;
+}
+
+.modal-medium {
+  width: 100%;
+  max-width: 600px;
+}
+
+.modal-large {
+  width: 100%;
+  max-width: 800px;
+}
+
+/* Modal Header */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 1.5rem 1rem;
+  position: relative;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--sgc-color-text-primary, #1d1d1d);
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+.modal-close {
+  flex-shrink: 0;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.modal-content {
+  padding: 0 1.5rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* showActions=false means .modal-actions (which otherwise supplies the
+   bottom gap) never renders -- without this, content sits flush against
+   the modal's bottom edge (e.g. ManualEventLookup.js's size="small" modal). */
+.modal-content--standalone {
+  padding-bottom: 1.5rem;
+}
+
+.modal-actions {
+  display: flex;
+  gap: var(--sgc-spacing-md, 1rem);
+  justify-content: flex-end;
+  padding: 1.5rem;
+}
+
+@keyframes modal-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 640px) {
+  .modal-overlay {
+    padding: 0.5rem;
+  }
+
+  .modal {
+    margin: 0.5rem;
+    max-height: calc(100vh - 1rem);
+  }
+
+  .modal-header {
+    padding: 1rem 1rem 0.75rem;
+  }
+
+  .modal-content {
+    padding: 1rem;
+  }
+
+  .modal-actions {
+    padding: 0.75rem 1rem 1rem;
+    flex-direction: column;
+  }
+
+  .modal-actions .sgc-btn {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal {
+    animation: none;
+  }
+}

--- a/event-libs/session-guide-configurator/components/Modal.js
+++ b/event-libs/session-guide-configurator/components/Modal.js
@@ -1,7 +1,5 @@
 import { useEffect, useRef, html } from '../../v1/deps/htm-preact.js';
 
-// Candidate for promotion to a shared location (identical to Tier 1 Event
-// Configurator's own Modal.js aside from the class prefix) — see PLAN.md §8.
 export default function Modal({
   isOpen,
   onClose,

--- a/event-libs/session-guide-configurator/components/Modal.js
+++ b/event-libs/session-guide-configurator/components/Modal.js
@@ -1,0 +1,101 @@
+import { useEffect, useRef, html } from '../../v1/deps/htm-preact.js';
+
+// Candidate for promotion to a shared location (identical to Tier 1 Event
+// Configurator's own Modal.js aside from the class prefix) — see PLAN.md §8.
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  onConfirm,
+  confirmDisabled = false,
+  showActions = true,
+  size = 'medium',
+}) {
+  const modalRef = useRef(null);
+  const firstFocusableRef = useRef(null);
+  const lastFocusableRef = useRef(null);
+
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === 'Escape' && isOpen) onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+      const focusable = modalRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length > 0) {
+        [firstFocusableRef.current, lastFocusableRef.current] = [focusable[0], focusable[focusable.length - 1]];
+      }
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Tab') {
+      if (e.shiftKey) {
+        if (document.activeElement === firstFocusableRef.current) {
+          e.preventDefault();
+          lastFocusableRef.current?.focus();
+        }
+      } else if (document.activeElement === lastFocusableRef.current) {
+        e.preventDefault();
+        firstFocusableRef.current?.focus();
+      }
+    }
+  };
+
+  const handleBackdropClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const sizeClass = { small: 'modal-small', medium: 'modal-medium', large: 'modal-large' }[size] || 'modal-medium';
+
+  const renderActions = () => {
+    if (!showActions) return null;
+    return html`
+      <div class="modal-actions">
+        <button type="button" class="sgc-btn sgc-btn--outline sgc-btn--l" onClick=${onClose}>
+          ${cancelText}
+        </button>
+        <button type="button" class="sgc-btn sgc-btn--primary sgc-btn--l" onClick=${onConfirm} disabled=${confirmDisabled}>
+          ${confirmText}
+        </button>
+      </div>
+    `;
+  };
+
+  return html`
+    <div class="modal-overlay" onClick=${handleBackdropClick} role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <div class="modal ${sizeClass}" ref=${modalRef} tabindex="-1" onKeyDown=${handleKeyDown} role="document">
+        <div class="modal-header">
+          ${title && html`<h2 id="modal-title" class="modal-title">${title}</h2>`}
+          <button type="button" class="sgc-btn sgc-btn--icon modal-close" onClick=${onClose} aria-label="Close modal">
+            <svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
+              <path fill="currentColor" fill-rule="evenodd" d="M13.243,3.343,9,7.586,4.757,3.343a.5.5,0,0,0-.707,0l-.707.707a.5.5,0,0,0,0,.707L7.586,9,3.343,13.243a.5.5,0,0,0,0,.707l.707.707a.5.5,0,0,0,.707,0L9,10.414l4.243,4.243a.5.5,0,0,0,.707,0l.707-.707a.5.5,0,0,0,0-.707L10.414,9l4.243-4.243a.5.5,0,0,0,0-.707l-.707-.707A.5.5,0,0,0,13.243,3.343Z"/>
+            </svg>
+          </button>
+        </div>
+        <div class="modal-content ${showActions ? '' : 'modal-content--standalone'}">
+          ${children}
+        </div>
+        ${renderActions()}
+      </div>
+    </div>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/SearchInput.js
+++ b/event-libs/session-guide-configurator/components/SearchInput.js
@@ -1,7 +1,5 @@
 import { html } from '../../v1/deps/htm-preact.js';
 
-// Candidate for promotion to a shared location (identical to Tier 1 Event
-// Configurator's own SearchInput.js aside from the class prefix) — see PLAN.md §8.
 export default function SearchInput({
   id, placeholder = 'Search', value = '', onInput, className = '',
 }) {

--- a/event-libs/session-guide-configurator/components/SearchInput.js
+++ b/event-libs/session-guide-configurator/components/SearchInput.js
@@ -1,0 +1,30 @@
+import { html } from '../../v1/deps/htm-preact.js';
+
+// Candidate for promotion to a shared location (identical to Tier 1 Event
+// Configurator's own SearchInput.js aside from the class prefix) — see PLAN.md §8.
+export default function SearchInput({
+  id, placeholder = 'Search', value = '', onInput, className = '',
+}) {
+  const handleInput = (e) => {
+    if (onInput) onInput(e);
+  };
+
+  return html`
+    <div class="sgc-search-input ${className}">
+      <div class="sgc-search-input__icon">
+        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20.3834 19.2168L14.7918 13.6252C15.8581 12.3037 16.5001 10.6261 16.5001 8.8001C16.5001 4.55478 13.0454 1.1001 8.8001 1.1001C4.55478 1.1001 1.1001 4.55477 1.1001 8.80009C1.1001 13.0454 4.55478 16.5001 8.8001 16.5001C10.6261 16.5001 12.3037 15.8581 13.6252 14.7918L19.2168 20.3834C19.3779 20.5445 19.5885 20.6251 19.8001 20.6251C20.0117 20.6251 20.2223 20.5445 20.3834 20.3834C20.7057 20.0611 20.7057 19.5391 20.3834 19.2168ZM8.8001 14.8501C5.46464 14.8501 2.7501 12.1355 2.7501 8.80009C2.7501 5.46463 5.46464 2.75009 8.8001 2.75009C12.1356 2.75009 14.8501 5.46463 14.8501 8.80009C14.8501 12.1355 12.1356 14.8501 8.8001 14.8501Z" fill="#292929"/>
+        </svg>
+      </div>
+      <input \
+        type="text" \
+        id="${id}" \
+        name="${id}" \
+        class="sgc-search-input__field" \
+        placeholder="${placeholder}" \
+        value="${value}" \
+        oninput="${handleInput}" \
+      />
+    </div>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
+++ b/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
@@ -2,18 +2,11 @@ import {
   useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect, html,
 } from '../../v1/deps/htm-preact.js';
 
-// Reorder + enable/disable + rename — no removing a track from the catalog itself.
-// Channel names/icons/colors used elsewhere on the page are still managed globally
-// via the Tier 1 Event Configurator, outside this tool (PLAN.md §4.6) — `displayName`
-// here only affects this session guide's own swimlane header. `tracks` is always
-// already seeded/valid by ConfigsContext.js's seedSwimlaneOrder before this renders,
-// so there's no add/remove-from-catalog concern here, unlike Tier 1's
-// FeaturedSessionsEditor.js (whose core pointer-drag + keyboard-reorder mechanics this
-// mirrors) — same reorder + rename mechanics as FiltersEditor.js. The original track
-// value is always shown alongside the editable name so authors know what they're
-// overriding. A disabled track is dropped entirely from the rendered guide by the
-// consuming side (MWPW-194336-CONSUMPTION-HANDOFF.md item 3), not just hidden from
-// ordering.
+// Reorder + enable/disable + rename only — tracks aren't added or removed here.
+// `displayName` only affects this session guide's swimlane header; the underlying
+// track's name/icon/color elsewhere on the page are managed separately. A disabled
+// track is dropped entirely from the rendered guide by the consuming side, not just
+// hidden from ordering.
 function DragHandleIcon() {
   return html`
     <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
@@ -32,11 +25,8 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
   const [announcement, setAnnouncement] = useState('');
 
   const rows = tracks || [];
-  // Memoized so the FLIP effect's prevOrder !== order check reflects a real order
-  // change, not a fresh array recreated every render (same reasoning as Tier 1's
-  // FeaturedSessionsEditor.js's featuredIds memo / FiltersEditor.js's rowIds memo).
-  // Depends on the tracks prop itself, not the locally-rebound `rows`, since `rows`
-  // is a fresh [] literal on every render whenever tracks is falsy.
+  // Depends on `tracks`, not `rows` — `rows` is a fresh [] literal on every render
+  // when tracks is falsy, which would defeat the FLIP effect's identity check below.
   const order = useMemo(() => rows.map((r) => r.track), [tracks]);
 
   const getTitleFor = useCallback(

--- a/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
+++ b/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
@@ -2,16 +2,18 @@ import {
   useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect, html,
 } from '../../v1/deps/htm-preact.js';
 
-// Reorder + enable/disable — no rename/remove of the track itself. Channel names/
-// icons/colors are managed globally via the Tier 1 Event Configurator, outside this
-// tool (PLAN.md §4.6). `tracks` is always already seeded/valid by ConfigsContext.js's
-// seedSwimlaneOrder before this renders, so there's no add/remove-from-catalog concern
-// here, unlike Tier 1's FeaturedSessionsEditor.js (whose core pointer-drag +
-// keyboard-reorder mechanics this mirrors) — same reorder mechanics as
-// FiltersEditor.js, minus the display-name rename input, since a track's display name
-// isn't authored here at all. A disabled track is dropped entirely from the rendered
-// guide by the consuming side (MWPW-194336-CONSUMPTION-HANDOFF.md item 3), not just
-// hidden from ordering.
+// Reorder + enable/disable + rename — no removing a track from the catalog itself.
+// Channel names/icons/colors used elsewhere on the page are still managed globally
+// via the Tier 1 Event Configurator, outside this tool (PLAN.md §4.6) — `displayName`
+// here only affects this session guide's own swimlane header. `tracks` is always
+// already seeded/valid by ConfigsContext.js's seedSwimlaneOrder before this renders,
+// so there's no add/remove-from-catalog concern here, unlike Tier 1's
+// FeaturedSessionsEditor.js (whose core pointer-drag + keyboard-reorder mechanics this
+// mirrors) — same reorder + rename mechanics as FiltersEditor.js. The original track
+// value is always shown alongside the editable name so authors know what they're
+// overriding. A disabled track is dropped entirely from the rendered guide by the
+// consuming side (MWPW-194336-CONSUMPTION-HANDOFF.md item 3), not just hidden from
+// ordering.
 function DragHandleIcon() {
   return html`
     <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
@@ -37,6 +39,11 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
   // is a fresh [] literal on every render whenever tracks is falsy.
   const order = useMemo(() => rows.map((r) => r.track), [tracks]);
 
+  const getTitleFor = useCallback(
+    (track) => rows.find((r) => r.track === track)?.displayName || track,
+    [rows],
+  );
+
   const updateRow = useCallback((track, updates) => {
     onChange(rows.map((r) => (r.track === track ? { ...r, ...updates } : r)));
   }, [rows, onChange]);
@@ -52,8 +59,8 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
     const next = [...order];
     [next[index], next[target]] = [next[target], next[index]];
     reorder(next);
-    setAnnouncement(`Moved "${next[target]}" to position ${target + 1} of ${next.length}`);
-  }, [order, reorder]);
+    setAnnouncement(`Moved "${getTitleFor(next[target])}" to position ${target + 1} of ${next.length}`);
+  }, [order, reorder, getTitleFor]);
 
   const handleKeyDown = useCallback((e, index) => {
     if (e.key === 'ArrowUp') {
@@ -143,7 +150,7 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
     }
     const finalIndex = orderRef.current.indexOf(info.track);
     if (finalIndex !== info.startIndex) {
-      setAnnouncement(`Moved "${info.track}" to position ${finalIndex + 1} of ${orderRef.current.length}`);
+      setAnnouncement(`Moved "${getTitleFor(info.track)}" to position ${finalIndex + 1} of ${orderRef.current.length}`);
     }
     dragInfo.current = null;
     setDraggedTrack(null);
@@ -203,7 +210,7 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
           <button \
             type="button" \
             class="sgc-swimlane-editor__handle" \
-            aria-label="Reorder ${row.track}. Position ${index + 1} of ${rows.length}. Drag, or press arrow up/down." \
+            aria-label="Reorder ${getTitleFor(row.track)}. Position ${index + 1} of ${rows.length}. Drag, or press arrow up/down." \
             onPointerDown=${(e) => handlePointerDown(e, row.track)} \
             onKeyDown=${(e) => handleKeyDown(e, index)} \
           >
@@ -217,7 +224,13 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
               onChange=${(e) => updateRow(row.track, { enabled: e.target.checked })}
             />
           </label>
-          <span class="sgc-swimlane-editor__title">${row.track}</span>
+          <span class="sgc-swimlane-editor__original" title="Original track name">${row.track}</span>
+          <input
+            type="text"
+            class="sgc-field sgc-swimlane-editor__name-input"
+            value=${row.displayName}
+            onInput=${(e) => updateRow(row.track, { displayName: e.target.value })}
+          />
         </li>
       `)}
     </ul>

--- a/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
+++ b/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
@@ -1,13 +1,17 @@
 import {
-  useState, useCallback, useRef, useLayoutEffect, useEffect, html,
+  useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect, html,
 } from '../../v1/deps/htm-preact.js';
 
-// Reorder only — no rename/remove. Channel names/icons/colors are managed globally
-// via the Tier 1 Event Configurator, outside this tool (PLAN.md §4.6). `tracks` is
-// always already seeded/valid by ConfigsContext.js's seedSwimlaneOrder before this
-// renders, so there's no add/remove-from-catalog concern here, unlike Tier 1's
-// FeaturedSessionsEditor.js (whose core pointer-drag + keyboard-reorder mechanics this
-// mirrors, simplified to a single column of plain track-name strings).
+// Reorder + enable/disable — no rename/remove of the track itself. Channel names/
+// icons/colors are managed globally via the Tier 1 Event Configurator, outside this
+// tool (PLAN.md §4.6). `tracks` is always already seeded/valid by ConfigsContext.js's
+// seedSwimlaneOrder before this renders, so there's no add/remove-from-catalog concern
+// here, unlike Tier 1's FeaturedSessionsEditor.js (whose core pointer-drag +
+// keyboard-reorder mechanics this mirrors) — same reorder mechanics as
+// FiltersEditor.js, minus the display-name rename input, since a track's display name
+// isn't authored here at all. A disabled track is dropped entirely from the rendered
+// guide by the consuming side (MWPW-194336-CONSUMPTION-HANDOFF.md item 3), not just
+// hidden from ordering.
 function DragHandleIcon() {
   return html`
     <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
@@ -25,16 +29,31 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
   const [draggedTrack, setDraggedTrack] = useState(null);
   const [announcement, setAnnouncement] = useState('');
 
-  const order = tracks || [];
+  const rows = tracks || [];
+  // Memoized so the FLIP effect's prevOrder !== order check reflects a real order
+  // change, not a fresh array recreated every render (same reasoning as Tier 1's
+  // FeaturedSessionsEditor.js's featuredIds memo / FiltersEditor.js's rowIds memo).
+  // Depends on the tracks prop itself, not the locally-rebound `rows`, since `rows`
+  // is a fresh [] literal on every render whenever tracks is falsy.
+  const order = useMemo(() => rows.map((r) => r.track), [tracks]);
+
+  const updateRow = useCallback((track, updates) => {
+    onChange(rows.map((r) => (r.track === track ? { ...r, ...updates } : r)));
+  }, [rows, onChange]);
+
+  const reorder = useCallback((nextOrder) => {
+    const byTrack = new Map(rows.map((r) => [r.track, r]));
+    onChange(nextOrder.map((track) => byTrack.get(track)));
+  }, [rows, onChange]);
 
   const handleMove = useCallback((index, direction) => {
     const target = index + direction;
     if (target < 0 || target >= order.length) return;
     const next = [...order];
     [next[index], next[target]] = [next[target], next[index]];
-    onChange(next);
+    reorder(next);
     setAnnouncement(`Moved "${next[target]}" to position ${target + 1} of ${next.length}`);
-  }, [order, onChange]);
+  }, [order, reorder]);
 
   const handleKeyDown = useCallback((e, index) => {
     if (e.key === 'ArrowUp') {
@@ -100,7 +119,7 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
       next.splice(currentIndex, 1);
       next.splice(targetIndex, 0, info.track);
       orderRef.current = next;
-      onChange(next);
+      reorder(next);
     }
 
     const draggedNode = itemRefs.current.get(info.track);
@@ -168,29 +187,37 @@ export default function SwimlaneOrderEditor({ tracks, onChange }) {
     prevOrderRef.current = order;
   }, [order, measureRowHeight]);
 
-  if (order.length === 0) {
+  if (rows.length === 0) {
     return html`<p class="sgc-swimlane-editor__empty">No tracks found in this event's session catalog yet.</p>`;
   }
 
   return html`
     <div aria-live="polite" class="sgc-sr-only">${announcement}</div>
     <ul class="sgc-swimlane-editor__list" ref=${listRef}>
-      ${order.map((track, index) => html`
+      ${rows.map((row, index) => html`
         <li \
-          class="sgc-swimlane-editor__row ${track === draggedTrack ? 'is-dragging' : ''}" \
-          key=${track} \
-          ref=${(node) => setItemRef(track, node)} \
+          class="sgc-swimlane-editor__row ${row.track === draggedTrack ? 'is-dragging' : ''} ${!row.enabled ? 'is-disabled' : ''}" \
+          key=${row.track} \
+          ref=${(node) => setItemRef(row.track, node)} \
         >
           <button \
             type="button" \
             class="sgc-swimlane-editor__handle" \
-            aria-label="Reorder ${track}. Position ${index + 1} of ${order.length}. Drag, or press arrow up/down." \
-            onPointerDown=${(e) => handlePointerDown(e, track)} \
+            aria-label="Reorder ${row.track}. Position ${index + 1} of ${rows.length}. Drag, or press arrow up/down." \
+            onPointerDown=${(e) => handlePointerDown(e, row.track)} \
             onKeyDown=${(e) => handleKeyDown(e, index)} \
           >
             <${DragHandleIcon} />
           </button>
-          <span class="sgc-swimlane-editor__title">${track}</span>
+          <label class="sgc-swimlane-editor__enable">
+            <input
+              type="checkbox"
+              checked=${row.enabled}
+              aria-label="Show ${row.track} in the session guide"
+              onChange=${(e) => updateRow(row.track, { enabled: e.target.checked })}
+            />
+          </label>
+          <span class="sgc-swimlane-editor__title">${row.track}</span>
         </li>
       `)}
     </ul>

--- a/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
+++ b/event-libs/session-guide-configurator/components/SwimlaneOrderEditor.js
@@ -1,0 +1,198 @@
+import {
+  useState, useCallback, useRef, useLayoutEffect, useEffect, html,
+} from '../../v1/deps/htm-preact.js';
+
+// Reorder only — no rename/remove. Channel names/icons/colors are managed globally
+// via the Tier 1 Event Configurator, outside this tool (PLAN.md §4.6). `tracks` is
+// always already seeded/valid by ConfigsContext.js's seedSwimlaneOrder before this
+// renders, so there's no add/remove-from-catalog concern here, unlike Tier 1's
+// FeaturedSessionsEditor.js (whose core pointer-drag + keyboard-reorder mechanics this
+// mirrors, simplified to a single column of plain track-name strings).
+function DragHandleIcon() {
+  return html`
+    <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
+      <circle cx="2" cy="2" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="2" r="1.5" fill="currentColor" />
+      <circle cx="2" cy="8" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+      <circle cx="2" cy="14" r="1.5" fill="currentColor" />
+      <circle cx="8" cy="14" r="1.5" fill="currentColor" />
+    </svg>
+  `;
+}
+
+export default function SwimlaneOrderEditor({ tracks, onChange }) {
+  const [draggedTrack, setDraggedTrack] = useState(null);
+  const [announcement, setAnnouncement] = useState('');
+
+  const order = tracks || [];
+
+  const handleMove = useCallback((index, direction) => {
+    const target = index + direction;
+    if (target < 0 || target >= order.length) return;
+    const next = [...order];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+    setAnnouncement(`Moved "${next[target]}" to position ${target + 1} of ${next.length}`);
+  }, [order, onChange]);
+
+  const handleKeyDown = useCallback((e, index) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      handleMove(index, -1);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      handleMove(index, 1);
+    }
+  }, [handleMove]);
+
+  const listRef = useRef(null);
+  const itemRefs = useRef(new Map());
+  const dragInfo = useRef(null); // { track, startClientY, startIndex, rowHeight }
+  const orderRef = useRef(order);
+  orderRef.current = order;
+
+  const setItemRef = useCallback((track, node) => {
+    if (node) itemRefs.current.set(track, node);
+    else itemRefs.current.delete(track);
+  }, []);
+
+  const measureRowHeight = useCallback(() => {
+    const [firstNode] = itemRefs.current.values();
+    if (!firstNode || !listRef.current) return 0;
+    const rect = firstNode.getBoundingClientRect();
+    const styles = window.getComputedStyle(listRef.current);
+    const gap = parseFloat(styles.rowGap || styles.gap || '0') || 0;
+    return rect.height + gap;
+  }, []);
+
+  const handlePointerMoveRef = useRef(() => {});
+  const endDragRef = useRef(() => {});
+  const stableMove = useRef((e) => handlePointerMoveRef.current(e)).current;
+  const stableEnd = useRef((e) => endDragRef.current(e)).current;
+
+  const handlePointerDown = useCallback((e, track) => {
+    if (e.button !== undefined && e.button !== 0) return;
+    const rowHeight = measureRowHeight();
+    const startIndex = orderRef.current.indexOf(track);
+    if (!rowHeight || startIndex === -1) return;
+    dragInfo.current = {
+      track, startClientY: e.clientY, startIndex, rowHeight,
+    };
+    setDraggedTrack(track);
+    window.addEventListener('pointermove', stableMove);
+    window.addEventListener('pointerup', stableEnd);
+    window.addEventListener('pointercancel', stableEnd);
+  }, [measureRowHeight, stableMove, stableEnd]);
+
+  handlePointerMoveRef.current = (e) => {
+    const info = dragInfo.current;
+    if (!info) return;
+    const deltaY = e.clientY - info.startClientY;
+    const current = orderRef.current;
+    const currentIndex = current.indexOf(info.track);
+    if (currentIndex === -1) return;
+    const rawTarget = info.startIndex + Math.round(deltaY / info.rowHeight);
+    const targetIndex = Math.min(Math.max(rawTarget, 0), current.length - 1);
+
+    if (targetIndex !== currentIndex) {
+      const next = [...current];
+      next.splice(currentIndex, 1);
+      next.splice(targetIndex, 0, info.track);
+      orderRef.current = next;
+      onChange(next);
+    }
+
+    const draggedNode = itemRefs.current.get(info.track);
+    if (draggedNode) {
+      const visualOffset = deltaY - (targetIndex - info.startIndex) * info.rowHeight;
+      draggedNode.style.transform = `translateY(${visualOffset}px)`;
+    }
+  };
+
+  endDragRef.current = () => {
+    const info = dragInfo.current;
+    if (!info) return;
+    window.removeEventListener('pointermove', stableMove);
+    window.removeEventListener('pointerup', stableEnd);
+    window.removeEventListener('pointercancel', stableEnd);
+    const node = itemRefs.current.get(info.track);
+    if (node) {
+      node.style.transition = 'transform 0.15s ease';
+      node.style.transform = '';
+      setTimeout(() => { if (node) node.style.transition = ''; }, 160);
+    }
+    const finalIndex = orderRef.current.indexOf(info.track);
+    if (finalIndex !== info.startIndex) {
+      setAnnouncement(`Moved "${info.track}" to position ${finalIndex + 1} of ${orderRef.current.length}`);
+    }
+    dragInfo.current = null;
+    setDraggedTrack(null);
+  };
+
+  useEffect(() => () => {
+    window.removeEventListener('pointermove', stableMove);
+    window.removeEventListener('pointerup', stableEnd);
+    window.removeEventListener('pointercancel', stableEnd);
+  }, [stableMove, stableEnd]);
+
+  const prevOrderRef = useRef(order);
+  useLayoutEffect(() => {
+    const prevOrder = prevOrderRef.current;
+    if (prevOrder !== order) {
+      const rowHeight = measureRowHeight();
+      if (rowHeight) {
+        const movedNodes = [];
+        prevOrder.forEach((track) => {
+          if (track === dragInfo.current?.track) return;
+          const oldIndex = prevOrder.indexOf(track);
+          const newIndex = order.indexOf(track);
+          if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
+          const node = itemRefs.current.get(track);
+          if (!node) return;
+          node.style.transition = 'none';
+          node.style.transform = `translateY(${(oldIndex - newIndex) * rowHeight}px)`;
+          movedNodes.push(node);
+        });
+
+        if (movedNodes.length > 0) {
+          // eslint-disable-next-line no-unused-expressions
+          document.body.offsetHeight; // one shared reflow for the whole batch
+          movedNodes.forEach((node) => {
+            node.style.transition = 'transform 0.2s ease';
+            node.style.transform = '';
+          });
+        }
+      }
+    }
+    prevOrderRef.current = order;
+  }, [order, measureRowHeight]);
+
+  if (order.length === 0) {
+    return html`<p class="sgc-swimlane-editor__empty">No tracks found in this event's session catalog yet.</p>`;
+  }
+
+  return html`
+    <div aria-live="polite" class="sgc-sr-only">${announcement}</div>
+    <ul class="sgc-swimlane-editor__list" ref=${listRef}>
+      ${order.map((track, index) => html`
+        <li \
+          class="sgc-swimlane-editor__row ${track === draggedTrack ? 'is-dragging' : ''}" \
+          key=${track} \
+          ref=${(node) => setItemRef(track, node)} \
+        >
+          <button \
+            type="button" \
+            class="sgc-swimlane-editor__handle" \
+            aria-label="Reorder ${track}. Position ${index + 1} of ${order.length}. Drag, or press arrow up/down." \
+            onPointerDown=${(e) => handlePointerDown(e, track)} \
+            onKeyDown=${(e) => handleKeyDown(e, index)} \
+          >
+            <${DragHandleIcon} />
+          </button>
+          <span class="sgc-swimlane-editor__title">${track}</span>
+        </li>
+      `)}
+    </ul>
+  `;
+}

--- a/event-libs/session-guide-configurator/components/Tier1ConfigPicker.js
+++ b/event-libs/session-guide-configurator/components/Tier1ConfigPicker.js
@@ -4,19 +4,15 @@ import {
 import Modal from './Modal.js';
 import SearchInput from './SearchInput.js';
 import LoadingInline from './LoadingInline.js';
-// Deliberate cross-app dependency, not a duplication risk like TRACK_ATTRIBUTE_NAME was
-// (PLAN.md §4.6) — Session Guide Configurator is explicitly designed to hook into an
-// existing Tier 1 Event Configurator config as its event source (PLAN.md §2), so
-// reusing Tier 1's own sheet-read and title-resolution logic directly is the correct
-// call, not a copy to keep in sync.
+// Deliberate cross-app import: this app uses Tier 1 configs as its event source, so
+// it reuses Tier 1's sheet-read and title-resolution logic directly rather than
+// duplicating it.
 import { getConfigs as getTier1Configs } from '../../tier-1-event-configurator/scripts/da-controller.js';
 import { getDisplayTitle as getTier1DisplayTitle } from '../../tier-1-event-configurator/utils.js';
 import { useDA } from '../context/DAContext.js';
 
-// Default event-source picker for New config: lists events that already have a Tier 1
-// Event Configurator config, since that's this app's real source of truth for event
-// data (PLAN.md §2). onSwitchToAlternative lets an author fall back to ESP browse /
-// manual Event ID entry for an event that doesn't have a Tier 1 config yet.
+// Lists events that already have a Tier 1 Event Configurator config — this app's
+// real source of truth for event data.
 export default function Tier1ConfigPicker({
   isOpen, onClose, onSelect, onSwitchToAlternative,
 }) {

--- a/event-libs/session-guide-configurator/components/Tier1ConfigPicker.js
+++ b/event-libs/session-guide-configurator/components/Tier1ConfigPicker.js
@@ -1,0 +1,101 @@
+import {
+  useState, useEffect, useMemo, useCallback, html,
+} from '../../v1/deps/htm-preact.js';
+import Modal from './Modal.js';
+import SearchInput from './SearchInput.js';
+import LoadingInline from './LoadingInline.js';
+// Deliberate cross-app dependency, not a duplication risk like TRACK_ATTRIBUTE_NAME was
+// (PLAN.md §4.6) — Session Guide Configurator is explicitly designed to hook into an
+// existing Tier 1 Event Configurator config as its event source (PLAN.md §2), so
+// reusing Tier 1's own sheet-read and title-resolution logic directly is the correct
+// call, not a copy to keep in sync.
+import { getConfigs as getTier1Configs } from '../../tier-1-event-configurator/scripts/da-controller.js';
+import { getDisplayTitle as getTier1DisplayTitle } from '../../tier-1-event-configurator/utils.js';
+import { useDA } from '../context/DAContext.js';
+
+// Default event-source picker for New config: lists events that already have a Tier 1
+// Event Configurator config, since that's this app's real source of truth for event
+// data (PLAN.md §2). onSwitchToAlternative lets an author fall back to ESP browse /
+// manual Event ID entry for an event that doesn't have a Tier 1 config yet.
+export default function Tier1ConfigPicker({
+  isOpen, onClose, onSelect, onSwitchToAlternative,
+}) {
+  const { org, repo } = useDA();
+  const [rows, setRows] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    if (!isOpen || !org || !repo) return undefined;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    getTier1Configs(org, repo).then((result) => {
+      if (cancelled) return;
+      if (!result.ok) {
+        setError(result.error || 'Failed to load Tier 1 Event Configurator configs');
+        return;
+      }
+      setRows(result.data);
+    }).finally(() => {
+      if (!cancelled) setIsLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [isOpen, org, repo]);
+
+  const filteredRows = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return rows;
+    return rows.filter(
+      (row) => getTier1DisplayTitle(row).toLowerCase().includes(term)
+        || (row.eventId || '').toLowerCase().includes(term),
+    );
+  }, [rows, search]);
+
+  const handleSearch = useCallback((e) => setSearch(e.target.value), []);
+
+  const handleSelect = useCallback((row) => {
+    onSelect({ eventId: row.eventId, enTitle: row.backendEventTitle }, row.eventServiceEnv);
+  }, [onSelect]);
+
+  return html`
+    <${Modal} isOpen=${isOpen} onClose=${onClose} title="New config — pick an event with a Tier 1 config" showActions=${false} size="large">
+      <div class="sgc-event-picker">
+        <${SearchInput} \
+          id="sgc-tier1-picker-search" \
+          placeholder="Search by event title or Event ID" \
+          value=${search} \
+          onInput=${handleSearch} \
+          className="sgc-event-picker__search" \
+        />
+        ${isLoading && html`<${LoadingInline} label="Loading Tier 1 configs…" />`}
+        ${error && html`<p class="sgc-event-picker__status sgc-event-picker__status--error">${error}</p>`}
+        ${!isLoading && !error && html`
+          <ul class="sgc-event-picker__list">
+            ${filteredRows.map((row) => html`
+              <li key=${row.eventId}>
+                <button type="button" class="sgc-event-picker__item-btn" onClick=${() => handleSelect(row)}>
+                  <span class="sgc-event-picker__item-title">${getTier1DisplayTitle(row)}</span>
+                  <span class="sgc-event-picker__item-meta">
+                    ${row.eventId}
+                    ${row.eventServiceEnv && row.eventServiceEnv !== 'prod' ? ` · ${row.eventServiceEnv}` : ''}
+                  </span>
+                </button>
+              </li>
+            `)}
+            ${filteredRows.length === 0 && html`
+              <li class="sgc-event-picker__empty">No Tier 1 configs match.</li>
+            `}
+          </ul>
+        `}
+        <p class="sgc-tier1-picker__alt">
+          Don't see your event?
+          <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${onSwitchToAlternative}>
+            Pick it another way
+          </button>
+        </p>
+      </div>
+    </${Modal}>
+  `;
+}

--- a/event-libs/session-guide-configurator/constants.js
+++ b/event-libs/session-guide-configurator/constants.js
@@ -4,6 +4,12 @@
 // keyed by configId, not eventId; see PLAN.md §2/§5).
 const CONFIGS_SHEET_PATH = '/tools/da-apps/session-guide-configurator/configs.json';
 
+// Copy Link's target — the DA app's own edit-mode URL, not the admin API origin
+// (DA_ADMIN_ORIGIN lives in v1/utils/da-sheet-controller.js, a different concern).
+// Same pattern as Schedule Maker's DA_ORIGIN/DA_APP_PATH (PLAN.md §3a).
+const DA_ORIGIN = 'https://da.live';
+const DA_APP_PATH = 'tools/da-apps/session-guide-configurator';
+
 const PAGES = {
   library: 'library',
   editor: 'editor',
@@ -26,6 +32,8 @@ const EVENT_SERVICE_ENV_OPTIONS = [
 
 export {
   CONFIGS_SHEET_PATH,
+  DA_ORIGIN,
+  DA_APP_PATH,
   PAGES,
   EVENT_BROWSE_ENABLED,
   EVENT_SERVICE_ENV_OPTIONS,

--- a/event-libs/session-guide-configurator/constants.js
+++ b/event-libs/session-guide-configurator/constants.js
@@ -1,12 +1,7 @@
-// One config-library sheet per content-repo (da-events, each floodgate space, etc.) —
-// resolved against whichever org/repo the DA SDK handshake reports. Sibling to Tier 1
-// Event Configurator's own sheet, not merged into it — row shapes differ (this one is
-// keyed by configId, not eventId; see PLAN.md §2/§5).
+// Keyed by configId, not eventId — an event can have multiple configs.
 const CONFIGS_SHEET_PATH = '/tools/da-apps/session-guide-configurator/configs.json';
 
-// Copy Link's target — the DA app's own edit-mode URL, not the admin API origin
-// (DA_ADMIN_ORIGIN lives in v1/utils/da-sheet-controller.js, a different concern).
-// Same pattern as Schedule Maker's DA_ORIGIN/DA_APP_PATH (PLAN.md §3a).
+// This app's own edit-mode URL, not the admin API origin.
 const DA_ORIGIN = 'https://da.live';
 const DA_APP_PATH = 'tools/da-apps/session-guide-configurator';
 
@@ -15,13 +10,12 @@ const PAGES = {
   editor: 'editor',
 };
 
-// Default flow for New Config is browsing the full ESP catalog (EventPicker);
-// Library.js auto-falls-back to ManualEventLookup if that fails at runtime. Flip to
-// false to disable browse outright — mirrors Tier 1 Event Configurator's own flag.
+// Library.js falls back to ManualEventLookup if EventPicker's browse fails; set to
+// false to disable browse outright.
 const EVENT_BROWSE_ENABLED = true;
 
-// Selectable in ManualEventLookup.js's env picker. Excludes 'local' — that's
-// for the localhost dev harness, and targets the same endpoints as 'dev'.
+// Excludes 'local' — that targets the same endpoints as 'dev' and is only relevant
+// to the localhost dev harness.
 const EVENT_SERVICE_ENV_OPTIONS = [
   { value: 'prod', label: 'Prod' },
   { value: 'stage', label: 'Stage' },

--- a/event-libs/session-guide-configurator/constants.js
+++ b/event-libs/session-guide-configurator/constants.js
@@ -1,15 +1,17 @@
 // One config-library sheet per content-repo (da-events, each floodgate space, etc.) —
-// resolved against whichever org/repo the DA SDK handshake reports.
-const CONFIGS_SHEET_PATH = '/tools/da-apps/tier-1-event-configurator/configs.json';
+// resolved against whichever org/repo the DA SDK handshake reports. Sibling to Tier 1
+// Event Configurator's own sheet, not merged into it — row shapes differ (this one is
+// keyed by configId, not eventId; see PLAN.md §2/§5).
+const CONFIGS_SHEET_PATH = '/tools/da-apps/session-guide-configurator/configs.json';
 
 const PAGES = {
   library: 'library',
   editor: 'editor',
 };
 
-// Default flow for New Config/Duplicate is browsing the full ESP catalog
-// (EventPicker); Library.js auto-falls-back to ManualEventLookup if that
-// fails at runtime. Flip to false to disable browse outright.
+// Default flow for New Config is browsing the full ESP catalog (EventPicker);
+// Library.js auto-falls-back to ManualEventLookup if that fails at runtime. Flip to
+// false to disable browse outright — mirrors Tier 1 Event Configurator's own flag.
 const EVENT_BROWSE_ENABLED = true;
 
 // Selectable in ManualEventLookup.js's env picker. Excludes 'local' — that's

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -39,9 +39,7 @@ const ConfigsProvider = ({ children }) => {
   const [toastSuccess, setToastSuccess] = useState(null);
   const [toastError, setToastError] = useState(null);
 
-  // The row currently open in the editor — always a full row shape
-  // ({ configId, componentName, eventId, backendEventTitle, eventServiceEnv, config }),
-  // whether freshly created (New/Duplicate) or loaded from the library (Edit).
+  // Always a full row shape, whether freshly created or loaded from the library.
   const [activeConfig, setActiveConfig] = useState(null);
 
   const loadConfigs = useCallback(async () => {
@@ -65,10 +63,8 @@ const ConfigsProvider = ({ children }) => {
     if (org && repo && !hasLoaded) loadConfigs();
   }, [org, repo, hasLoaded, loadConfigs]);
 
-  // Starts a fresh row for a newly picked event. Unlike Tier 1 Event Configurator,
-  // there's no dedup-by-event check here — an event can have many configs (widget +
-  // page variants, testing variants; see PLAN.md §2/§5), so picking an event that
-  // already has other rows is expected, not an error.
+  // An event can have many configs, so picking an event that already has rows is
+  // expected, not an error — there's no dedup-by-event check.
   const startNewConfig = useCallback((event, eventServiceEnv) => {
     setActiveConfig({
       configId: crypto.randomUUID(),
@@ -80,11 +76,8 @@ const ConfigsProvider = ({ children }) => {
     });
   }, []);
 
-  // Clones a row's settings as-is onto the *same* event — no event re-picking, unlike
-  // Tier 1 Event Configurator's cross-event Duplicate (which exists only because that
-  // tool is one-row-per-event; this one isn't). Component name is pre-filled with a
-  // "(copy)" suggestion rather than left blank, since everything else about the clone
-  // is deliberately unchanged (PLAN.md §4.1: "Duplicates should copy everything over").
+  // Clones a row's settings as-is onto the same event; only componentName gets a
+  // "(copy)" suggestion.
   const startDuplicateConfig = useCallback((sourceRow) => {
     setActiveConfig({
       configId: crypto.randomUUID(),
@@ -102,14 +95,11 @@ const ConfigsProvider = ({ children }) => {
 
   const clearActiveConfig = useCallback(() => setActiveConfig(null), []);
 
-  // componentName lives at the row level, not inside config (see PLAN.md §5) — its
-  // own setter, distinct from updateConfigField below.
+  // componentName lives at the row level, not inside config, hence a separate setter.
   const updateComponentName = useCallback((componentName) => {
     setActiveConfig((prev) => (prev ? { ...prev, componentName } : prev));
   }, []);
 
-  // Sets a single top-level config field (e.g. surface, theme) immutably, so the
-  // editor UI (reading activeConfig.config directly) stays in sync automatically.
   const updateConfigField = useCallback((key, value) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
@@ -117,8 +107,6 @@ const ConfigsProvider = ({ children }) => {
     });
   }, []);
 
-  // Sets a single field within a nested config object (headings.*, behaviorFlags.*),
-  // immutably, same reasoning as updateConfigField above.
   const updateNestedConfigField = useCallback((group, key, value) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
@@ -129,22 +117,16 @@ const ConfigsProvider = ({ children }) => {
     });
   }, []);
 
-  // Called once real tracks are known (session fetch resolves) — mirrors Tier 1 Event
-  // Configurator's seedTrackIcons: drops swimlaneOrder entries for tracks that no
-  // longer appear in the live catalog, and appends any newly-discovered track not yet
-  // in the authored order (enabled by default — the "starting point" requirement,
-  // same as seedFilterCategories below), without disturbing the author's existing
-  // ordering/enabled/displayName state. `track` itself is the immutable original
-  // value (used to match sessions to swimlanes); `displayName` defaults to it and is
-  // author-editable, same rename pattern as filterCategories below.
+  // Seeds tracks from the live catalog on top of swimlaneOrder: drops entries for
+  // tracks no longer live, appends new ones (enabled by default), and otherwise
+  // leaves the author's existing order/enabled/displayName state untouched.
   const seedSwimlaneOrder = useCallback((tracks) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
       const existing = prev.config.swimlaneOrder || [];
       const liveTracks = tracks || [];
       const liveTrackSet = new Set(liveTracks);
-      // Backfills `displayName` on entries seeded before that field existed (rather
-      // than leaving it undefined forever) — `stillValid` isn't otherwise touched.
+      // Backfills displayName on entries seeded before that field existed.
       let backfilled = false;
       const stillValid = existing
         .filter((r) => liveTrackSet.has(r.track))
@@ -165,22 +147,17 @@ const ConfigsProvider = ({ children }) => {
     });
   }, []);
 
-  // Same "seed once discovered, never destroy authored state" pattern as
-  // seedSwimlaneOrder above, for the Filters step (PLAN.md §7): candidateAttributes
-  // comes from deriveFacetableAttributes(sessions) — everything facetable starts
-  // enabled by default (the "starting point" requirement), author unselects/renames/
-  // reorders from there. filterCategories is a plain array in display order — no
-  // separate numeric `order` field, to avoid two sources of truth for the same thing.
-  // `label` is the immutable original ESP label (kept alongside `displayName` so the
-  // editor can always show what's being overridden, even after a rename).
+  // Seeds newly-discovered facetable attributes on top of filterCategories (enabled
+  // by default), without disturbing existing order/state. Display order is the array
+  // order — there's no separate `order` field. `label` keeps the original ESP label
+  // alongside the editable `displayName`.
   const seedFilterCategories = useCallback((candidateAttributes) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
       const existing = prev.config.filterCategories || [];
       const candidates = candidateAttributes || [];
       const candidatesById = new Map(candidates.map((c) => [c.attributeId, c]));
-      // Backfills `label` on entries seeded before that field existed (rather than
-      // leaving it undefined forever) — `stillValid` isn't otherwise touched.
+      // Backfills label on entries seeded before that field existed.
       let backfilled = false;
       const stillValid = existing
         .filter((c) => candidatesById.has(c.attributeId))

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -134,7 +134,9 @@ const ConfigsProvider = ({ children }) => {
   // longer appear in the live catalog, and appends any newly-discovered track not yet
   // in the authored order (enabled by default — the "starting point" requirement,
   // same as seedFilterCategories below), without disturbing the author's existing
-  // ordering/enabled state.
+  // ordering/enabled/displayName state. `track` itself is the immutable original
+  // value (used to match sessions to swimlanes); `displayName` defaults to it and is
+  // author-editable, same rename pattern as filterCategories below.
   const seedSwimlaneOrder = useCallback((tracks) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
@@ -145,7 +147,7 @@ const ConfigsProvider = ({ children }) => {
       const existingTrackSet = new Set(existing.map((r) => r.track));
       const newOnes = liveTracks
         .filter((t) => !existingTrackSet.has(t))
-        .map((t) => ({ track: t, enabled: true }));
+        .map((t) => ({ track: t, displayName: t, enabled: true }));
       if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
       return {
         ...prev,
@@ -160,6 +162,8 @@ const ConfigsProvider = ({ children }) => {
   // enabled by default (the "starting point" requirement), author unselects/renames/
   // reorders from there. filterCategories is a plain array in display order — no
   // separate numeric `order` field, to avoid two sources of truth for the same thing.
+  // `label` is the immutable original ESP label (kept alongside `displayName` so the
+  // editor can always show what's being overridden, even after a rename).
   const seedFilterCategories = useCallback((candidateAttributes) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
@@ -170,7 +174,9 @@ const ConfigsProvider = ({ children }) => {
       const existingIds = new Set(existing.map((c) => c.attributeId));
       const newOnes = candidates
         .filter((c) => !existingIds.has(c.attributeId))
-        .map((c) => ({ attributeId: c.attributeId, displayName: c.label, enabled: true }));
+        .map((c) => ({
+          attributeId: c.attributeId, label: c.label, displayName: c.label, enabled: true,
+        }));
       if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
       return {
         ...prev,

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -132,14 +132,20 @@ const ConfigsProvider = ({ children }) => {
   // Called once real tracks are known (session fetch resolves) — mirrors Tier 1 Event
   // Configurator's seedTrackIcons: drops swimlaneOrder entries for tracks that no
   // longer appear in the live catalog, and appends any newly-discovered track not yet
-  // in the authored order, without disturbing the author's existing ordering.
+  // in the authored order (enabled by default — the "starting point" requirement,
+  // same as seedFilterCategories below), without disturbing the author's existing
+  // ordering/enabled state.
   const seedSwimlaneOrder = useCallback((tracks) => {
     setActiveConfig((prev) => {
       if (!prev) return prev;
       const existing = prev.config.swimlaneOrder || [];
       const liveTracks = tracks || [];
-      const stillValid = existing.filter((t) => liveTracks.includes(t));
-      const newOnes = liveTracks.filter((t) => !existing.includes(t));
+      const liveTrackSet = new Set(liveTracks);
+      const stillValid = existing.filter((r) => liveTrackSet.has(r.track));
+      const existingTrackSet = new Set(existing.map((r) => r.track));
+      const newOnes = liveTracks
+        .filter((t) => !existingTrackSet.has(t))
+        .map((t) => ({ track: t, enabled: true }));
       if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
       return {
         ...prev,

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -143,12 +143,21 @@ const ConfigsProvider = ({ children }) => {
       const existing = prev.config.swimlaneOrder || [];
       const liveTracks = tracks || [];
       const liveTrackSet = new Set(liveTracks);
-      const stillValid = existing.filter((r) => liveTrackSet.has(r.track));
+      // Backfills `displayName` on entries seeded before that field existed (rather
+      // than leaving it undefined forever) — `stillValid` isn't otherwise touched.
+      let backfilled = false;
+      const stillValid = existing
+        .filter((r) => liveTrackSet.has(r.track))
+        .map((r) => {
+          if (r.displayName) return r;
+          backfilled = true;
+          return { ...r, displayName: r.track };
+        });
       const existingTrackSet = new Set(existing.map((r) => r.track));
       const newOnes = liveTracks
         .filter((t) => !existingTrackSet.has(t))
         .map((t) => ({ track: t, displayName: t, enabled: true }));
-      if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
+      if (newOnes.length === 0 && stillValid.length === existing.length && !backfilled) return prev;
       return {
         ...prev,
         config: { ...prev.config, swimlaneOrder: [...stillValid, ...newOnes] },
@@ -169,15 +178,24 @@ const ConfigsProvider = ({ children }) => {
       if (!prev) return prev;
       const existing = prev.config.filterCategories || [];
       const candidates = candidateAttributes || [];
-      const candidateIds = new Set(candidates.map((c) => c.attributeId));
-      const stillValid = existing.filter((c) => candidateIds.has(c.attributeId));
+      const candidatesById = new Map(candidates.map((c) => [c.attributeId, c]));
+      // Backfills `label` on entries seeded before that field existed (rather than
+      // leaving it undefined forever) — `stillValid` isn't otherwise touched.
+      let backfilled = false;
+      const stillValid = existing
+        .filter((c) => candidatesById.has(c.attributeId))
+        .map((c) => {
+          if (c.label) return c;
+          backfilled = true;
+          return { ...c, label: candidatesById.get(c.attributeId).label ?? c.displayName };
+        });
       const existingIds = new Set(existing.map((c) => c.attributeId));
       const newOnes = candidates
         .filter((c) => !existingIds.has(c.attributeId))
         .map((c) => ({
           attributeId: c.attributeId, label: c.label, displayName: c.label, enabled: true,
         }));
-      if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
+      if (newOnes.length === 0 && stillValid.length === existing.length && !backfilled) return prev;
       return {
         ...prev,
         config: { ...prev.config, filterCategories: [...stillValid, ...newOnes] },

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -1,0 +1,197 @@
+import {
+  createContext, useState, useContext, useCallback, useEffect, html,
+} from '../../v1/deps/htm-preact.js';
+import {
+  getConfigs,
+  upsertConfig as upsertConfigController,
+  deleteConfig as deleteConfigController,
+} from '../scripts/da-controller.js';
+import { useDA } from './DAContext.js';
+import { getDisplayTitle } from '../utils.js';
+
+const ConfigsContext = createContext();
+
+function emptyConfig() {
+  return {
+    surface: 'widget',
+    theme: 'dark',
+    headings: {
+      loggedOut: '', loggedIn: '', loggedOutPostEvent: '', loggedInPostEvent: '',
+    },
+    behaviorFlags: {
+      enableScheduling: true,
+      enableFavoriting: true,
+      enableWatchNowCtas: true,
+      enableBrandConciergeRibbon: true,
+    },
+    filterCategories: [],
+    swimlaneOrder: [],
+  };
+}
+
+const ConfigsProvider = ({ children }) => {
+  const { org, repo } = useDA();
+
+  const [configs, setConfigs] = useState([]);
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState(null);
+  const [toastSuccess, setToastSuccess] = useState(null);
+  const [toastError, setToastError] = useState(null);
+
+  // The row currently open in the editor — always a full row shape
+  // ({ configId, componentName, eventId, backendEventTitle, eventServiceEnv, config }),
+  // whether freshly created (New/Duplicate) or loaded from the library (Edit).
+  const [activeConfig, setActiveConfig] = useState(null);
+
+  const loadConfigs = useCallback(async () => {
+    if (!org || !repo) return;
+    setIsInitialLoading(true);
+    setError(null);
+    try {
+      const result = await getConfigs(org, repo);
+      if (!result.ok) {
+        setError(result.error || 'Failed to load the config library');
+        return;
+      }
+      setConfigs(result.data);
+      setHasLoaded(true);
+    } finally {
+      setIsInitialLoading(false);
+    }
+  }, [org, repo]);
+
+  useEffect(() => {
+    if (org && repo && !hasLoaded) loadConfigs();
+  }, [org, repo, hasLoaded, loadConfigs]);
+
+  // Starts a fresh row for a newly picked event. Unlike Tier 1 Event Configurator,
+  // there's no dedup-by-event check here — an event can have many configs (widget +
+  // page variants, testing variants; see PLAN.md §2/§5), so picking an event that
+  // already has other rows is expected, not an error.
+  const startNewConfig = useCallback((event, eventServiceEnv) => {
+    setActiveConfig({
+      configId: crypto.randomUUID(),
+      componentName: '',
+      eventId: event.eventId,
+      backendEventTitle: event.enTitle || event.eventId,
+      eventServiceEnv,
+      config: emptyConfig(),
+    });
+  }, []);
+
+  // Clones a row's settings as-is onto the *same* event — no event re-picking, unlike
+  // Tier 1 Event Configurator's cross-event Duplicate (which exists only because that
+  // tool is one-row-per-event; this one isn't). Component name is pre-filled with a
+  // "(copy)" suggestion rather than left blank, since everything else about the clone
+  // is deliberately unchanged (PLAN.md §4.1: "Duplicates should copy everything over").
+  const startDuplicateConfig = useCallback((sourceRow) => {
+    setActiveConfig({
+      configId: crypto.randomUUID(),
+      componentName: sourceRow.componentName ? `${sourceRow.componentName} (copy)` : '',
+      eventId: sourceRow.eventId,
+      backendEventTitle: sourceRow.backendEventTitle,
+      eventServiceEnv: sourceRow.eventServiceEnv,
+      config: { ...sourceRow.config },
+    });
+  }, []);
+
+  const startEditConfig = useCallback((row) => {
+    setActiveConfig(row);
+  }, []);
+
+  const clearActiveConfig = useCallback(() => setActiveConfig(null), []);
+
+  // componentName lives at the row level, not inside config (see PLAN.md §5) — its
+  // own setter, distinct from updateConfigField below.
+  const updateComponentName = useCallback((componentName) => {
+    setActiveConfig((prev) => (prev ? { ...prev, componentName } : prev));
+  }, []);
+
+  // Sets a single top-level config field (e.g. surface, theme) immutably, so the
+  // editor UI (reading activeConfig.config directly) stays in sync automatically.
+  const updateConfigField = useCallback((key, value) => {
+    setActiveConfig((prev) => {
+      if (!prev) return prev;
+      return { ...prev, config: { ...prev.config, [key]: value } };
+    });
+  }, []);
+
+  // Sets a single field within a nested config object (headings.*, behaviorFlags.*),
+  // immutably, same reasoning as updateConfigField above.
+  const updateNestedConfigField = useCallback((group, key, value) => {
+    setActiveConfig((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        config: { ...prev.config, [group]: { ...prev.config[group], [key]: value } },
+      };
+    });
+  }, []);
+
+  const saveActiveConfig = useCallback(async () => {
+    if (!activeConfig || !org || !repo) return { ok: false };
+    const result = await upsertConfigController(org, repo, activeConfig);
+    if (!result.ok) {
+      setToastError(result.error || 'Failed to save — please retry');
+      return result;
+    }
+    setConfigs((prev) => {
+      const idx = prev.findIndex((r) => r.configId === result.data.configId);
+      if (idx === -1) return [result.data, ...prev];
+      const next = [...prev];
+      next[idx] = result.data;
+      return next;
+    });
+    setActiveConfig(result.data);
+    setToastSuccess(`Saved ${getDisplayTitle(result.data)}`);
+    return result;
+  }, [activeConfig, org, repo]);
+
+  const removeConfig = useCallback(async (configId) => {
+    if (!org || !repo) return { ok: false };
+    const result = await deleteConfigController(org, repo, configId);
+    if (!result.ok) {
+      setToastError(result.error || 'Failed to delete — please retry');
+      return result;
+    }
+    setConfigs((prev) => prev.filter((r) => r.configId !== configId));
+    setToastSuccess('Config deleted');
+    return result;
+  }, [org, repo]);
+
+  const clearToastError = useCallback(() => setToastError(null), []);
+  const clearToastSuccess = useCallback(() => setToastSuccess(null), []);
+
+  const value = {
+    configs,
+    isInitialLoading,
+    error,
+    toastSuccess,
+    toastError,
+    clearToastError,
+    clearToastSuccess,
+    setToastError,
+    setToastSuccess,
+    activeConfig,
+    startNewConfig,
+    startDuplicateConfig,
+    startEditConfig,
+    clearActiveConfig,
+    updateComponentName,
+    updateConfigField,
+    updateNestedConfigField,
+    saveActiveConfig,
+    removeConfig,
+  };
+
+  return html`
+    <${ConfigsContext.Provider} value=${value}>
+      ${children}
+    </${ConfigsContext.Provider}>
+  `;
+};
+
+const useConfigs = () => useContext(ConfigsContext);
+
+export { ConfigsContext, ConfigsProvider, useConfigs };

--- a/event-libs/session-guide-configurator/context/ConfigsContext.js
+++ b/event-libs/session-guide-configurator/context/ConfigsContext.js
@@ -129,6 +129,50 @@ const ConfigsProvider = ({ children }) => {
     });
   }, []);
 
+  // Called once real tracks are known (session fetch resolves) — mirrors Tier 1 Event
+  // Configurator's seedTrackIcons: drops swimlaneOrder entries for tracks that no
+  // longer appear in the live catalog, and appends any newly-discovered track not yet
+  // in the authored order, without disturbing the author's existing ordering.
+  const seedSwimlaneOrder = useCallback((tracks) => {
+    setActiveConfig((prev) => {
+      if (!prev) return prev;
+      const existing = prev.config.swimlaneOrder || [];
+      const liveTracks = tracks || [];
+      const stillValid = existing.filter((t) => liveTracks.includes(t));
+      const newOnes = liveTracks.filter((t) => !existing.includes(t));
+      if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
+      return {
+        ...prev,
+        config: { ...prev.config, swimlaneOrder: [...stillValid, ...newOnes] },
+      };
+    });
+  }, []);
+
+  // Same "seed once discovered, never destroy authored state" pattern as
+  // seedSwimlaneOrder above, for the Filters step (PLAN.md §7): candidateAttributes
+  // comes from deriveFacetableAttributes(sessions) — everything facetable starts
+  // enabled by default (the "starting point" requirement), author unselects/renames/
+  // reorders from there. filterCategories is a plain array in display order — no
+  // separate numeric `order` field, to avoid two sources of truth for the same thing.
+  const seedFilterCategories = useCallback((candidateAttributes) => {
+    setActiveConfig((prev) => {
+      if (!prev) return prev;
+      const existing = prev.config.filterCategories || [];
+      const candidates = candidateAttributes || [];
+      const candidateIds = new Set(candidates.map((c) => c.attributeId));
+      const stillValid = existing.filter((c) => candidateIds.has(c.attributeId));
+      const existingIds = new Set(existing.map((c) => c.attributeId));
+      const newOnes = candidates
+        .filter((c) => !existingIds.has(c.attributeId))
+        .map((c) => ({ attributeId: c.attributeId, displayName: c.label, enabled: true }));
+      if (newOnes.length === 0 && stillValid.length === existing.length) return prev;
+      return {
+        ...prev,
+        config: { ...prev.config, filterCategories: [...stillValid, ...newOnes] },
+      };
+    });
+  }, []);
+
   const saveActiveConfig = useCallback(async () => {
     if (!activeConfig || !org || !repo) return { ok: false };
     const result = await upsertConfigController(org, repo, activeConfig);
@@ -181,6 +225,8 @@ const ConfigsProvider = ({ children }) => {
     updateComponentName,
     updateConfigField,
     updateNestedConfigField,
+    seedSwimlaneOrder,
+    seedFilterCategories,
     saveActiveConfig,
     removeConfig,
   };

--- a/event-libs/session-guide-configurator/context/DAContext.js
+++ b/event-libs/session-guide-configurator/context/DAContext.js
@@ -1,0 +1,50 @@
+import {
+  createContext, useState, useContext, useEffect, html,
+} from '../../v1/deps/htm-preact.js';
+import { setDaToken, setDaFetch } from '../scripts/da-controller.js';
+import { setEspAuthToken } from '../../v1/utils/esp-controller.js';
+
+const DAContext = createContext();
+
+const DAProvider = ({ children }) => {
+  const [token, setToken] = useState(null);
+  const [org, setOrg] = useState(null);
+  const [repo, setRepo] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function initSdk() {
+      try {
+        const { default: DA_SDK } = await import('https://da.live/nx/utils/sdk.js');
+        const { token: sdkToken, context, actions } = await DA_SDK;
+        setToken(sdkToken);
+        setOrg(context?.org);
+        setRepo(context?.repo);
+        setDaToken(sdkToken);
+        if (actions?.daFetch) setDaFetch(actions.daFetch);
+        // No Milo/IMS bootstrap here (no window.adobeIMS), so ESP calls have
+        // no token otherwise — reuse DA's own as the Authorization Bearer.
+        setEspAuthToken(sdkToken);
+      } catch (err) {
+        window.lana?.log(`DA SDK init error: ${err}`);
+        setError('Failed to initialize DA SDK. Please reload the page.');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    initSdk();
+  }, []);
+
+  const value = { token, org, repo, isLoading, error };
+
+  return html`
+    <${DAContext.Provider} value=${value}>
+      ${children}
+    </${DAContext.Provider}>
+  `;
+};
+
+const useDA = () => useContext(DAContext);
+
+export { DAContext, DAProvider, useDA };

--- a/event-libs/session-guide-configurator/context/DAContext.js
+++ b/event-libs/session-guide-configurator/context/DAContext.js
@@ -23,8 +23,7 @@ const DAProvider = ({ children }) => {
         setRepo(context?.repo);
         setDaToken(sdkToken);
         if (actions?.daFetch) setDaFetch(actions.daFetch);
-        // No Milo/IMS bootstrap here (no window.adobeIMS), so ESP calls have
-        // no token otherwise — reuse DA's own as the Authorization Bearer.
+        // No Milo/IMS bootstrap here, so reuse DA's token as the ESP auth bearer.
         setEspAuthToken(sdkToken);
       } catch (err) {
         window.lana?.log(`DA SDK init error: ${err}`);

--- a/event-libs/session-guide-configurator/context/EventEnvContext.js
+++ b/event-libs/session-guide-configurator/context/EventEnvContext.js
@@ -1,0 +1,29 @@
+import {
+  createContext, useState, useContext, useCallback, useMemo, html,
+} from '../../v1/deps/htm-preact.js';
+import { setEventServiceEnvOverride, getEventServiceEnv } from '../../v1/utils/utils.js';
+
+const EventEnvContext = createContext();
+
+// Reactive wrapper around utils.js's module-level env override, so a plain
+// variable (needed for non-React callers too) can still drive a re-render.
+const EventEnvProvider = ({ children }) => {
+  const [envName, setEnvName] = useState(() => getEventServiceEnv().name);
+
+  const setEnv = useCallback((name) => {
+    setEventServiceEnvOverride(name);
+    setEnvName(getEventServiceEnv().name);
+  }, []);
+
+  const value = useMemo(() => ({ envName, setEnv }), [envName, setEnv]);
+
+  return html`
+    <${EventEnvContext.Provider} value=${value}>
+      ${children}
+    </${EventEnvContext.Provider}>
+  `;
+};
+
+const useEventEnv = () => useContext(EventEnvContext);
+
+export { EventEnvProvider, useEventEnv };

--- a/event-libs/session-guide-configurator/context/EventEnvContext.js
+++ b/event-libs/session-guide-configurator/context/EventEnvContext.js
@@ -5,8 +5,8 @@ import { setEventServiceEnvOverride, getEventServiceEnv } from '../../v1/utils/u
 
 const EventEnvContext = createContext();
 
-// Reactive wrapper around utils.js's module-level env override, so a plain
-// variable (needed for non-React callers too) can still drive a re-render.
+// Reactive wrapper around utils.js's module-level env override, so non-React callers
+// can still trigger a re-render.
 const EventEnvProvider = ({ children }) => {
   const [envName, setEnvName] = useState(() => getEventServiceEnv().name);
 

--- a/event-libs/session-guide-configurator/context/NavigationContext.js
+++ b/event-libs/session-guide-configurator/context/NavigationContext.js
@@ -1,0 +1,34 @@
+import {
+  useState, useContext, useCallback, createContext, html,
+} from '../../v1/deps/htm-preact.js';
+import { PAGES } from '../constants.js';
+
+const NavigationContext = createContext();
+
+const NavigationProvider = ({ children }) => {
+  const [activePage, setActivePage] = useState(PAGES.library);
+
+  const goToLibrary = useCallback(() => {
+    setActivePage(PAGES.library);
+  }, []);
+
+  const goToEditor = useCallback(() => {
+    setActivePage(PAGES.editor);
+  }, []);
+
+  const value = {
+    activePage,
+    goToLibrary,
+    goToEditor,
+  };
+
+  return html`
+    <${NavigationContext.Provider} value=${value}>
+      ${children}
+    </${NavigationContext.Provider}>
+  `;
+};
+
+const useNavigation = () => useContext(NavigationContext);
+
+export { NavigationContext, NavigationProvider, useNavigation };

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -1,0 +1,121 @@
+import { useState, html } from '../../v1/deps/htm-preact.js';
+import { useNavigation } from '../context/NavigationContext.js';
+import { useConfigs } from '../context/ConfigsContext.js';
+import { getDisplayTitle } from '../utils.js';
+
+export default function ConfigEditor() {
+  const { goToLibrary } = useNavigation();
+  const {
+    activeConfig, saveActiveConfig, clearActiveConfig, updateComponentName, updateConfigField,
+  } = useConfigs();
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleCancel = () => {
+    clearActiveConfig();
+    goToLibrary();
+  };
+
+  const componentNameMissing = !activeConfig?.componentName?.trim();
+
+  const handleSave = async () => {
+    if (componentNameMissing) return;
+    setIsSaving(true);
+    try {
+      const result = await saveActiveConfig();
+      if (result.ok) goToLibrary();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!activeConfig) return null;
+
+  return html`
+    <div class="sgc-page sgc-editor">
+      <div class="sgc-editor__header">
+        <button type="button" class="sgc-btn sgc-btn--icon" onClick=${handleCancel} aria-label="Back to library">←</button>
+        <div class="sgc-editor__header-text">
+          <h1 class="sgc-editor__title">${getDisplayTitle(activeConfig)}</h1>
+          <p class="sgc-editor__event-id">${activeConfig.eventId} · Backend title: ${activeConfig.backendEventTitle}</p>
+        </div>
+      </div>
+
+      <section class="sgc-editor__section">
+        <h2>Component name</h2>
+        <p class="sgc-editor__section-hint">Distinguishes this config from others authored for the same event (e.g. a widget vs. full-page variant).</p>
+        <input
+          type="text"
+          class="sgc-field sgc-editor__title-input"
+          placeholder="e.g. MAX 26 — Widget"
+          value=${activeConfig.componentName}
+          onInput=${(e) => updateComponentName(e.target.value)}
+        />
+        ${componentNameMissing && html`
+          <p class="sgc-editor__error">Component name is required before saving.</p>
+        `}
+      </section>
+
+      <section class="sgc-editor__section">
+        <h2>Page mode</h2>
+        <p class="sgc-editor__section-hint">Embedded on page mounts as a drawer widget; Full page renders as a dedicated page layout.</p>
+        <label class="sgc-editor__radio">
+          <input
+            type="radio"
+            name="surface"
+            value="widget"
+            checked=${activeConfig.config.surface === 'widget'}
+            onChange=${() => updateConfigField('surface', 'widget')}
+          />
+          Embedded on page
+        </label>
+        <label class="sgc-editor__radio">
+          <input
+            type="radio"
+            name="surface"
+            value="page"
+            checked=${activeConfig.config.surface === 'page'}
+            onChange=${() => updateConfigField('surface', 'page')}
+          />
+          Full page
+        </label>
+      </section>
+
+      <section class="sgc-editor__section">
+        <h2>Theme</h2>
+        <label class="sgc-editor__radio">
+          <input
+            type="radio"
+            name="theme"
+            value="light"
+            checked=${activeConfig.config.theme === 'light'}
+            onChange=${() => updateConfigField('theme', 'light')}
+          />
+          Light
+        </label>
+        <label class="sgc-editor__radio">
+          <input
+            type="radio"
+            name="theme"
+            value="dark"
+            checked=${activeConfig.config.theme === 'dark'}
+            onChange=${() => updateConfigField('theme', 'dark')}
+          />
+          Dark
+        </label>
+      </section>
+
+      <div class="sgc-editor__actions">
+        <button type="button" class="sgc-btn sgc-btn--outline sgc-btn--l" onClick=${handleCancel}>Cancel</button>
+        <button
+          type="button"
+          class="sgc-btn sgc-btn--primary sgc-btn--l"
+          onClick=${handleSave}
+          disabled=${isSaving || componentNameMissing}
+        >
+          ${isSaving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  `;
+}

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -242,7 +242,7 @@ export default function ConfigEditor() {
 
       <section class="sgc-editor__section">
         <h2>On-demand swimlane order</h2>
-        <p class="sgc-editor__section-hint">Drag to reorder, or focus a handle and press arrow up/down. Unselect a track to hide it from the session guide entirely. Renaming swimlanes isn't available here — track names/icons/colors are managed globally via the Tier 1 Event Configurator.</p>
+        <p class="sgc-editor__section-hint">Drag to reorder, or focus a handle and press arrow up/down. Unselect a track to hide it from the session guide entirely, or edit its name to change how it's labeled here — the original value stays shown alongside for reference. Track icons/colors are still managed globally via the Tier 1 Event Configurator.</p>
         ${isLoadingSessions && html`<${LoadingInline} label="Loading tracks…" />`}
         ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
         ${!isLoadingSessions && !sessionsError && html`
@@ -255,7 +255,7 @@ export default function ConfigEditor() {
 
       <section class="sgc-editor__section">
         <h2>Filters</h2>
-        <p class="sgc-editor__section-hint">Every facetable attribute from this event's sessions starts enabled — unselect, rename, or reorder the ones shown in the published Session Guide. Filter options themselves are always read live from ESP, not authored here.</p>
+        <p class="sgc-editor__section-hint">Every facetable attribute from this event's sessions starts enabled — unselect, rename, or reorder the ones shown in the published Session Guide. The original name stays shown alongside the editable one for reference. Filter options themselves are always read live from ESP, not authored here.</p>
         ${isLoadingSessions && html`<${LoadingInline} label="Loading filters…" />`}
         ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
         ${!isLoadingSessions && !sessionsError && html`

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -6,7 +6,9 @@ import { extractDistinctTracks, deriveFacetableAttributes } from '../../v1/servi
 import { useNavigation } from '../context/NavigationContext.js';
 import { useConfigs } from '../context/ConfigsContext.js';
 import { useDA } from '../context/DAContext.js';
-import { getDisplayTitle, copyTextToClipboard, createSessionGuideConfigURL } from '../utils.js';
+import {
+  getDisplayTitle, createSessionGuideConfigURL, copySessionGuideConfigLink, formatUpdatedTime,
+} from '../utils.js';
 import SwimlaneOrderEditor from '../components/SwimlaneOrderEditor.js';
 import FiltersEditor from '../components/FiltersEditor.js';
 import LoadingInline from '../components/LoadingInline.js';
@@ -69,10 +71,16 @@ export default function ConfigEditor() {
   // Encodes whatever's currently in the editor, saved or not — same as Tier 1 Event
   // Configurator's in-editor Copy Config, which doesn't require a prior save either.
   // Consumed by decorate.js's prebuildAutoBlock at decoration time (PLAN.md §3a); no
-  // manual authoring-table path exists for this block.
+  // manual authoring-table path exists for this block. Copies a real hyperlink (with
+  // display text), not just the bare URL, same as Schedule Maker's own Copy Link —
+  // pasting into a DA doc drops in a working link, not a wall of base64.
   const handleCopyLink = async () => {
     const url = createSessionGuideConfigURL(activeConfig.config, org, repo);
-    const ok = await copyTextToClipboard(url);
+    const formattedDate = formatUpdatedTime(activeConfig.updated);
+    const linkText = formattedDate
+      ? `Session Guide: ${getDisplayTitle(activeConfig)} – ${formattedDate}`
+      : `Session Guide: ${getDisplayTitle(activeConfig)}`;
+    const ok = await copySessionGuideConfigLink(url, linkText);
     if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
     else setToastError('Could not copy the link — please retry');
   };

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -6,9 +6,7 @@ import { extractDistinctTracks, deriveFacetableAttributes } from '../../v1/servi
 import { useNavigation } from '../context/NavigationContext.js';
 import { useConfigs } from '../context/ConfigsContext.js';
 import { useDA } from '../context/DAContext.js';
-import {
-  getDisplayTitle, createSessionGuideConfigURL, copySessionGuideConfigLink, formatUpdatedTime,
-} from '../utils.js';
+import { getDisplayTitle, copyRowLinkWithToast } from '../utils.js';
 import SwimlaneOrderEditor from '../components/SwimlaneOrderEditor.js';
 import FiltersEditor from '../components/FiltersEditor.js';
 import LoadingInline from '../components/LoadingInline.js';
@@ -68,22 +66,8 @@ export default function ConfigEditor() {
     }
   };
 
-  // Encodes whatever's currently in the editor, saved or not — same as Tier 1 Event
-  // Configurator's in-editor Copy Config, which doesn't require a prior save either.
-  // Consumed by decorate.js's prebuildAutoBlock at decoration time (PLAN.md §3a); no
-  // manual authoring-table path exists for this block. Copies a real hyperlink (with
-  // display text), not just the bare URL, same as Schedule Maker's own Copy Link —
-  // pasting into a DA doc drops in a working link, not a wall of base64.
-  const handleCopyLink = async () => {
-    const url = createSessionGuideConfigURL(activeConfig.config, org, repo);
-    const formattedDate = formatUpdatedTime(activeConfig.updated);
-    const linkText = formattedDate
-      ? `Session Guide: ${getDisplayTitle(activeConfig)} – ${formattedDate}`
-      : `Session Guide: ${getDisplayTitle(activeConfig)}`;
-    const ok = await copySessionGuideConfigLink(url, linkText);
-    if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
-    else setToastError('Could not copy the link — please retry');
-  };
+  // Encodes activeConfig.config directly — works on unsaved changes too, no save required.
+  const handleCopyLink = () => copyRowLinkWithToast(activeConfig, org, repo, setToastSuccess, setToastError);
 
   if (!activeConfig) return null;
 

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -1,15 +1,52 @@
-import { useState, html } from '../../v1/deps/htm-preact.js';
+import {
+  useState, useEffect, useMemo, html,
+} from '../../v1/deps/htm-preact.js';
+import { getEventSessionCatalog } from '../../v1/utils/esp-controller.js';
+import { extractDistinctTracks, deriveFacetableAttributes } from '../../v1/services/sessions/sessions-api.js';
 import { useNavigation } from '../context/NavigationContext.js';
 import { useConfigs } from '../context/ConfigsContext.js';
-import { getDisplayTitle } from '../utils.js';
+import { useDA } from '../context/DAContext.js';
+import { getDisplayTitle, copyTextToClipboard, createSessionGuideConfigURL } from '../utils.js';
+import SwimlaneOrderEditor from '../components/SwimlaneOrderEditor.js';
+import FiltersEditor from '../components/FiltersEditor.js';
+import LoadingInline from '../components/LoadingInline.js';
 
 export default function ConfigEditor() {
   const { goToLibrary } = useNavigation();
+  const { org, repo } = useDA();
   const {
     activeConfig, saveActiveConfig, clearActiveConfig, updateComponentName, updateConfigField,
+    updateNestedConfigField, seedSwimlaneOrder, seedFilterCategories, setToastSuccess, setToastError,
   } = useConfigs();
 
   const [isSaving, setIsSaving] = useState(false);
+  const [sessions, setSessions] = useState([]);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+  const [sessionsError, setSessionsError] = useState(null);
+
+  const eventId = activeConfig?.eventId;
+
+  useEffect(() => {
+    if (!eventId) return undefined;
+    let cancelled = false;
+    setIsLoadingSessions(true);
+    setSessionsError(null);
+    getEventSessionCatalog(eventId).then((result) => {
+      if (cancelled) return;
+      if (!result.ok) {
+        setSessionsError(result.error || 'Failed to load sessions for this event');
+        return;
+      }
+      setSessions(result.data.sessions);
+      seedSwimlaneOrder(extractDistinctTracks(result.data.sessions));
+      seedFilterCategories(deriveFacetableAttributes(result.data.sessions));
+    }).finally(() => {
+      if (!cancelled) setIsLoadingSessions(false);
+    });
+    return () => { cancelled = true; };
+  }, [eventId, seedSwimlaneOrder, seedFilterCategories]);
+
+  const tracks = useMemo(() => extractDistinctTracks(sessions), [sessions]);
 
   const handleCancel = () => {
     clearActiveConfig();
@@ -29,6 +66,17 @@ export default function ConfigEditor() {
     }
   };
 
+  // Encodes whatever's currently in the editor, saved or not — same as Tier 1 Event
+  // Configurator's in-editor Copy Config, which doesn't require a prior save either.
+  // Consumed by decorate.js's prebuildAutoBlock at decoration time (PLAN.md §3a); no
+  // manual authoring-table path exists for this block.
+  const handleCopyLink = async () => {
+    const url = createSessionGuideConfigURL(activeConfig.config, org, repo);
+    const ok = await copyTextToClipboard(url);
+    if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
+    else setToastError('Could not copy the link — please retry');
+  };
+
   if (!activeConfig) return null;
 
   return html`
@@ -40,6 +88,15 @@ export default function ConfigEditor() {
           <p class="sgc-editor__event-id">${activeConfig.eventId} · Backend title: ${activeConfig.backendEventTitle}</p>
         </div>
       </div>
+
+      <section class="sgc-editor__section">
+        <h2>Sessions</h2>
+        ${isLoadingSessions && html`<${LoadingInline} label="Loading sessions…" />`}
+        ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
+        ${!isLoadingSessions && !sessionsError && html`
+          <p class="sgc-editor__section-hint">${sessions.length} session(s) found — ${tracks.length} distinct track(s).</p>
+        `}
+      </section>
 
       <section class="sgc-editor__section">
         <h2>Component name</h2>
@@ -105,8 +162,120 @@ export default function ConfigEditor() {
         </label>
       </section>
 
+      <section class="sgc-editor__section">
+        <h2>Headings</h2>
+        <p class="sgc-editor__section-hint">Shown reflects the viewer's auth state, and separately their pre-/post-event state.</p>
+        <label class="sgc-editor__field-label">
+          Logged-out
+          <input
+            type="text"
+            class="sgc-field sgc-editor__heading-input"
+            value=${activeConfig.config.headings.loggedOut}
+            onInput=${(e) => updateNestedConfigField('headings', 'loggedOut', e.target.value)}
+          />
+        </label>
+        <label class="sgc-editor__field-label">
+          Logged-in
+          <input
+            type="text"
+            class="sgc-field sgc-editor__heading-input"
+            value=${activeConfig.config.headings.loggedIn}
+            onInput=${(e) => updateNestedConfigField('headings', 'loggedIn', e.target.value)}
+          />
+        </label>
+        <label class="sgc-editor__field-label">
+          Logged-out (post-event)
+          <input
+            type="text"
+            class="sgc-field sgc-editor__heading-input"
+            value=${activeConfig.config.headings.loggedOutPostEvent}
+            onInput=${(e) => updateNestedConfigField('headings', 'loggedOutPostEvent', e.target.value)}
+          />
+        </label>
+        <label class="sgc-editor__field-label">
+          Logged-in (post-event)
+          <input
+            type="text"
+            class="sgc-field sgc-editor__heading-input"
+            value=${activeConfig.config.headings.loggedInPostEvent}
+            onInput=${(e) => updateNestedConfigField('headings', 'loggedInPostEvent', e.target.value)}
+          />
+        </label>
+      </section>
+
+      <section class="sgc-editor__section">
+        <h2>Behavior flags</h2>
+        <label class="sgc-editor__checkbox">
+          <input
+            type="checkbox"
+            checked=${!!activeConfig.config.behaviorFlags.enableScheduling}
+            onChange=${(e) => updateNestedConfigField('behaviorFlags', 'enableScheduling', e.target.checked)}
+          />
+          Enable scheduling
+        </label>
+        <label class="sgc-editor__checkbox">
+          <input
+            type="checkbox"
+            checked=${!!activeConfig.config.behaviorFlags.enableFavoriting}
+            onChange=${(e) => updateNestedConfigField('behaviorFlags', 'enableFavoriting', e.target.checked)}
+          />
+          Enable favoriting
+        </label>
+        <label class="sgc-editor__checkbox">
+          <input
+            type="checkbox"
+            checked=${!!activeConfig.config.behaviorFlags.enableWatchNowCtas}
+            onChange=${(e) => updateNestedConfigField('behaviorFlags', 'enableWatchNowCtas', e.target.checked)}
+          />
+          Enable Watch Now CTAs
+        </label>
+        <label class="sgc-editor__checkbox">
+          <input
+            type="checkbox"
+            checked=${!!activeConfig.config.behaviorFlags.enableBrandConciergeRibbon}
+            onChange=${(e) => updateNestedConfigField('behaviorFlags', 'enableBrandConciergeRibbon', e.target.checked)}
+          />
+          Enable Brand Concierge Ribbon
+        </label>
+        <p class="sgc-editor__section-hint">Allowing double-booking of overlapping sessions is set at the event level via the linked Tier 1 config, not here.</p>
+      </section>
+
+      <section class="sgc-editor__section">
+        <h2>On-demand swimlane order</h2>
+        <p class="sgc-editor__section-hint">Drag to reorder, or focus a handle and press arrow up/down. Renaming/removing swimlanes isn't available here — track names/icons/colors are managed globally via the Tier 1 Event Configurator.</p>
+        ${isLoadingSessions && html`<${LoadingInline} label="Loading tracks…" />`}
+        ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
+        ${!isLoadingSessions && !sessionsError && html`
+          <${SwimlaneOrderEditor} \
+            tracks=${activeConfig.config.swimlaneOrder} \
+            onChange=${(next) => updateConfigField('swimlaneOrder', next)} \
+          />
+        `}
+      </section>
+
+      <section class="sgc-editor__section">
+        <h2>Filters</h2>
+        <p class="sgc-editor__section-hint">Every facetable attribute from this event's sessions starts enabled — unselect, rename, or reorder the ones shown in the published Session Guide. Filter options themselves are always read live from ESP, not authored here.</p>
+        ${isLoadingSessions && html`<${LoadingInline} label="Loading filters…" />`}
+        ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
+        ${!isLoadingSessions && !sessionsError && html`
+          <${FiltersEditor} \
+            categories=${activeConfig.config.filterCategories} \
+            onChange=${(next) => updateConfigField('filterCategories', next)} \
+          />
+        `}
+      </section>
+
       <div class="sgc-editor__actions">
         <button type="button" class="sgc-btn sgc-btn--outline sgc-btn--l" onClick=${handleCancel}>Cancel</button>
+        <button
+          type="button"
+          class="sgc-btn sgc-btn--outline sgc-btn--l"
+          onClick=${handleCopyLink}
+          disabled=${componentNameMissing}
+        >
+          Copy link
+        </button>
         <button
           type="button"
           class="sgc-btn sgc-btn--primary sgc-btn--l"

--- a/event-libs/session-guide-configurator/pages/ConfigEditor.js
+++ b/event-libs/session-guide-configurator/pages/ConfigEditor.js
@@ -242,7 +242,7 @@ export default function ConfigEditor() {
 
       <section class="sgc-editor__section">
         <h2>On-demand swimlane order</h2>
-        <p class="sgc-editor__section-hint">Drag to reorder, or focus a handle and press arrow up/down. Renaming/removing swimlanes isn't available here — track names/icons/colors are managed globally via the Tier 1 Event Configurator.</p>
+        <p class="sgc-editor__section-hint">Drag to reorder, or focus a handle and press arrow up/down. Unselect a track to hide it from the session guide entirely. Renaming swimlanes isn't available here — track names/icons/colors are managed globally via the Tier 1 Event Configurator.</p>
         ${isLoadingSessions && html`<${LoadingInline} label="Loading tracks…" />`}
         ${sessionsError && html`<p class="sgc-editor__error">${sessionsError}</p>`}
         ${!isLoadingSessions && !sessionsError && html`

--- a/event-libs/session-guide-configurator/pages/Library.js
+++ b/event-libs/session-guide-configurator/pages/Library.js
@@ -2,6 +2,7 @@ import {
   useState, useMemo, useCallback, html,
 } from '../../v1/deps/htm-preact.js';
 import SearchInput from '../components/SearchInput.js';
+import Tier1ConfigPicker from '../components/Tier1ConfigPicker.js';
 import EventPicker from '../components/EventPicker.js';
 import ManualEventLookup from '../components/ManualEventLookup.js';
 import Modal from '../components/Modal.js';
@@ -24,6 +25,11 @@ export default function Library() {
 
   const [search, setSearch] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
+  // 'tier1' (default — pick an event that already has a Tier 1 Event Configurator
+  // config, this app's real source of truth, PLAN.md §2) | 'browse' (ESP catalog) |
+  // 'manual' (Event ID entry) — the latter two are explicit fallbacks for an event
+  // that doesn't have a Tier 1 config yet, reached via Tier1ConfigPicker's own link.
+  const [pickerMode, setPickerMode] = useState('tier1');
   const [rowPendingDelete, setRowPendingDelete] = useState(null);
   // If EventPicker's listAllEvents() fails for any reason, fail over to
   // ManualEventLookup for the rest of the session (sticky per page load, not
@@ -45,7 +51,14 @@ export default function Library() {
 
   const handleSearch = useCallback((e) => setSearch(e.target.value), []);
 
-  const openNewPicker = useCallback(() => setPickerOpen(true), []);
+  const openNewPicker = useCallback(() => {
+    setPickerMode('tier1');
+    setPickerOpen(true);
+  }, []);
+
+  const switchToAlternativePicker = useCallback(() => {
+    setPickerMode(EVENT_BROWSE_ENABLED && !browseFailed ? 'browse' : 'manual');
+  }, [browseFailed]);
 
   const openEdit = useCallback((row) => {
     // Restores the ESP env this row was created against before opening it — a full
@@ -64,14 +77,21 @@ export default function Library() {
     goToEditor();
   }, [setEnv, startDuplicateConfig, goToEditor]);
 
-  const handlePickEvent = useCallback((event) => {
+  // eventServiceEnv is only ever supplied by Tier1ConfigPicker (the picked event's
+  // config's own authored env) — EventPicker/ManualEventLookup don't supply one, so
+  // this falls back to whatever the global env picker is currently set to, same as
+  // before this picker gained a third mode.
+  const handlePickEvent = useCallback((event, eventServiceEnv) => {
     setPickerOpen(false);
-    startNewConfig(event, envName);
+    const env = eventServiceEnv || envName;
+    setEnv(env);
+    startNewConfig(event, env);
     goToEditor();
-  }, [startNewConfig, envName, goToEditor]);
+  }, [startNewConfig, envName, setEnv, goToEditor]);
 
   const handleBrowseError = useCallback((message) => {
     setBrowseFailed(true);
+    setPickerMode('manual');
     window.lana?.log(`session-guide-configurator: EventPicker failed, falling back to ManualEventLookup. ${message}`);
   }, []);
 
@@ -130,24 +150,31 @@ export default function Library() {
         </ul>
       `}
 
-      ${EVENT_BROWSE_ENABLED && !browseFailed
-        ? html`
-          <${EventPicker} \
-            isOpen=${pickerOpen} \
-            onClose=${() => setPickerOpen(false)} \
-            onSelect=${handlePickEvent} \
-            onError=${handleBrowseError} \
-            title="New config — pick an event" \
-          />
-        `
-        : html`
-          <${ManualEventLookup} \
-            isOpen=${pickerOpen} \
-            onClose=${() => setPickerOpen(false)} \
-            onSelect=${handlePickEvent} \
-            title="New config — enter an Event ID" \
-          />
-        `}
+      ${pickerMode === 'tier1' && html`
+        <${Tier1ConfigPicker} \
+          isOpen=${pickerOpen} \
+          onClose=${() => setPickerOpen(false)} \
+          onSelect=${handlePickEvent} \
+          onSwitchToAlternative=${switchToAlternativePicker} \
+        />
+      `}
+      ${pickerMode === 'browse' && html`
+        <${EventPicker} \
+          isOpen=${pickerOpen} \
+          onClose=${() => setPickerOpen(false)} \
+          onSelect=${handlePickEvent} \
+          onError=${handleBrowseError} \
+          title="New config — pick an event" \
+        />
+      `}
+      ${pickerMode === 'manual' && html`
+        <${ManualEventLookup} \
+          isOpen=${pickerOpen} \
+          onClose=${() => setPickerOpen(false)} \
+          onSelect=${handlePickEvent} \
+          title="New config — enter an Event ID" \
+        />
+      `}
 
       <${Modal} \
         isOpen=${!!rowPendingDelete} \

--- a/event-libs/session-guide-configurator/pages/Library.js
+++ b/event-libs/session-guide-configurator/pages/Library.js
@@ -1,0 +1,168 @@
+import {
+  useState, useMemo, useCallback, html,
+} from '../../v1/deps/htm-preact.js';
+import SearchInput from '../components/SearchInput.js';
+import EventPicker from '../components/EventPicker.js';
+import ManualEventLookup from '../components/ManualEventLookup.js';
+import Modal from '../components/Modal.js';
+import { useNavigation } from '../context/NavigationContext.js';
+import { useConfigs } from '../context/ConfigsContext.js';
+import { useEventEnv } from '../context/EventEnvContext.js';
+import { getDisplayTitle, formatUpdatedTime } from '../utils.js';
+import { EVENT_BROWSE_ENABLED } from '../constants.js';
+
+export default function Library() {
+  const { goToEditor } = useNavigation();
+  const {
+    configs,
+    startNewConfig,
+    startDuplicateConfig,
+    startEditConfig,
+    removeConfig,
+  } = useConfigs();
+  const { envName, setEnv } = useEventEnv();
+
+  const [search, setSearch] = useState('');
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [rowPendingDelete, setRowPendingDelete] = useState(null);
+  // If EventPicker's listAllEvents() fails for any reason, fail over to
+  // ManualEventLookup for the rest of the session (sticky per page load, not
+  // per open, so a transient failure doesn't force a doomed re-attempt).
+  const [browseFailed, setBrowseFailed] = useState(false);
+
+  const filteredConfigs = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const sorted = [...configs].sort(
+      (a, b) => new Date(b.updated || 0) - new Date(a.updated || 0),
+    );
+    if (!term) return sorted;
+    return sorted.filter(
+      (row) => (row.componentName || '').toLowerCase().includes(term)
+        || (row.backendEventTitle || '').toLowerCase().includes(term)
+        || (row.eventId || '').toLowerCase().includes(term),
+    );
+  }, [configs, search]);
+
+  const handleSearch = useCallback((e) => setSearch(e.target.value), []);
+
+  const openNewPicker = useCallback(() => setPickerOpen(true), []);
+
+  const openEdit = useCallback((row) => {
+    // Restores the ESP env this row was created against before opening it — a full
+    // page reload resets EventEnvContext's override to its default (prod), same
+    // reasoning as Tier 1 Event Configurator's own openEdit.
+    setEnv(row.eventServiceEnv || 'prod');
+    startEditConfig(row);
+    goToEditor();
+  }, [setEnv, startEditConfig, goToEditor]);
+
+  // No event re-picking, unlike Tier 1 Event Configurator's cross-event Duplicate —
+  // clones the row onto the same event (see ConfigsContext.js/PLAN.md §4.1).
+  const handleDuplicate = useCallback((row) => {
+    setEnv(row.eventServiceEnv || 'prod');
+    startDuplicateConfig(row);
+    goToEditor();
+  }, [setEnv, startDuplicateConfig, goToEditor]);
+
+  const handlePickEvent = useCallback((event) => {
+    setPickerOpen(false);
+    startNewConfig(event, envName);
+    goToEditor();
+  }, [startNewConfig, envName, goToEditor]);
+
+  const handleBrowseError = useCallback((message) => {
+    setBrowseFailed(true);
+    window.lana?.log(`session-guide-configurator: EventPicker failed, falling back to ManualEventLookup. ${message}`);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!rowPendingDelete) return;
+    await removeConfig(rowPendingDelete.configId);
+    setRowPendingDelete(null);
+  }, [rowPendingDelete, removeConfig]);
+
+  return html`
+    <div class="sgc-page">
+      <div class="sgc-library__header">
+        <div>
+          <h1 class="sgc-page__title">Session Guide Configurator</h1>
+          <p class="sgc-page__subtitle">Per-event Session Guide config, exported as a link to paste into the event page.</p>
+        </div>
+        <button type="button" class="sgc-btn sgc-btn--primary sgc-btn--l" onClick=${openNewPicker}>New config</button>
+      </div>
+
+      <${SearchInput} \
+        id="sgc-library-search" \
+        placeholder="Search by component name, event title, or Event ID" \
+        value=${search} \
+        onInput=${handleSearch} \
+        className="sgc-library__search" \
+      />
+
+      ${filteredConfigs.length === 0 && html`
+        <p class="sgc-library__empty">
+          No configs yet — click "New config" to author one for an event.
+        </p>
+      `}
+
+      ${filteredConfigs.length > 0 && html`
+        <ul class="sgc-library__list">
+          ${filteredConfigs.map((row) => html`
+            <li class="sgc-library__item" key=${row.configId}>
+              <div class="sgc-library__item-info">
+                <span class="sgc-library__item-title-row">
+                  <span class="sgc-library__item-title">${getDisplayTitle(row)}</span>
+                  ${row.eventServiceEnv && row.eventServiceEnv !== 'prod' && html`
+                    <span class="sgc-library__item-env">${row.eventServiceEnv}</span>
+                  `}
+                </span>
+                <span class="sgc-library__item-meta">
+                  ${row.backendEventTitle ? `${row.backendEventTitle} · ` : ''}${row.eventId} · updated ${formatUpdatedTime(row.updated)}
+                </span>
+              </div>
+              <div class="sgc-library__item-actions">
+                <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${() => openEdit(row)}>Edit</button>
+                <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${() => handleDuplicate(row)}>Duplicate</button>
+                <button type="button" class="sgc-btn sgc-btn--quiet sgc-btn--danger" onClick=${() => setRowPendingDelete(row)}>Delete</button>
+              </div>
+            </li>
+          `)}
+        </ul>
+      `}
+
+      ${EVENT_BROWSE_ENABLED && !browseFailed
+        ? html`
+          <${EventPicker} \
+            isOpen=${pickerOpen} \
+            onClose=${() => setPickerOpen(false)} \
+            onSelect=${handlePickEvent} \
+            onError=${handleBrowseError} \
+            title="New config — pick an event" \
+          />
+        `
+        : html`
+          <${ManualEventLookup} \
+            isOpen=${pickerOpen} \
+            onClose=${() => setPickerOpen(false)} \
+            onSelect=${handlePickEvent} \
+            title="New config — enter an Event ID" \
+          />
+        `}
+
+      <${Modal} \
+        isOpen=${!!rowPendingDelete} \
+        onClose=${() => setRowPendingDelete(null)} \
+        onConfirm=${confirmDelete} \
+        title="Delete config?" \
+        confirmText="Delete" \
+        size="small" \
+      >
+        <p>
+          This removes
+          ${' '}<strong>${rowPendingDelete && getDisplayTitle(rowPendingDelete)}</strong> from the library.
+          The sheet has no version history, so this can't be undone.
+        </p>
+      </${Modal}>
+    </div>
+  `;
+}

--- a/event-libs/session-guide-configurator/pages/Library.js
+++ b/event-libs/session-guide-configurator/pages/Library.js
@@ -9,7 +9,10 @@ import Modal from '../components/Modal.js';
 import { useNavigation } from '../context/NavigationContext.js';
 import { useConfigs } from '../context/ConfigsContext.js';
 import { useEventEnv } from '../context/EventEnvContext.js';
-import { getDisplayTitle, formatUpdatedTime } from '../utils.js';
+import { useDA } from '../context/DAContext.js';
+import {
+  getDisplayTitle, formatUpdatedTime, createSessionGuideConfigURL, copySessionGuideConfigLink,
+} from '../utils.js';
 import { EVENT_BROWSE_ENABLED } from '../constants.js';
 
 export default function Library() {
@@ -20,8 +23,11 @@ export default function Library() {
     startDuplicateConfig,
     startEditConfig,
     removeConfig,
+    setToastSuccess,
+    setToastError,
   } = useConfigs();
   const { envName, setEnv } = useEventEnv();
+  const { org, repo } = useDA();
 
   const [search, setSearch] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -76,6 +82,20 @@ export default function Library() {
     startDuplicateConfig(row);
     goToEditor();
   }, [setEnv, startDuplicateConfig, goToEditor]);
+
+  // Same rich-hyperlink copy as ConfigEditor.js's Copy Link — lets an author grab a
+  // saved config's link straight from the library, without opening it in the editor
+  // first (PLAN.md §3a).
+  const handleCopyLink = useCallback(async (row) => {
+    const url = createSessionGuideConfigURL(row.config, org, repo);
+    const formattedDate = formatUpdatedTime(row.updated);
+    const linkText = formattedDate
+      ? `Session Guide: ${getDisplayTitle(row)} – ${formattedDate}`
+      : `Session Guide: ${getDisplayTitle(row)}`;
+    const ok = await copySessionGuideConfigLink(url, linkText);
+    if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
+    else setToastError('Could not copy the link — please retry');
+  }, [org, repo, setToastSuccess, setToastError]);
 
   // eventServiceEnv is only ever supplied by Tier1ConfigPicker (the picked event's
   // config's own authored env) — EventPicker/ManualEventLookup don't supply one, so
@@ -142,6 +162,7 @@ export default function Library() {
               </div>
               <div class="sgc-library__item-actions">
                 <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${() => openEdit(row)}>Edit</button>
+                <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${() => handleCopyLink(row)}>Copy link</button>
                 <button type="button" class="sgc-btn sgc-btn--quiet" onClick=${() => handleDuplicate(row)}>Duplicate</button>
                 <button type="button" class="sgc-btn sgc-btn--quiet sgc-btn--danger" onClick=${() => setRowPendingDelete(row)}>Delete</button>
               </div>

--- a/event-libs/session-guide-configurator/pages/Library.js
+++ b/event-libs/session-guide-configurator/pages/Library.js
@@ -10,9 +10,7 @@ import { useNavigation } from '../context/NavigationContext.js';
 import { useConfigs } from '../context/ConfigsContext.js';
 import { useEventEnv } from '../context/EventEnvContext.js';
 import { useDA } from '../context/DAContext.js';
-import {
-  getDisplayTitle, formatUpdatedTime, createSessionGuideConfigURL, copySessionGuideConfigLink,
-} from '../utils.js';
+import { getDisplayTitle, formatUpdatedTime, copyRowLinkWithToast } from '../utils.js';
 import { EVENT_BROWSE_ENABLED } from '../constants.js';
 
 export default function Library() {
@@ -31,15 +29,10 @@ export default function Library() {
 
   const [search, setSearch] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
-  // 'tier1' (default — pick an event that already has a Tier 1 Event Configurator
-  // config, this app's real source of truth, PLAN.md §2) | 'browse' (ESP catalog) |
-  // 'manual' (Event ID entry) — the latter two are explicit fallbacks for an event
-  // that doesn't have a Tier 1 config yet, reached via Tier1ConfigPicker's own link.
+  // 'tier1' is the default; 'browse' and 'manual' are fallbacks for events without a Tier 1 config yet.
   const [pickerMode, setPickerMode] = useState('tier1');
   const [rowPendingDelete, setRowPendingDelete] = useState(null);
-  // If EventPicker's listAllEvents() fails for any reason, fail over to
-  // ManualEventLookup for the rest of the session (sticky per page load, not
-  // per open, so a transient failure doesn't force a doomed re-attempt).
+  // Sticky for the page load once EventPicker fails, so a transient failure doesn't retry every reopen.
   const [browseFailed, setBrowseFailed] = useState(false);
 
   const filteredConfigs = useMemo(() => {
@@ -67,40 +60,24 @@ export default function Library() {
   }, [browseFailed]);
 
   const openEdit = useCallback((row) => {
-    // Restores the ESP env this row was created against before opening it — a full
-    // page reload resets EventEnvContext's override to its default (prod), same
-    // reasoning as Tier 1 Event Configurator's own openEdit.
+    // A page reload resets the env override to its default, so restore the row's env before opening it.
     setEnv(row.eventServiceEnv || 'prod');
     startEditConfig(row);
     goToEditor();
   }, [setEnv, startEditConfig, goToEditor]);
 
-  // No event re-picking, unlike Tier 1 Event Configurator's cross-event Duplicate —
-  // clones the row onto the same event (see ConfigsContext.js/PLAN.md §4.1).
   const handleDuplicate = useCallback((row) => {
     setEnv(row.eventServiceEnv || 'prod');
     startDuplicateConfig(row);
     goToEditor();
   }, [setEnv, startDuplicateConfig, goToEditor]);
 
-  // Same rich-hyperlink copy as ConfigEditor.js's Copy Link — lets an author grab a
-  // saved config's link straight from the library, without opening it in the editor
-  // first (PLAN.md §3a).
-  const handleCopyLink = useCallback(async (row) => {
-    const url = createSessionGuideConfigURL(row.config, org, repo);
-    const formattedDate = formatUpdatedTime(row.updated);
-    const linkText = formattedDate
-      ? `Session Guide: ${getDisplayTitle(row)} – ${formattedDate}`
-      : `Session Guide: ${getDisplayTitle(row)}`;
-    const ok = await copySessionGuideConfigLink(url, linkText);
-    if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
-    else setToastError('Could not copy the link — please retry');
-  }, [org, repo, setToastSuccess, setToastError]);
+  const handleCopyLink = useCallback(
+    (row) => copyRowLinkWithToast(row, org, repo, setToastSuccess, setToastError),
+    [org, repo, setToastSuccess, setToastError],
+  );
 
-  // eventServiceEnv is only ever supplied by Tier1ConfigPicker (the picked event's
-  // config's own authored env) — EventPicker/ManualEventLookup don't supply one, so
-  // this falls back to whatever the global env picker is currently set to, same as
-  // before this picker gained a third mode.
+  // eventServiceEnv is only supplied by Tier1ConfigPicker; other pickers omit it, so fall back to the global env.
   const handlePickEvent = useCallback((event, eventServiceEnv) => {
     setPickerOpen(false);
     const env = eventServiceEnv || envName;

--- a/event-libs/session-guide-configurator/scripts/da-controller.js
+++ b/event-libs/session-guide-configurator/scripts/da-controller.js
@@ -1,0 +1,56 @@
+import {
+  setDaToken, setDaFetch, readSheet, mutateSheet, parseRowConfig,
+} from '../../v1/utils/da-sheet-controller.js';
+import { CONFIGS_SHEET_PATH } from '../constants.js';
+
+export { setDaToken, setDaFetch };
+
+// Rows are keyed by their own configId, not eventId — an event can have many configs
+// (widget + page variants, testing variants; see PLAN.md §2/§5), so there's no
+// event-based dedup/migration logic to mirror from Tier 1 Event Configurator here.
+function parseRows(rawRows) {
+  return rawRows
+    .filter((row) => row && row.configId)
+    .map((row) => ({ ...row, config: parseRowConfig(row, 'session-guide-configurator') }));
+}
+
+export async function getConfigs(org, repo) {
+  const result = await readSheet(org, repo, CONFIGS_SHEET_PATH);
+  if (!result.ok && result.status === 404) return { ok: true, data: [] };
+  if (!result.ok) return result;
+  return { ok: true, data: parseRows(result.data) };
+}
+
+// Upsert-by-configId: replaces the existing row for this config, or appends a new one.
+export async function upsertConfig(org, repo, {
+  configId, componentName, eventId, backendEventTitle, eventServiceEnv, config,
+}) {
+  const updated = new Date().toISOString();
+  const stampedConfig = { ...config, eventId, updated };
+  const newRow = {
+    configId, componentName, eventId, backendEventTitle, eventServiceEnv, config: stampedConfig, updated,
+  };
+
+  const result = await mutateSheet(org, repo, CONFIGS_SHEET_PATH, (rows) => {
+    const idx = rows.findIndex((r) => r.configId === configId);
+    if (idx === -1) return { rows: [newRow, ...rows], result: newRow };
+    const next = [...rows];
+    next[idx] = newRow;
+    return { rows: next, result: newRow };
+  });
+  if (!result.ok) return result;
+  return { ok: true, data: result.data };
+}
+
+export async function deleteConfig(org, repo, configId) {
+  let found = false;
+  const result = await mutateSheet(org, repo, CONFIGS_SHEET_PATH, (rows) => {
+    const next = rows.filter((r) => r.configId !== configId);
+    if (next.length === rows.length) return { rows, result: null, skip: true };
+    found = true;
+    return { rows: next, result: null };
+  });
+  if (!result.ok) return result;
+  if (!found) return { ok: false, status: 404, error: 'Config not found' };
+  return { ok: true };
+}

--- a/event-libs/session-guide-configurator/scripts/da-controller.js
+++ b/event-libs/session-guide-configurator/scripts/da-controller.js
@@ -5,9 +5,7 @@ import { CONFIGS_SHEET_PATH } from '../constants.js';
 
 export { setDaToken, setDaFetch };
 
-// Rows are keyed by their own configId, not eventId — an event can have many configs
-// (widget + page variants, testing variants; see PLAN.md §2/§5), so there's no
-// event-based dedup/migration logic to mirror from Tier 1 Event Configurator here.
+// Rows are keyed by configId, not eventId — an event can have many configs.
 function parseRows(rawRows) {
   return rawRows
     .filter((row) => row && row.configId)
@@ -21,7 +19,6 @@ export async function getConfigs(org, repo) {
   return { ok: true, data: parseRows(result.data) };
 }
 
-// Upsert-by-configId: replaces the existing row for this config, or appends a new one.
 export async function upsertConfig(org, repo, {
   configId, componentName, eventId, backendEventTitle, eventServiceEnv, config,
 }) {

--- a/event-libs/session-guide-configurator/session-guide-configurator.css
+++ b/event-libs/session-guide-configurator/session-guide-configurator.css
@@ -415,6 +415,17 @@
   color: var(--sgc-color-text-secondary);
 }
 
+.sgc-tier1-picker__alt {
+  margin-top: var(--sgc-spacing-md);
+  padding-top: var(--sgc-spacing-md);
+  border-top: 1px solid var(--sgc-color-border);
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 /* Manual event lookup */
 .sgc-manual-lookup__hint {
   color: var(--sgc-color-text-secondary);

--- a/event-libs/session-guide-configurator/session-guide-configurator.css
+++ b/event-libs/session-guide-configurator/session-guide-configurator.css
@@ -584,6 +584,12 @@
   cursor: grabbing;
 }
 
+.sgc-swimlane-editor__enable {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 .sgc-swimlane-editor__handle {
   display: flex;
   align-items: center;
@@ -618,4 +624,9 @@
   flex: 1;
   min-width: 0;
   font-size: 14px;
+}
+
+.sgc-swimlane-editor__row.is-disabled .sgc-swimlane-editor__title {
+  color: var(--sgc-color-text-secondary);
+  text-decoration: line-through;
 }

--- a/event-libs/session-guide-configurator/session-guide-configurator.css
+++ b/event-libs/session-guide-configurator/session-guide-configurator.css
@@ -620,13 +620,116 @@
   outline-offset: 2px;
 }
 
-.sgc-swimlane-editor__title {
-  flex: 1;
+.sgc-swimlane-editor__original {
+  flex-shrink: 0;
   min-width: 0;
-  font-size: 14px;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
 }
 
-.sgc-swimlane-editor__row.is-disabled .sgc-swimlane-editor__title {
+.sgc-swimlane-editor__name-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.sgc-swimlane-editor__row.is-disabled .sgc-swimlane-editor__original,
+.sgc-swimlane-editor__row.is-disabled .sgc-swimlane-editor__name-input {
+  opacity: 0.5;
+}
+
+/* Filters editor — same structure/behavior as the swimlane order editor above */
+.sgc-filters-editor__empty {
   color: var(--sgc-color-text-secondary);
-  text-decoration: line-through;
+  font-size: 13px;
+}
+
+.sgc-filters-editor__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.sgc-filters-editor__row {
+  display: flex;
+  align-items: center;
+  gap: var(--sgc-spacing-sm);
+  padding: 8px;
+  background: var(--sgc-color-background);
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius-sm);
+}
+
+.sgc-filters-editor__row.is-dragging {
+  position: relative;
+  z-index: 5;
+  background: var(--sgc-color-surface);
+  border-color: var(--sgc-color-border-hover);
+  box-shadow: var(--sgc-shadow-md);
+  cursor: grabbing;
+}
+
+.sgc-filters-editor__handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--sgc-border-radius-sm);
+  background: transparent;
+  color: var(--sgc-color-text-secondary);
+  cursor: grab;
+  touch-action: none;
+}
+
+.sgc-filters-editor__handle:hover {
+  background: var(--sgc-color-surface-hover);
+  color: var(--sgc-color-text-primary);
+}
+
+.sgc-filters-editor__handle:active {
+  cursor: grabbing;
+}
+
+.sgc-filters-editor__handle:focus-visible {
+  outline: 2px solid var(--sgc-color-primary);
+  outline-offset: 2px;
+}
+
+.sgc-filters-editor__enable {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.sgc-filters-editor__original {
+  flex-shrink: 0;
+  min-width: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+}
+
+.sgc-filters-editor__name-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.sgc-filters-editor__row.is-disabled .sgc-filters-editor__original,
+.sgc-filters-editor__row.is-disabled .sgc-filters-editor__name-input {
+  opacity: 0.5;
 }

--- a/event-libs/session-guide-configurator/session-guide-configurator.css
+++ b/event-libs/session-guide-configurator/session-guide-configurator.css
@@ -1,0 +1,519 @@
+/* stylelint-disable selector-class-pattern */
+
+@import url('./components/Modal.css');
+
+:root {
+  /* Brand */
+  --sgc-color-primary: #1473e6;
+  --sgc-color-primary-hover: #0d66d0;
+  --sgc-color-primary-down: #095aba;
+  --sgc-color-on-primary: #fff;
+
+  /* Neutrals */
+  --sgc-color-text-primary: #1d1d1d;
+  --sgc-color-text-secondary: #6e6e6e;
+  --sgc-color-text-placeholder: #959595;
+  --sgc-color-border: #d5d5d5;
+  --sgc-color-border-hover: #b3b3b3;
+  --sgc-color-background: #fafafa;
+  --sgc-color-surface: #fff;
+  --sgc-color-surface-hover: #f5f5f5;
+
+  /* Semantic */
+  --sgc-color-error: #d7373f;
+  --sgc-color-error-bg: #fdecea;
+  --sgc-color-success: #268e6c;
+  --sgc-color-success-bg: #e9f7f1;
+
+  /* Shape */
+  --sgc-border-radius-sm: 4px;
+  --sgc-border-radius: 8px;
+  --sgc-border-radius-lg: 12px;
+
+  /* Spacing */
+  --sgc-spacing-xs: 8px;
+  --sgc-spacing-sm: 12px;
+  --sgc-spacing-md: 16px;
+  --sgc-spacing-lg: 24px;
+  --sgc-spacing-xl: 32px;
+
+  /* Elevation */
+  --sgc-shadow-sm: 0 1px 2px rgb(0 0 0 / 6%);
+  --sgc-shadow-md: 0 4px 12px rgb(0 0 0 / 8%);
+  --sgc-shadow-lg: 0 20px 25px -5px rgb(0 0 0 / 10%), 0 10px 10px -5px rgb(0 0 0 / 4%);
+
+  /* Typography */
+  --sgc-font-family: var(--body-font-family, adobe-clean, adobe-clean-serif, sans-serif);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.sgc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sgc-app {
+  background-color: var(--sgc-color-background);
+  min-height: 100vh;
+  color: var(--sgc-color-text-primary);
+  font-family: var(--sgc-font-family);
+  -webkit-font-smoothing: antialiased;
+}
+
+.sgc-loading,
+.sgc-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
+.sgc-access-error {
+  color: var(--sgc-color-error);
+  padding: var(--sgc-spacing-md);
+}
+
+.sgc-content {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--sgc-spacing-xl) var(--sgc-spacing-lg);
+}
+
+.sgc-env-banner {
+  background: var(--sgc-color-error-bg);
+  color: var(--sgc-color-error);
+  padding: var(--sgc-spacing-sm) var(--sgc-spacing-lg);
+  text-align: center;
+  font-size: 14px;
+}
+
+.sgc-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--sgc-color-border);
+  border-top-color: var(--sgc-color-primary);
+  border-radius: 50%;
+  animation: sgc-spin 0.8s linear infinite;
+}
+
+.sgc-spinner--s {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: var(--sgc-spacing-xs);
+}
+
+@keyframes sgc-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sgc-loading-inline {
+  color: var(--sgc-color-text-secondary);
+  display: flex;
+  align-items: center;
+  padding: var(--sgc-spacing-md) 0;
+}
+
+/* Toast */
+.sgc-toast {
+  position: fixed;
+  bottom: var(--sgc-spacing-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--sgc-spacing-sm);
+  padding: var(--sgc-spacing-sm) var(--sgc-spacing-md);
+  border-radius: var(--sgc-border-radius);
+  box-shadow: var(--sgc-shadow-md);
+  z-index: 1100;
+  font-size: 14px;
+}
+
+.sgc-toast--success {
+  background: var(--sgc-color-success-bg);
+  color: var(--sgc-color-success);
+}
+
+.sgc-toast--error {
+  background: var(--sgc-color-error-bg);
+  color: var(--sgc-color-error);
+}
+
+/* Buttons */
+.sgc-btn {
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--sgc-border-radius-sm);
+  padding: 8px 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.sgc-btn--l {
+  padding: 10px 20px;
+  font-size: 15px;
+}
+
+.sgc-btn--primary {
+  background: var(--sgc-color-primary);
+  color: var(--sgc-color-on-primary);
+}
+
+.sgc-btn--primary:hover {
+  background: var(--sgc-color-primary-hover);
+}
+
+.sgc-btn--primary:active {
+  background: var(--sgc-color-primary-down);
+}
+
+.sgc-btn--primary:disabled {
+  background: var(--sgc-color-border);
+  cursor: not-allowed;
+}
+
+.sgc-btn--outline {
+  background: transparent;
+  border-color: var(--sgc-color-border);
+  color: var(--sgc-color-text-primary);
+}
+
+.sgc-btn--outline:hover {
+  border-color: var(--sgc-color-border-hover);
+  background: var(--sgc-color-surface-hover);
+}
+
+.sgc-btn--quiet {
+  background: transparent;
+  color: var(--sgc-color-text-primary);
+}
+
+.sgc-btn--quiet:hover {
+  background: var(--sgc-color-surface-hover);
+}
+
+.sgc-btn--danger {
+  color: var(--sgc-color-error);
+}
+
+.sgc-btn--icon {
+  background: transparent;
+  padding: 6px;
+  line-height: 1;
+}
+
+.sgc-btn--icon:hover {
+  background: var(--sgc-color-surface-hover);
+}
+
+/* Page shell */
+.sgc-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sgc-spacing-lg);
+}
+
+.sgc-page__title {
+  font-size: 24px;
+  margin: 0 0 4px;
+}
+
+.sgc-page__subtitle {
+  color: var(--sgc-color-text-secondary);
+  margin: 0;
+  font-size: 14px;
+}
+
+/* Library */
+.sgc-library__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sgc-spacing-md);
+}
+
+.sgc-library__search {
+  max-width: 420px;
+}
+
+.sgc-library__empty {
+  color: var(--sgc-color-text-secondary);
+  padding: var(--sgc-spacing-lg) 0;
+}
+
+.sgc-library__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sgc-spacing-sm);
+}
+
+.sgc-library__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sgc-spacing-md);
+  padding: var(--sgc-spacing-md);
+  background: var(--sgc-color-surface);
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius);
+}
+
+.sgc-library__item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sgc-library__item-title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sgc-spacing-xs);
+}
+
+.sgc-library__item-title {
+  font-weight: 600;
+}
+
+.sgc-library__item-env {
+  font-size: 11px;
+  text-transform: uppercase;
+  background: var(--sgc-color-error-bg);
+  color: var(--sgc-color-error);
+  padding: 2px 6px;
+  border-radius: var(--sgc-border-radius-sm);
+}
+
+.sgc-library__item-meta {
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+}
+
+.sgc-library__item-actions {
+  display: flex;
+  gap: var(--sgc-spacing-xs);
+  flex-shrink: 0;
+}
+
+/* Search input */
+.sgc-search-input {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.sgc-search-input__icon {
+  position: absolute;
+  left: 10px;
+  display: flex;
+  pointer-events: none;
+}
+
+.sgc-search-input__field {
+  width: 100%;
+  padding: 8px 12px 8px 38px;
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius-sm);
+  font-size: 14px;
+  font-family: inherit;
+}
+
+/* Fields (shared by the editor + manual lookup) */
+.sgc-field {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px 12px;
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius-sm);
+}
+
+/* Event picker */
+.sgc-event-picker__controls {
+  display: flex;
+  gap: var(--sgc-spacing-sm);
+  margin-bottom: var(--sgc-spacing-md);
+  flex-wrap: wrap;
+}
+
+.sgc-event-picker__publish-filter {
+  display: flex;
+  gap: 4px;
+}
+
+.sgc-event-picker__publish-filter-btn {
+  font-family: inherit;
+  font-size: 13px;
+  padding: 6px 12px;
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius-sm);
+  background: transparent;
+  cursor: pointer;
+}
+
+.sgc-event-picker__publish-filter-btn.is-active {
+  background: var(--sgc-color-primary);
+  color: var(--sgc-color-on-primary);
+  border-color: var(--sgc-color-primary);
+}
+
+.sgc-event-picker__status--error {
+  color: var(--sgc-color-error);
+}
+
+.sgc-event-picker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.sgc-event-picker__item-btn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--sgc-color-border);
+  padding: var(--sgc-spacing-sm);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sgc-event-picker__item-btn:hover {
+  background: var(--sgc-color-surface-hover);
+}
+
+.sgc-event-picker__item-meta {
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+}
+
+.sgc-event-picker__empty {
+  padding: var(--sgc-spacing-md);
+  color: var(--sgc-color-text-secondary);
+}
+
+/* Manual event lookup */
+.sgc-manual-lookup__hint {
+  color: var(--sgc-color-text-secondary);
+  font-size: 13px;
+}
+
+.sgc-manual-lookup__env-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--sgc-spacing-sm);
+}
+
+.sgc-manual-lookup__row {
+  display: flex;
+  gap: var(--sgc-spacing-xs);
+}
+
+.sgc-manual-lookup__input {
+  flex: 1;
+}
+
+.sgc-manual-lookup__error {
+  color: var(--sgc-color-error);
+  font-size: 13px;
+}
+
+.sgc-manual-lookup__result {
+  margin-top: var(--sgc-spacing-md);
+  padding: var(--sgc-spacing-md);
+  background: var(--sgc-color-surface-hover);
+  border-radius: var(--sgc-border-radius-sm);
+}
+
+.sgc-manual-lookup__result-title {
+  font-weight: 600;
+  margin: 0 0 2px;
+}
+
+.sgc-manual-lookup__result-meta {
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+  margin: 0 0 var(--sgc-spacing-sm);
+}
+
+/* Editor */
+.sgc-editor__header {
+  display: flex;
+  align-items: center;
+  gap: var(--sgc-spacing-sm);
+}
+
+.sgc-editor__title {
+  font-size: 22px;
+  margin: 0;
+}
+
+.sgc-editor__event-id {
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+  margin: 0;
+}
+
+.sgc-editor__section {
+  background: var(--sgc-color-surface);
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius);
+  padding: var(--sgc-spacing-md);
+}
+
+.sgc-editor__section h2 {
+  font-size: 16px;
+  margin: 0 0 var(--sgc-spacing-xs);
+}
+
+.sgc-editor__section-hint {
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+  margin: 0 0 var(--sgc-spacing-sm);
+}
+
+.sgc-editor__title-input {
+  width: 100%;
+}
+
+.sgc-editor__radio {
+  display: block;
+  font-size: 14px;
+  margin-bottom: var(--sgc-spacing-xs);
+}
+
+.sgc-editor__error {
+  color: var(--sgc-color-error);
+  font-size: 13px;
+  margin: var(--sgc-spacing-xs) 0 0;
+}
+
+.sgc-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sgc-spacing-sm);
+}

--- a/event-libs/session-guide-configurator/session-guide-configurator.css
+++ b/event-libs/session-guide-configurator/session-guide-configurator.css
@@ -523,8 +523,99 @@
   margin: var(--sgc-spacing-xs) 0 0;
 }
 
+.sgc-editor__field-label {
+  display: block;
+  font-size: 13px;
+  color: var(--sgc-color-text-secondary);
+  margin-bottom: var(--sgc-spacing-sm);
+}
+
+.sgc-editor__heading-input {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.sgc-editor__checkbox {
+  display: block;
+  font-size: 14px;
+  margin-bottom: var(--sgc-spacing-xs);
+}
+
 .sgc-editor__actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--sgc-spacing-sm);
+}
+
+/* Swimlane order editor */
+.sgc-swimlane-editor__empty {
+  color: var(--sgc-color-text-secondary);
+  font-size: 13px;
+}
+
+.sgc-swimlane-editor__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.sgc-swimlane-editor__row {
+  display: flex;
+  align-items: center;
+  gap: var(--sgc-spacing-sm);
+  padding: 8px;
+  background: var(--sgc-color-background);
+  border: 1px solid var(--sgc-color-border);
+  border-radius: var(--sgc-border-radius-sm);
+}
+
+.sgc-swimlane-editor__row.is-dragging {
+  position: relative;
+  z-index: 5;
+  background: var(--sgc-color-surface);
+  border-color: var(--sgc-color-border-hover);
+  box-shadow: var(--sgc-shadow-md);
+  cursor: grabbing;
+}
+
+.sgc-swimlane-editor__handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--sgc-border-radius-sm);
+  background: transparent;
+  color: var(--sgc-color-text-secondary);
+  cursor: grab;
+  touch-action: none;
+}
+
+.sgc-swimlane-editor__handle:hover {
+  background: var(--sgc-color-surface-hover);
+  color: var(--sgc-color-text-primary);
+}
+
+.sgc-swimlane-editor__handle:active {
+  cursor: grabbing;
+}
+
+.sgc-swimlane-editor__handle:focus-visible {
+  outline: 2px solid var(--sgc-color-primary);
+  outline-offset: 2px;
+}
+
+.sgc-swimlane-editor__title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
 }

--- a/event-libs/session-guide-configurator/session-guide-configurator.js
+++ b/event-libs/session-guide-configurator/session-guide-configurator.js
@@ -1,0 +1,27 @@
+import { render, html } from '../v1/deps/htm-preact.js';
+import { DAProvider } from './context/DAContext.js';
+import { NavigationProvider } from './context/NavigationContext.js';
+import { ConfigsProvider } from './context/ConfigsContext.js';
+import { EventEnvProvider } from './context/EventEnvContext.js';
+import SessionGuideConfigurator from './SessionGuideConfigurator.js';
+
+// No Spectrum Web Components — plain HTML/CSS (session-guide-configurator.css),
+// same precedent as tier-1-event-configurator.
+async function init() {
+  render(
+    html`
+      <${DAProvider}>
+        <${EventEnvProvider}>
+          <${NavigationProvider}>
+            <${ConfigsProvider}>
+              <${SessionGuideConfigurator} />
+            </${ConfigsProvider}>
+          </${NavigationProvider}>
+        </${EventEnvProvider}>
+      </${DAProvider}>
+    `,
+    document.getElementById('app'),
+  );
+}
+
+init();

--- a/event-libs/session-guide-configurator/session-guide-configurator.js
+++ b/event-libs/session-guide-configurator/session-guide-configurator.js
@@ -5,8 +5,7 @@ import { ConfigsProvider } from './context/ConfigsContext.js';
 import { EventEnvProvider } from './context/EventEnvContext.js';
 import SessionGuideConfigurator from './SessionGuideConfigurator.js';
 
-// No Spectrum Web Components — plain HTML/CSS (session-guide-configurator.css),
-// same precedent as tier-1-event-configurator.
+// Plain HTML/CSS — no Spectrum Web Components (session-guide-configurator.css).
 async function init() {
   render(
     html`

--- a/event-libs/session-guide-configurator/utils.js
+++ b/event-libs/session-guide-configurator/utils.js
@@ -44,6 +44,30 @@ export function createSessionGuideConfigURL(configBlob, org, repo) {
   return url.toString();
 }
 
+// Copies a rich hyperlink (an <a> element, not just the bare URL string) to the
+// clipboard, so pasting into DA's rich-text editor drops in a real link with display
+// text — same technique as Schedule Maker's ScheduleURLUtility.copyScheduleToClipboard.
+// Falls back to a plain-text URL copy (via copyTextToClipboard above) when the
+// rich-clipboard write API isn't available.
+export async function copySessionGuideConfigLink(url, linkText) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.write) {
+      const linkElement = document.createElement('a');
+      linkElement.href = url;
+      linkElement.textContent = linkText;
+      const blob = new Blob([linkElement.outerHTML], { type: 'text/html' });
+      // eslint-disable-next-line no-undef
+      const data = [new ClipboardItem({ [blob.type]: blob })];
+      await navigator.clipboard.write(data);
+      return true;
+    }
+    return await copyTextToClipboard(url);
+  } catch (error) {
+    window.lana?.log(`Error copying session guide link to clipboard: ${error}`);
+    return false;
+  }
+}
+
 export function formatUpdatedTime(isoString) {
   if (!isoString) return '';
   try {

--- a/event-libs/session-guide-configurator/utils.js
+++ b/event-libs/session-guide-configurator/utils.js
@@ -1,16 +1,13 @@
 import { DA_ORIGIN, DA_APP_PATH } from './constants.js';
 
-// Display title for a row: componentName is the deliberate identifying label here
-// (not a fallback) — an event can have multiple configs (widget/page variants, test
-// copies; see PLAN.md §2/§5), so unlike Tier 1 Event Configurator, the linked event's
-// own title alone isn't unique per row.
+// componentName is the primary label, not just a fallback — an event can have
+// multiple configs, so its title alone isn't unique per row.
 export function getDisplayTitle(row) {
   return row?.componentName || row?.backendEventTitle || row?.eventId || '';
 }
 
-// Copies text to the clipboard, falling back to a hidden textarea +
-// execCommand('copy') when navigator.clipboard isn't available (not
-// guaranteed inside the DA iframe) — same as Tier 1 Event Configurator's own helper.
+// Falls back to a hidden textarea + execCommand('copy') when navigator.clipboard
+// isn't available (not guaranteed inside the DA iframe).
 export async function copyTextToClipboard(text) {
   try {
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -32,10 +29,9 @@ export async function copyTextToClipboard(text) {
   }
 }
 
-// Encodes a config blob into a URL pointing at this app, same base64 technique as
-// Schedule Maker's ScheduleURLUtility.createScheduleURL (PLAN.md §3a). decorate.js's
-// prebuildAutoBlock reverses this via the shared parseEncodedConfig() (v1/utils/
-// utils.js) at decoration time — no manual authoring-table path exists for this block.
+// Encodes a config blob into a URL pointing at this app. decorate.js's
+// prebuildAutoBlock decodes it via the shared parseEncodedConfig() (v1/utils/utils.js)
+// at decoration time — there is no manual authoring-table path for this block.
 export function createSessionGuideConfigURL(configBlob, org, repo) {
   const jsonString = JSON.stringify(configBlob);
   const base64JsonString = btoa(unescape(encodeURIComponent(jsonString)));
@@ -44,11 +40,9 @@ export function createSessionGuideConfigURL(configBlob, org, repo) {
   return url.toString();
 }
 
-// Copies a rich hyperlink (an <a> element, not just the bare URL string) to the
-// clipboard, so pasting into DA's rich-text editor drops in a real link with display
-// text — same technique as Schedule Maker's ScheduleURLUtility.copyScheduleToClipboard.
-// Falls back to a plain-text URL copy (via copyTextToClipboard above) when the
-// rich-clipboard write API isn't available.
+// Copies a rich hyperlink (an <a> element, not just the bare URL string) so pasting
+// into DA's rich-text editor drops in a real link with display text. Falls back to a
+// plain-text URL copy when the rich-clipboard write API isn't available.
 export async function copySessionGuideConfigLink(url, linkText) {
   try {
     if (navigator.clipboard && navigator.clipboard.write) {
@@ -81,4 +75,17 @@ export function formatUpdatedTime(isoString) {
   } catch {
     return '';
   }
+}
+
+// Shared by ConfigEditor.js (the open config, saved or not) and Library.js (any saved
+// row) — builds the link, copies it, and reports the result via the given toast setters.
+export async function copyRowLinkWithToast(row, org, repo, setToastSuccess, setToastError) {
+  const url = createSessionGuideConfigURL(row.config, org, repo);
+  const formattedDate = formatUpdatedTime(row.updated);
+  const linkText = formattedDate
+    ? `Session Guide: ${getDisplayTitle(row)} – ${formattedDate}`
+    : `Session Guide: ${getDisplayTitle(row)}`;
+  const ok = await copySessionGuideConfigLink(url, linkText);
+  if (ok) setToastSuccess('Link copied — paste it into the event page where the Session Guide should appear');
+  else setToastError('Could not copy the link — please retry');
 }

--- a/event-libs/session-guide-configurator/utils.js
+++ b/event-libs/session-guide-configurator/utils.js
@@ -1,9 +1,47 @@
+import { DA_ORIGIN, DA_APP_PATH } from './constants.js';
+
 // Display title for a row: componentName is the deliberate identifying label here
 // (not a fallback) — an event can have multiple configs (widget/page variants, test
 // copies; see PLAN.md §2/§5), so unlike Tier 1 Event Configurator, the linked event's
 // own title alone isn't unique per row.
 export function getDisplayTitle(row) {
   return row?.componentName || row?.backendEventTitle || row?.eventId || '';
+}
+
+// Copies text to the clipboard, falling back to a hidden textarea +
+// execCommand('copy') when navigator.clipboard isn't available (not
+// guaranteed inside the DA iframe) — same as Tier 1 Event Configurator's own helper.
+export async function copyTextToClipboard(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    document.body.appendChild(textArea);
+    textArea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textArea);
+    return successful;
+  } catch (error) {
+    window.lana?.log(`Error copying to clipboard: ${error}`);
+    return false;
+  }
+}
+
+// Encodes a config blob into a URL pointing at this app, same base64 technique as
+// Schedule Maker's ScheduleURLUtility.createScheduleURL (PLAN.md §3a). decorate.js's
+// prebuildAutoBlock reverses this via the shared parseEncodedConfig() (v1/utils/
+// utils.js) at decoration time — no manual authoring-table path exists for this block.
+export function createSessionGuideConfigURL(configBlob, org, repo) {
+  const jsonString = JSON.stringify(configBlob);
+  const base64JsonString = btoa(unescape(encodeURIComponent(jsonString)));
+  const url = new URL(`${DA_ORIGIN}/app/${org}/${repo}/${DA_APP_PATH}`);
+  url.searchParams.set('sgConfig', base64JsonString);
+  return url.toString();
 }
 
 export function formatUpdatedTime(isoString) {

--- a/event-libs/session-guide-configurator/utils.js
+++ b/event-libs/session-guide-configurator/utils.js
@@ -1,0 +1,22 @@
+// Display title for a row: componentName is the deliberate identifying label here
+// (not a fallback) — an event can have multiple configs (widget/page variants, test
+// copies; see PLAN.md §2/§5), so unlike Tier 1 Event Configurator, the linked event's
+// own title alone isn't unique per row.
+export function getDisplayTitle(row) {
+  return row?.componentName || row?.backendEventTitle || row?.eventId || '';
+}
+
+export function formatUpdatedTime(isoString) {
+  if (!isoString) return '';
+  try {
+    return new Date(isoString).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}

--- a/event-libs/tier-1-event-configurator/scripts/da-controller.js
+++ b/event-libs/tier-1-event-configurator/scripts/da-controller.js
@@ -1,65 +1,9 @@
-import { DA_ADMIN_ORIGIN, CONFIGS_SHEET_PATH } from '../constants.js';
+import {
+  setDaToken, setDaFetch, readSheet, mutateSheet, parseRowConfig,
+} from '../../v1/utils/da-sheet-controller.js';
+import { CONFIGS_SHEET_PATH } from '../constants.js';
 
-let daToken = null;
-let sdkDaFetch = null;
-
-export function setDaToken(token) {
-  daToken = token;
-}
-
-export function setDaFetch(fn) {
-  sdkDaFetch = fn;
-}
-
-// Prefer the DA SDK's authenticated fetch when it has been provided; otherwise
-// fall back to the global fetch (auth is then supplied via the Bearer token).
-function doFetch(url, options) {
-  return (sdkDaFetch || fetch)(url, options);
-}
-
-// admin.da.live sits behind a CDN that weakens ETags (W/"...") when it gzips a
-// response. R2/S3 reject weak validators on a conditional write, so strip the
-// W/ prefix to recover the strong ETag that If-Match compares against.
-function normalizeEtag(etag) {
-  if (!etag) return undefined;
-  return etag.replace(/^W\//, '');
-}
-
-function getHeaders(method = 'GET', body = null) {
-  const headers = new Headers();
-  if (daToken) headers.append('Authorization', `Bearer ${daToken}`);
-  if (body) headers.append('content-type', 'application/json');
-  // no-store bypasses the browser cache — otherwise a cached GET can return a
-  // stale ETag, so the very next conditional write's If-Match fails against
-  // the CDN's actual current ETag and surfaces as a false-positive Conflict
-  // (same issue Schedule Maker's da-controller.js hit and fixed the same way).
-  return {
-    method, headers, body: body ? JSON.stringify(body) : undefined, cache: 'no-store',
-  };
-}
-
-async function daFetch(path, options = {}) {
-  const url = `${DA_ADMIN_ORIGIN}${path}`;
-  let resp;
-  try {
-    resp = await doFetch(url, options);
-  } catch (err) {
-    window.lana?.log(`DA fetch network error: ${err} — ${url}`);
-    return { ok: false, status: 0, error: 'Network error' };
-  }
-  if (!resp.ok) {
-    const error = await resp.text().catch(() => resp.statusText);
-    window.lana?.log(`DA fetch error ${resp.status}: ${url} — ${error}`);
-    return { ok: false, status: resp.status, error };
-  }
-  const etag = resp.headers.get('ETag');
-  const contentType = resp.headers.get('content-type') || '';
-  if (contentType.includes('application/json')) {
-    const data = await resp.json();
-    return { ok: true, status: resp.status, data, etag };
-  }
-  return { ok: true, status: resp.status, etag };
-}
+export { setDaToken, setDaFetch };
 
 // One-time migration-on-read: old rows had a single `eventTitle` meaning the
 // backend title. Now that's `backendEventTitle`, and `eventTitle` means an
@@ -81,109 +25,20 @@ function migrateLegacyTitle(row) {
   };
 }
 
-// A malformed config string (bad manual edit, truncated write) shouldn't take
-// down the whole library load — log and default that one row to {} instead.
-function parseRowConfig(row) {
-  if (typeof row.config !== 'string') return row.config ?? {};
-  try {
-    return JSON.parse(row.config);
-  } catch (error) {
-    window.lana?.log(`tier-1-event-configurator: malformed config JSON for row ${row.eventId}, defaulting to {}. ${error}`);
-    return {};
-  }
-}
-
-// Reads a sheet and returns its rows plus the ETag, so callers can perform
-// conditional (optimistic-locking) writes with writeSheet. `config` is stored
-// on the sheet as a stringified JSON blob and parsed back into an object here.
-async function readSheet(org, repo, path) {
-  const result = await daFetch(`/source/${org}/${repo}${path}`, getHeaders('GET'));
-  if (!result.ok) return result;
-  // Admin API always returns { ":type":"sheet", "data":[...objects] } for .json sheet files
-  const raw = result.data?.data ?? [];
-
-  const rows = raw
+function parseAndMigrateRows(rawRows) {
+  return rawRows
     .filter((row) => row && row.eventId)
-    .map((row) => migrateLegacyTitle({ ...row, config: parseRowConfig(row) }));
-  return { ok: true, data: rows, etag: result.etag };
-}
-
-// Writes the full sheet. { etag } → If-Match (write only if unchanged);
-// { create: true } → If-None-Match: * (only if the sheet doesn't exist yet);
-// neither → unconditional. A precondition failure returns status:412 so
-// callers can re-read and retry instead of clobbering a concurrent write.
-async function writeSheet(org, repo, path, rows, { etag, create } = {}) {
-  const serialized = rows.map((row) => ({
-    ...row,
-    config: typeof row.config === 'string' ? row.config : JSON.stringify(row.config ?? {}),
-  }));
-
-  // DA admin API accepts the same object format it returns on GET
-  const payload = JSON.stringify({
-    ':type': 'sheet',
-    ':sheetname': 'data',
-    total: serialized.length,
-    limit: serialized.length,
-    offset: 0,
-    data: serialized,
-  });
-
-  const url = `${DA_ADMIN_ORIGIN}/source/${org}/${repo}${path}`;
-  const formData = new FormData();
-  formData.append('data', new Blob([payload], { type: 'application/json' }), 'blob');
-
-  const headers = new Headers();
-  if (daToken) headers.append('Authorization', `Bearer ${daToken}`);
-  if (etag) headers.append('If-Match', etag);
-  else if (create) headers.append('If-None-Match', '*');
-
-  let resp;
-  try {
-    resp = await doFetch(url, { method: 'POST', headers, body: formData });
-  } catch (err) {
-    window.lana?.log(`DA writeSheet network error: ${err} — ${url}`);
-    return { ok: false, status: 0, error: 'Network error' };
-  }
-  if (resp.status === 412) {
-    return { ok: false, status: 412, conflict: true, error: 'Sheet changed concurrently' };
-  }
-  if (!resp.ok) {
-    const error = await resp.text().catch(() => resp.statusText);
-    return { ok: false, status: resp.status, error };
-  }
-  return { ok: true, status: resp.status, etag: resp.headers.get('ETag') };
-}
-
-const MAX_WRITE_RETRIES = 4;
-const CONFLICT_ERROR = 'Conflict: the config library sheet was changed by someone else. Please retry.';
-
-// Optimistic-locking read-modify-write: reads the sheet + ETag, applies
-// mutate(rows), writes conditionally, and retries on a 412 conflict.
-// mutate(rows) returns { rows, result, skip? } — skip avoids a needless write.
-async function mutateSheet(org, repo, path, mutate) {
-  for (let attempt = 0; attempt <= MAX_WRITE_RETRIES; attempt += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    const read = await readSheet(org, repo, path);
-    if (!read.ok && read.status !== 404) return read;
-    const rows = read.ok ? (read.data || []) : [];
-    // Existing sheet → If-Match its etag (or unconditional if etag unavailable).
-    // Missing sheet (404) → If-None-Match:* to guard concurrent first creation.
-    const opts = read.ok ? { etag: normalizeEtag(read.etag) } : { create: true };
-    const { rows: newRows, result, skip } = mutate(rows);
-    if (skip) return { ok: true, data: result, skipped: true };
-    // eslint-disable-next-line no-await-in-loop
-    const write = await writeSheet(org, repo, path, newRows, opts);
-    if (write.ok) return { ok: true, data: result };
-    if (write.status !== 412) return write;
-  }
-  return { ok: false, status: 412, error: CONFLICT_ERROR };
+    .map((row) => migrateLegacyTitle({
+      ...row,
+      config: parseRowConfig(row, 'tier-1-event-configurator'),
+    }));
 }
 
 export async function getConfigs(org, repo) {
   const result = await readSheet(org, repo, CONFIGS_SHEET_PATH);
   if (!result.ok && result.status === 404) return { ok: true, data: [] };
   if (!result.ok) return result;
-  return { ok: true, data: result.data };
+  return { ok: true, data: parseAndMigrateRows(result.data) };
 }
 
 // Upsert-by-Event-ID: replaces the existing row for this event, or appends a
@@ -207,6 +62,8 @@ export async function upsertConfig(org, repo, {
   };
 
   const result = await mutateSheet(org, repo, CONFIGS_SHEET_PATH, (rows) => {
+    // eventId is a top-level column, not inside the stringified `config` blob, so
+    // matching against raw (unparsed) rows is safe here.
     const idx = rows.findIndex((r) => r.eventId === eventId);
     if (idx === -1) return { rows: [newRow, ...rows], result: newRow };
     const next = [...rows];

--- a/event-libs/tier-1-event-configurator/utils.js
+++ b/event-libs/tier-1-event-configurator/utils.js
@@ -1,4 +1,4 @@
-import { TRACK_ATTRIBUTE_NAME } from '../v1/services/sessions/sessions-api.js';
+export { getSessionTrack, extractDistinctTracks } from '../v1/services/sessions/sessions-api.js';
 
 // Copies text to the clipboard, falling back to a hidden textarea +
 // execCommand('copy') when navigator.clipboard isn't available (not
@@ -22,20 +22,6 @@ export async function copyTextToClipboard(text) {
     window.lana?.log(`Error copying to clipboard: ${error}`);
     return false;
   }
-}
-
-export function getSessionTrack(session) {
-  const attr = (session?.customAttributes || []).find((a) => a?.name === TRACK_ATTRIBUTE_NAME);
-  return attr?.values?.[0]?.label ?? attr?.values?.[0]?.value ?? null;
-}
-
-export function extractDistinctTracks(sessions) {
-  const tracks = new Set();
-  (sessions || []).forEach((session) => {
-    const value = getSessionTrack(session);
-    if (value) tracks.add(value);
-  });
-  return [...tracks].sort();
 }
 
 // Formats in the sessionTime's own venue timezone, not the viewer's local

--- a/event-libs/v1/blocks/sessions-guide/store/index.js
+++ b/event-libs/v1/blocks/sessions-guide/store/index.js
@@ -30,7 +30,8 @@ function getDefaultDay(eventDays, userTz) {
 // Named guideConfig (not eventConfig) to stay distinct from utils.js's page-wide
 // getEventConfig() and the Tier 1 Event Configurator's tier-1-event-config.js —
 // this is sessions-guide's own block-level authoring config (parse-config.js's
-// output: title, filterCategories, theme, surface, userTz, registerUrl).
+// output: eventId, surface, theme, userTz, filterCategories, headings, behaviorFlags,
+// swimlaneOrder, authoredFilterCategories, plus registerUrl merged in by init()).
 export function buildInitialState(guideConfig) {
   return {
     drawerState: 'hidden',

--- a/event-libs/v1/blocks/sessions-guide/store/index.js
+++ b/event-libs/v1/blocks/sessions-guide/store/index.js
@@ -29,9 +29,7 @@ function getDefaultDay(eventDays, userTz) {
 // favorited, scheduled, auth) lives in event-libs/v1/utils/session-store.js instead.
 // Named guideConfig (not eventConfig) to stay distinct from utils.js's page-wide
 // getEventConfig() and the Tier 1 Event Configurator's tier-1-event-config.js —
-// this is sessions-guide's own block-level authoring config (parse-config.js's
-// output: eventId, surface, theme, userTz, filterCategories, headings, behaviorFlags,
-// swimlaneOrder, authoredFilterCategories, plus registerUrl merged in by init()).
+// this is sessions-guide's own block-level authoring config (see parse-config.js).
 export function buildInitialState(guideConfig) {
   return {
     drawerState: 'hidden',

--- a/event-libs/v1/blocks/sessions-guide/utils/parse-config.js
+++ b/event-libs/v1/blocks/sessions-guide/utils/parse-config.js
@@ -1,25 +1,16 @@
 import { detectUserTimezone } from './time.js';
 
-// Legacy fallback for FilterPanel.js, which still filters directly against session
-// fields by id (s[id]) — untouched until it's rewired to consume the ESP-derived
-// authoredFilterCategories shape below (deferred, separate work).
+// Legacy fallback for FilterPanel.js, which indexes sessions by category id, not by
+// ESP attributeId; the authored categories are exposed separately as authoredFilterCategories.
 const DEFAULT_FILTER_CATEGORIES = [
   { id: 'track', label: 'Channel' },
   { id: 'type', label: 'Session Type' },
 ];
 
-// Reads the block's config from the data-session-guide-config attribute that
-// decorate.js's prebuildAutoBlock sets at decoration time (Session Guide
-// Configurator's Copy Link output, decoded there via parseEncodedConfig). There's no
-// authoring-table path anymore — the URL-encoded config is the only source of truth.
-//
-// Only surface/theme/userTz/registerUrl are consumed by the component tree today.
-// headings/behaviorFlags/swimlaneOrder/authoredFilterCategories are carried through
-// as new fields so they're available once DrawerHeader.js/FilterPanel.js/
-// OnDemandView.js are rewired to read them — that rewiring is separate work.
-// filterCategories itself is deliberately left as the legacy track/type default
-// above (not the new authored shape) to avoid silently breaking FilterPanel.js,
-// which indexes sessions by category id, not by ESP attributeId.
+// Config comes solely from the data-session-guide-config attribute decorate.js sets
+// (decoded via parseEncodedConfig); there is no authoring-table path.
+// headings/behaviorFlags/swimlaneOrder/authoredFilterCategories aren't consumed by the
+// component tree yet — keep returning them for callers not yet wired up to read them.
 export function parseSessionsGuideConfig(el, { logPrefix, forcedSurface } = {}) {
   let authored = {};
   try {

--- a/event-libs/v1/blocks/sessions-guide/utils/parse-config.js
+++ b/event-libs/v1/blocks/sessions-guide/utils/parse-config.js
@@ -1,42 +1,48 @@
 import { detectUserTimezone } from './time.js';
 
-// Shared by sessions-guide.js and sessions-guide-full-page.js so authoring-table keys
-// only need to be handled in one place — previously duplicated per-file, which let the
-// two copies silently drift out of sync.
+// Legacy fallback for FilterPanel.js, which still filters directly against session
+// fields by id (s[id]) — untouched until it's rewired to consume the ESP-derived
+// authoredFilterCategories shape below (deferred, separate work).
 const DEFAULT_FILTER_CATEGORIES = [
   { id: 'track', label: 'Channel' },
   { id: 'type', label: 'Session Type' },
 ];
 
+// Reads the block's config from the data-session-guide-config attribute that
+// decorate.js's prebuildAutoBlock sets at decoration time (Session Guide
+// Configurator's Copy Link output, decoded there via parseEncodedConfig). There's no
+// authoring-table path anymore — the URL-encoded config is the only source of truth.
+//
+// Only surface/theme/userTz/registerUrl are consumed by the component tree today.
+// headings/behaviorFlags/swimlaneOrder/authoredFilterCategories are carried through
+// as new fields so they're available once DrawerHeader.js/FilterPanel.js/
+// OnDemandView.js are rewired to read them — that rewiring is separate work.
+// filterCategories itself is deliberately left as the legacy track/type default
+// above (not the new authored shape) to avoid silently breaking FilterPanel.js,
+// which indexes sessions by category id, not by ESP attributeId.
 export function parseSessionsGuideConfig(el, { logPrefix, forcedSurface } = {}) {
-  const config = {
-    title: '',
-    filterCategories: DEFAULT_FILTER_CATEGORIES,
-    theme: null,
-  };
-  [...el.querySelectorAll(':scope > div')].forEach((row) => {
-    const cells = row.querySelectorAll(':scope > div');
-    const key = cells[0]?.textContent?.trim().toLowerCase();
-    const val = cells[1]?.textContent?.trim();
-    if (!key || val === undefined) return;
-    switch (key) {
-      case 'event-title': config.title = val; break;
-      case 'theme': if (val) config.theme = val; break;
-      case 'filter-categories':
-        try { config.filterCategories = JSON.parse(val); } catch {
-          window.lana?.log(`[${logPrefix}] invalid filter-categories JSON`);
-        }
-        break;
-      default: break;
-    }
-  });
-  config.surface = forcedSurface || (el.classList.contains('page') ? 'page' : 'widget');
-  config.userTz = detectUserTimezone();
+  let authored = {};
+  try {
+    authored = JSON.parse(el.dataset.sessionGuideConfig || '{}');
+  } catch {
+    window.lana?.log(`[${logPrefix}] invalid data-session-guide-config JSON`);
+  }
+
+  const surface = forcedSurface || authored.surface || 'widget';
   // Default theme by surface when not explicitly authored:
   // widget → dark (overlaid drawer sits on any host page background)
   // page   → light (full-page layout; dark tokens cascade into all rendered content)
-  if (!config.theme) {
-    config.theme = config.surface === 'page' ? 'light' : 'dark';
-  }
-  return config;
+  const theme = authored.theme || (surface === 'page' ? 'light' : 'dark');
+
+  return {
+    eventId: authored.eventId,
+    surface,
+    theme,
+    userTz: detectUserTimezone(),
+    filterCategories: DEFAULT_FILTER_CATEGORIES,
+    headings: authored.headings,
+    behaviorFlags: authored.behaviorFlags,
+    swimlaneOrder: authored.swimlaneOrder,
+    authoredFilterCategories: authored.filterCategories,
+  };
 }

--- a/event-libs/v1/services/sessions/sessions-api.js
+++ b/event-libs/v1/services/sessions/sessions-api.js
@@ -366,6 +366,59 @@ export function normalizeSessions(rawSessions) {
 // attribute for its own track editor) doesn't carry a second, independently-drifting copy.
 export const TRACK_ATTRIBUTE_NAME = 'Primary Track for Agenda (Digital Agenda)';
 
+// Generic session/track helpers, not Tier-1-specific — moved here (2026-07-30) so both
+// tier-1-event-configurator and session-guide-configurator import the same
+// implementation instead of one DA app importing from the other's UI code.
+export function getSessionTrack(session) {
+  const attr = (session?.customAttributes || []).find((a) => a?.name === TRACK_ATTRIBUTE_NAME);
+  return attr?.values?.[0]?.label ?? attr?.values?.[0]?.value ?? null;
+}
+
+export function extractDistinctTracks(sessions) {
+  const tracks = new Set();
+  (sessions || []).forEach((session) => {
+    const value = getSessionTrack(session);
+    if (value) tracks.add(value);
+  });
+  return [...tracks].sort();
+}
+
+// Derives facetable custom attributes + their distinct values from an already-fetched
+// session catalog. Mirrors the same enabled/inputType/valueId gate ESP's own
+// /session-facets applies server-side (see events-service-platform's
+// resolveCustomAttributes/buildAttributeIndexItems), so results match it field-for-
+// field, without the extra network round-trip — both consumers (session-guide-
+// configurator's own Filters step, and sessions-guide's FilterPanel.js) already have
+// the full session catalog in memory for other reasons. See
+// session-guide-configurator/PLAN.md §7 for the full design writeup.
+export function deriveFacetableAttributes(sessions) {
+  const attributeMap = new Map(); // attributeId -> { attributeId, label, values: Map<valueId, {...}> }
+  (sessions || []).forEach((session) => {
+    (session.customAttributes || []).forEach((attr) => {
+      if (attr.enabled === false) return;
+      if (!['single-select', 'multi-select'].includes(attr.inputType)) return;
+      if (!attributeMap.has(attr.attributeId)) {
+        attributeMap.set(attr.attributeId, { attributeId: attr.attributeId, label: attr.label, values: new Map() });
+      }
+      const group = attributeMap.get(attr.attributeId);
+      (attr.values || []).forEach((v) => {
+        if (!v.valueId) return; // free-text values aren't indexable
+        if (!group.values.has(v.valueId)) {
+          group.values.set(v.valueId, {
+            valueId: v.valueId, label: v.label, ordinal: v.ordinal, count: 0,
+          });
+        }
+        group.values.get(v.valueId).count += 1;
+      });
+    });
+  });
+  return [...attributeMap.values()].map((group) => ({
+    attributeId: group.attributeId,
+    label: group.label,
+    values: [...group.values.values()].sort((a, b) => a.ordinal - b.ordinal),
+  }));
+}
+
 // customAttributes carry things like track/audience/technical-level as name+values pairs
 // rather than plain session fields. `values[]` holds the value(s) actually selected for
 // that session (see events-service-platform's resolveCustomAttributes), not the full

--- a/event-libs/v1/services/sessions/sessions-api.js
+++ b/event-libs/v1/services/sessions/sessions-api.js
@@ -366,9 +366,9 @@ export function normalizeSessions(rawSessions) {
 // attribute for its own track editor) doesn't carry a second, independently-drifting copy.
 export const TRACK_ATTRIBUTE_NAME = 'Primary Track for Agenda (Digital Agenda)';
 
-// Generic session/track helpers, not Tier-1-specific — moved here (2026-07-30) so both
-// tier-1-event-configurator and session-guide-configurator import the same
-// implementation instead of one DA app importing from the other's UI code.
+// Generic session/track helpers, not Tier-1-specific — shared here so
+// tier-1-event-configurator and session-guide-configurator use the same implementation
+// instead of one importing from the other's UI code.
 export function getSessionTrack(session) {
   const attr = (session?.customAttributes || []).find((a) => a?.name === TRACK_ATTRIBUTE_NAME);
   return attr?.values?.[0]?.label ?? attr?.values?.[0]?.value ?? null;
@@ -384,13 +384,9 @@ export function extractDistinctTracks(sessions) {
 }
 
 // Derives facetable custom attributes + their distinct values from an already-fetched
-// session catalog. Mirrors the same enabled/inputType/valueId gate ESP's own
-// /session-facets applies server-side (see events-service-platform's
-// resolveCustomAttributes/buildAttributeIndexItems), so results match it field-for-
-// field, without the extra network round-trip — both consumers (session-guide-
-// configurator's own Filters step, and sessions-guide's FilterPanel.js) already have
-// the full session catalog in memory for other reasons. See
-// session-guide-configurator/PLAN.md §7 for the full design writeup.
+// session catalog, mirroring the enabled/inputType/valueId filtering ESP's own
+// /session-facets endpoint applies server-side, so results match it without an extra
+// network round-trip.
 export function deriveFacetableAttributes(sessions) {
   const attributeMap = new Map(); // attributeId -> { attributeId, label, values: Map<valueId, {...}> }
   (sessions || []).forEach((session) => {

--- a/event-libs/v1/utils/da-sheet-controller.js
+++ b/event-libs/v1/utils/da-sheet-controller.js
@@ -1,8 +1,7 @@
 // Generic DA admin-API sheet CRUD, shared by every DA app that stores a config library
-// as a single sheet (tier-1-event-configurator, session-guide-configurator, ...) —
-// extracted 2026-07-30 rather than left as a third independently-drifting copy.
-// App-specific concerns (row key, upsert/delete semantics, schema migration) stay in
-// each app's own scripts/da-controller.js, built on top of these primitives.
+// as a single sheet (tier-1-event-configurator, session-guide-configurator). App-specific
+// concerns (row key, upsert/delete semantics, schema migration) stay in each app's own
+// scripts/da-controller.js, built on top of these primitives.
 
 const DA_ADMIN_ORIGIN = 'https://admin.da.live';
 

--- a/event-libs/v1/utils/da-sheet-controller.js
+++ b/event-libs/v1/utils/da-sheet-controller.js
@@ -1,0 +1,161 @@
+// Generic DA admin-API sheet CRUD, shared by every DA app that stores a config library
+// as a single sheet (tier-1-event-configurator, session-guide-configurator, ...) —
+// extracted 2026-07-30 rather than left as a third independently-drifting copy.
+// App-specific concerns (row key, upsert/delete semantics, schema migration) stay in
+// each app's own scripts/da-controller.js, built on top of these primitives.
+
+const DA_ADMIN_ORIGIN = 'https://admin.da.live';
+
+let daToken = null;
+let sdkDaFetch = null;
+
+export function setDaToken(token) {
+  daToken = token;
+}
+
+export function setDaFetch(fn) {
+  sdkDaFetch = fn;
+}
+
+// Prefer the DA SDK's authenticated fetch when it has been provided; otherwise
+// fall back to the global fetch (auth is then supplied via the Bearer token).
+function doFetch(url, options) {
+  return (sdkDaFetch || fetch)(url, options);
+}
+
+// admin.da.live sits behind a CDN that weakens ETags (W/"...") when it gzips a
+// response. R2/S3 reject weak validators on a conditional write, so strip the
+// W/ prefix to recover the strong ETag that If-Match compares against.
+function normalizeEtag(etag) {
+  if (!etag) return undefined;
+  return etag.replace(/^W\//, '');
+}
+
+function getHeaders(method = 'GET', body = null) {
+  const headers = new Headers();
+  if (daToken) headers.append('Authorization', `Bearer ${daToken}`);
+  if (body) headers.append('content-type', 'application/json');
+  // no-store bypasses the browser cache — otherwise a cached GET can return a
+  // stale ETag, so the very next conditional write's If-Match fails against
+  // the CDN's actual current ETag and surfaces as a false-positive Conflict.
+  return {
+    method, headers, body: body ? JSON.stringify(body) : undefined, cache: 'no-store',
+  };
+}
+
+async function daFetch(path, options = {}) {
+  const url = `${DA_ADMIN_ORIGIN}${path}`;
+  let resp;
+  try {
+    resp = await doFetch(url, options);
+  } catch (err) {
+    window.lana?.log(`DA fetch network error: ${err} — ${url}`);
+    return { ok: false, status: 0, error: 'Network error' };
+  }
+  if (!resp.ok) {
+    const error = await resp.text().catch(() => resp.statusText);
+    window.lana?.log(`DA fetch error ${resp.status}: ${url} — ${error}`);
+    return { ok: false, status: resp.status, error };
+  }
+  const etag = resp.headers.get('ETag');
+  const contentType = resp.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    const data = await resp.json();
+    return { ok: true, status: resp.status, data, etag };
+  }
+  return { ok: true, status: resp.status, etag };
+}
+
+// A malformed config string (bad manual edit, truncated write) shouldn't take
+// down the whole library load — log and default that one row to {} instead.
+export function parseRowConfig(row, logPrefix) {
+  if (typeof row.config !== 'string') return row.config ?? {};
+  try {
+    return JSON.parse(row.config);
+  } catch (error) {
+    window.lana?.log(`${logPrefix}: malformed config JSON for row, defaulting to {}. ${error}`);
+    return {};
+  }
+}
+
+// Reads a sheet and returns its rows plus the ETag, so callers can perform
+// conditional (optimistic-locking) writes with writeSheet. Rows are returned raw
+// (caller decides how to parse/validate `config` and which key identifies a row).
+export async function readSheet(org, repo, path) {
+  const result = await daFetch(`/source/${org}/${repo}${path}`, getHeaders('GET'));
+  if (!result.ok) return result;
+  // Admin API always returns { ":type":"sheet", "data":[...objects] } for .json sheet files
+  const rows = result.data?.data ?? [];
+  return { ok: true, data: rows, etag: result.etag };
+}
+
+// Writes the full sheet. { etag } → If-Match (write only if unchanged);
+// { create: true } → If-None-Match: * (only if the sheet doesn't exist yet);
+// neither → unconditional. A precondition failure returns status:412 so
+// callers can re-read and retry instead of clobbering a concurrent write.
+export async function writeSheet(org, repo, path, rows, { etag, create } = {}) {
+  const serialized = rows.map((row) => ({
+    ...row,
+    config: typeof row.config === 'string' ? row.config : JSON.stringify(row.config ?? {}),
+  }));
+
+  // DA admin API accepts the same object format it returns on GET
+  const payload = JSON.stringify({
+    ':type': 'sheet',
+    ':sheetname': 'data',
+    total: serialized.length,
+    limit: serialized.length,
+    offset: 0,
+    data: serialized,
+  });
+
+  const url = `${DA_ADMIN_ORIGIN}/source/${org}/${repo}${path}`;
+  const formData = new FormData();
+  formData.append('data', new Blob([payload], { type: 'application/json' }), 'blob');
+
+  const headers = new Headers();
+  if (daToken) headers.append('Authorization', `Bearer ${daToken}`);
+  if (etag) headers.append('If-Match', etag);
+  else if (create) headers.append('If-None-Match', '*');
+
+  let resp;
+  try {
+    resp = await doFetch(url, { method: 'POST', headers, body: formData });
+  } catch (err) {
+    window.lana?.log(`DA writeSheet network error: ${err} — ${url}`);
+    return { ok: false, status: 0, error: 'Network error' };
+  }
+  if (resp.status === 412) {
+    return { ok: false, status: 412, conflict: true, error: 'Sheet changed concurrently' };
+  }
+  if (!resp.ok) {
+    const error = await resp.text().catch(() => resp.statusText);
+    return { ok: false, status: resp.status, error };
+  }
+  return { ok: true, status: resp.status, etag: resp.headers.get('ETag') };
+}
+
+const MAX_WRITE_RETRIES = 4;
+const CONFLICT_ERROR = 'Conflict: the config library sheet was changed by someone else. Please retry.';
+
+// Optimistic-locking read-modify-write: reads the sheet + ETag, applies
+// mutate(rows), writes conditionally, and retries on a 412 conflict.
+// mutate(rows) returns { rows, result, skip? } — skip avoids a needless write.
+export async function mutateSheet(org, repo, path, mutate) {
+  for (let attempt = 0; attempt <= MAX_WRITE_RETRIES; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const read = await readSheet(org, repo, path);
+    if (!read.ok && read.status !== 404) return read;
+    const rows = read.ok ? (read.data || []) : [];
+    // Existing sheet → If-Match its etag (or unconditional if etag unavailable).
+    // Missing sheet (404) → If-None-Match:* to guard concurrent first creation.
+    const opts = read.ok ? { etag: normalizeEtag(read.etag) } : { create: true };
+    const { rows: newRows, result, skip } = mutate(rows);
+    if (skip) return { ok: true, data: result, skipped: true };
+    // eslint-disable-next-line no-await-in-loop
+    const write = await writeSheet(org, repo, path, newRows, opts);
+    if (write.ok) return { ok: true, data: result };
+    if (write.status !== 412) return write;
+  }
+  return { ok: false, status: 412, error: CONFLICT_ERROR };
+}

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -576,6 +576,36 @@ function prebuildAutoBlock(blockName, link) {
 
       return chronoBoxEl;
     },
+    'sessions-guide': (link) => {
+      const url = new URL(link.href);
+      const hashMatch = url.hash.match(/[#&]sgConfig=([A-Za-z0-9+/=%-]{20,})/);
+      const sgConfigBase64 = url.searchParams.get('sgConfig') || hashMatch?.[1];
+      const config = parseEncodedConfig(sgConfigBase64);
+
+      if (!config) {
+        return null;
+      }
+
+      // Catches the real failure mode this manual copy/paste hand-off invites: an
+      // author pastes the wrong event's link onto the wrong page (mirrors
+      // MWPW-200314 item 4's tier-1-event-config eventId cross-check).
+      const pageEventId = getMetadata('event-id');
+      if (config.eventId && pageEventId && config.eventId !== pageEventId) {
+        window.lana?.log(`[sessions-guide] eventId mismatch: config authored for ${config.eventId}, page is ${pageEventId}`);
+      }
+
+      // surface picks which already-registered block this becomes — sessions-guide
+      // (widget/drawer) or sessions-guide-full-page (dedicated page layout) — same
+      // two blocks EVENT_BLOCKS already supports for manual authoring, just reached
+      // a different way here. No manual authoring-table path exists for this block;
+      // sessions-guide.js's init() reads data-session-guide-config only.
+      const blockClass = config.surface === 'page' ? 'sessions-guide-full-page' : 'sessions-guide';
+
+      return createTag('div', {
+        class: blockClass,
+        'data-session-guide-config': JSON.stringify(config),
+      });
+    },
   }
 
   if (autoBlockBuilders[blockName]) {
@@ -591,6 +621,7 @@ export function processAutoBlockLinks(parent) {
   const autoBlockIdentifiers = {
     'chrono-box': { pattern: 'schedule-maker' },
     'mobile-rider': { pattern: 'mobilerider.com', selfInit: true },
+    'sessions-guide': { pattern: 'session-guide-configurator' },
   };
 
   Object.entries(autoBlockIdentifiers).forEach(([blockName, { pattern, selfInit }]) => {

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -586,19 +586,15 @@ function prebuildAutoBlock(blockName, link) {
         return null;
       }
 
-      // Catches the real failure mode this manual copy/paste hand-off invites: an
-      // author pastes the wrong event's link onto the wrong page (mirrors
-      // MWPW-200314 item 4's tier-1-event-config eventId cross-check).
+      // Guards against the real risk of this manual copy/paste hand-off: an author
+      // pasting the wrong event's link onto the wrong page.
       const pageEventId = getMetadata('event-id');
       if (config.eventId && pageEventId && config.eventId !== pageEventId) {
         window.lana?.log(`[sessions-guide] eventId mismatch: config authored for ${config.eventId}, page is ${pageEventId}`);
       }
 
-      // surface picks which already-registered block this becomes — sessions-guide
-      // (widget/drawer) or sessions-guide-full-page (dedicated page layout) — same
-      // two blocks EVENT_BLOCKS already supports for manual authoring, just reached
-      // a different way here. No manual authoring-table path exists for this block;
-      // sessions-guide.js's init() reads data-session-guide-config only.
+      // No authoring-table path exists for this block — sessions-guide.js's init()
+      // reads data-session-guide-config only.
       const blockClass = config.surface === 'page' ? 'sessions-guide-full-page' : 'sessions-guide';
 
       return createTag('div', {

--- a/test/unit/blocks/sessions-guide/mocks/default.html
+++ b/test/unit/blocks/sessions-guide/mocks/default.html
@@ -1,5 +1,1 @@
-<div class="sessions-guide page">
-  <div><div>event-title</div><div>Adobe MAX 2026</div></div>
-  <div><div>theme</div><div>dark</div></div>
-  <div><div>mr-env</div><div>dev</div></div>
-</div>
+<div class="sessions-guide" data-session-guide-config='{"eventId":"evt-123","surface":"page","theme":"dark"}'></div>


### PR DESCRIPTION
## Summary
New DA authoring app for building Session Guide configs — same shape as the Tier 1 Event Configurator (Preact+HTM, no build step), but consumed via a URL-encoded auto-block mechanism (like Schedule Maker → chrono-box) instead of a metadata-table paste.

- **Event linkage**: defaults to picking an already-authored Tier 1 Event Configurator config as the event source, with ESP event-browse / manual event-ID entry as fallback.
- **Core fields**: page mode (widget/full-page), theme, component name, per-auth-state/post-event headings, behavior flags.
- **Filters**: derives facetable custom attributes from the event's session catalog (`deriveFacetableAttributes()`, shared with sessions-guide); authors select/rename/reorder.
- **Swimlane ordering**: drag-and-drop reorder over the event's distinct tracks.
- **Duplicate/Delete**: many configs per event supported (widget vs. full-page variants, test copies).
- **Export**: Copy Link encodes the config into a URL; `decorate.js`'s `prebuildAutoBlock` decodes it at page-decoration time into the `sessions-guide`/`sessions-guide-full-page` block's `data-session-guide-config` attribute — no manual-authoring-table path exists for this block.

Full design rationale: `session-guide-configurator/PLAN.md`.

**Partial PR — consuming-side rendering is a tracked follow-up, not included here.** `headings`/`authoredFilterCategories`/`swimlaneOrder`/`behaviorFlags` reach the page (plumbing only) but aren't yet wired into `DrawerHeader.js`/`FilterPanel.js`/`OnDemandView.js`'s actual rendering — full checklist in `session-guide-configurator/MWPW-194336-CONSUMPTION-HANDOFF.md`. Also deferred: promoting `EventPicker`/`ManualEventLookup`/`Modal`/`SearchInput`/`LoadingInline` to a shared location instead of duplicating Tier 1 Event Configurator's copies (decision made, location not picked — `PLAN.md` §8), and Preview (v2).

## Test plan
- [x] Full suite: 1019/1019 passing, lint clean.

URL for testing:

- https://mwpw-194336--event-libs--adobecom.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)