### PR TITLE
Add blade variant to profile-cards for BACOM speaker section design

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -48,6 +48,50 @@
   flex-direction: column;
 }
 
+/* Blade variant - Mobile first */
+.profile-cards.blade {
+  max-width: 1200px;
+  margin: auto;
+}
+
+.profile-cards.blade .cards-wrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 24px;
+  column-gap: 24px;
+  padding: 32px 16px;
+}
+
+.profile-cards.blade .card-container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 16px;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+}
+
+.profile-cards.blade .card-content {
+  padding: 0;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.profile-cards.blade .blade-read-more {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin-left: 4px;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+  color: inherit;
+  display: inline;
+}
+
 .profile-cards.single .card-container {
   display: flex;
   align-items: flex-start;
@@ -136,6 +180,28 @@
   font-weight: 400;
   line-height: var(--type-body-l-lh);
   margin-top: 0;
+}
+
+.profile-cards.blade .card-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #2c2c2c;
+}
+
+.profile-cards.blade .card-title {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  font-weight: 400;
+  margin: 0 0 8px;
+}
+
+.profile-cards.blade .card-desc {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  font-weight: 400;
+  margin: 0;
+  color: #2c2c2c;
 }
 
 .profile-cards .card-social-icons {
@@ -231,8 +297,24 @@
   display: block;
 }
 
+.profile-cards.blade .card-container .card-image-container {
+  flex: 0 0 98px;
+  width: 98px;
+  height: 98px;
+  border-radius: 50%;
+}
+
+.profile-cards.blade .cards-wrapper .card-container:only-child {
+  grid-column: 1 / -1;
+  justify-self: center;
+}
+
 /* Tablet and up */
 @media screen and (min-width: 600px) {
+  .profile-cards.blade .cards-wrapper {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   /* Grid variants: Tablet - all variants get 2 columns */
   .profile-cards.grid.two-up .cards-wrapper,
   .profile-cards.grid.three-up .cards-wrapper,
@@ -307,6 +389,12 @@
 
   .profile-cards.single .cards-wrapper .card-social-icons {
     margin-left: 15px;
+  }
+
+  .profile-cards.blade .cards-wrapper {
+    column-gap: 48px;
+    row-gap: 40px;
+    padding: 56px 16px;
   }
 
   /* Grid variants: Desktop */

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -83,13 +83,13 @@
   background: none;
   border: 0;
   padding: 0;
-  margin-left: 4px;
+  margin: 0;
   font: inherit;
-  font-weight: 700;
+  font-weight: 400;
   text-decoration: underline;
   cursor: pointer;
   color: inherit;
-  display: inline;
+  display: block;
 }
 
 .profile-cards.single .card-container {

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -205,8 +205,7 @@
   margin: 0;
   color: #2c2c2c;
   overflow: hidden;
-  line-clamp: 2;
-  /* stylelint-disable-next-line value-no-vendor-prefix -- Safari needs -webkit-box for line clamp */
+  /* stylelint-disable-next-line value-no-vendor-prefix -- required for -webkit-line-clamp */
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -318,8 +317,6 @@
 }
 
 .profile-cards.blade .card-container.expanded .card-desc {
-  display: block;
-  line-clamp: unset;
   -webkit-line-clamp: unset;
   overflow: visible;
 }

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -195,7 +195,7 @@
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
   font-weight: 400;
-  margin: 0 0 8px;
+  margin: 0;
 }
 
 .profile-cards.blade .card-desc {

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -202,6 +202,12 @@
   font-weight: 400;
   margin: 0;
   color: #2c2c2c;
+  overflow: hidden;
+  line-clamp: 2;
+  /* stylelint-disable-next-line value-no-vendor-prefix -- Safari needs -webkit-box for line clamp */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .profile-cards .card-social-icons {
@@ -307,6 +313,13 @@
 .profile-cards.blade .cards-wrapper .card-container:only-child {
   grid-column: 1 / -1;
   justify-self: center;
+}
+
+.profile-cards.blade .card-container.expanded .card-desc {
+  display: block;
+  line-clamp: unset;
+  -webkit-line-clamp: unset;
+  overflow: visible;
 }
 
 /* Tablet and up */

--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -85,6 +85,8 @@
   padding: 0;
   margin: 0;
   font: inherit;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
   font-weight: 400;
   text-decoration: underline;
   cursor: pointer;

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -9,8 +9,6 @@ import {
 
 let modalLoader;
 
-const BLADE_BIO_PREVIEW_LENGTH = 144;
-
 function decorateImage(card, photo) {
   if (!photo) return;
 
@@ -215,62 +213,29 @@ function getSocialLinks(data) {
   return data?.socialLinks || data?.socialMedia || [];
 }
 
-function getBioPlainText(bio) {
-  const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
-  if (!trimmedBio) return '';
-  if (!trimmedBio.includes('<')) return trimmedBio;
-
-  const container = createTag('div');
-  container.innerHTML = trimmedBio;
-  return container.textContent.trim();
-}
-
-function truncateBioText(text, limit) {
-  if (text.length <= limit) return { text, truncated: false };
-
-  let cut = text.lastIndexOf(' ', limit);
-  if (cut <= 0) cut = limit;
-
-  return { text: text.slice(0, cut).trimEnd(), truncated: true };
-}
-
 function appendBioBlade(container, bio, fullName) {
-  const plainBio = getBioPlainText(bio);
-  if (!plainBio) return;
+  const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
+  if (!trimmedBio) return;
 
   const desc = createTag('div', { class: 'card-desc blade-desc' });
-  const textEl = createTag('span', { class: 'blade-desc-text' });
-  desc.append(textEl);
-  container.append(desc);
-
-  const short = truncateBioText(plainBio, BLADE_BIO_PREVIEW_LENGTH);
-  if (!short.truncated) {
-    textEl.textContent = plainBio;
-    return;
+  if (trimmedBio.includes('<')) {
+    desc.innerHTML = trimmedBio;
+  } else {
+    desc.textContent = trimmedBio;
   }
-
-  let expanded = false;
-
-  const renderState = () => {
-    if (expanded) {
-      textEl.textContent = plainBio;
-      return;
-    }
-    textEl.textContent = `${short.text}…`;
-  };
-
-  renderState();
+  container.append(desc);
 
   const btn = createTag('button', {
     type: 'button',
     class: 'blade-read-more',
+    hidden: '',
     'aria-expanded': 'false',
     'aria-label': `Read more about ${fullName}'s bio`,
   }, 'Read more');
 
   btn.addEventListener('click', () => {
-    expanded = !expanded;
-    renderState();
+    const cardContainer = btn.closest('.card-container');
+    const expanded = cardContainer.classList.toggle('expanded');
     btn.textContent = expanded ? 'Collapse' : 'Read more';
     btn.setAttribute('aria-expanded', String(expanded));
     btn.setAttribute('aria-label', expanded
@@ -278,7 +243,37 @@ function appendBioBlade(container, bio, fullName) {
       : `Read more about ${fullName}'s bio`);
   });
 
-  desc.append(btn);
+  container.append(btn);
+}
+
+function syncBladeBioOverflow(cardContainer) {
+  const desc = cardContainer.querySelector('.blade-desc');
+  const btn = cardContainer.querySelector('.blade-read-more');
+  if (!desc || !btn) return;
+
+  if (cardContainer.classList.contains('expanded')) {
+    btn.hidden = false;
+    return;
+  }
+
+  btn.hidden = desc.scrollHeight <= desc.clientHeight;
+}
+
+/**
+ * Reveals the Read more toggle only for blade cards whose 2-line-clamped
+ * bio actually overflows. Exported so tests can call it directly after
+ * stubbing scrollHeight/clientHeight, matching the sessions-hub pattern.
+ */
+export function syncBladeBiosOverflow(el) {
+  el.querySelectorAll('.card-container').forEach(syncBladeBioOverflow);
+}
+
+function scheduleBladeBiosOverflowSync(el) {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      syncBladeBiosOverflow(el);
+    });
+  });
 }
 
 function decorateContentBlade(cardContainer, data) {
@@ -567,6 +562,8 @@ function decorateStaticCards(el, { modal, blade } = {}) {
     el.classList.add('with-carousel');
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
+
+  if (blade) scheduleBladeBiosOverflowSync(el);
 }
 
 function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
@@ -608,6 +605,8 @@ function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
 
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
+
+  if (blade) scheduleBladeBiosOverflowSync(el);
 }
 
 function sortDataByOrdinals(data) {

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -9,6 +9,8 @@ import {
 
 let modalLoader;
 
+const BLADE_BIO_PREVIEW_LENGTH = 144;
+
 function decorateImage(card, photo) {
   if (!photo) return;
 
@@ -212,8 +214,6 @@ function getProfileName(data) {
 function getSocialLinks(data) {
   return data?.socialLinks || data?.socialMedia || [];
 }
-
-const BLADE_BIO_PREVIEW_LENGTH = 144;
 
 function getBioPlainText(bio) {
   const trimmedBio = typeof bio === 'string' ? bio.trim() : '';

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -213,6 +213,90 @@ function getSocialLinks(data) {
   return data?.socialLinks || data?.socialMedia || [];
 }
 
+const BLADE_BIO_PREVIEW_LENGTH = 144;
+
+function getBioPlainText(bio) {
+  const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
+  if (!trimmedBio) return '';
+  if (!trimmedBio.includes('<')) return trimmedBio;
+
+  const container = createTag('div');
+  container.innerHTML = trimmedBio;
+  return container.textContent.trim();
+}
+
+function truncateBioText(text, limit) {
+  if (text.length <= limit) return { text, truncated: false };
+
+  let cut = text.lastIndexOf(' ', limit);
+  if (cut <= 0) cut = limit;
+
+  return { text: text.slice(0, cut).trimEnd(), truncated: true };
+}
+
+function appendBioBlade(container, bio, fullName) {
+  const plainBio = getBioPlainText(bio);
+  if (!plainBio) return;
+
+  const desc = createTag('div', { class: 'card-desc blade-desc' });
+  const textEl = createTag('span', { class: 'blade-desc-text' });
+  desc.append(textEl);
+  container.append(desc);
+
+  const short = truncateBioText(plainBio, BLADE_BIO_PREVIEW_LENGTH);
+  if (!short.truncated) {
+    textEl.textContent = plainBio;
+    return;
+  }
+
+  let expanded = false;
+
+  const renderState = () => {
+    if (expanded) {
+      textEl.textContent = plainBio;
+      return;
+    }
+    textEl.textContent = `${short.text}…`;
+  };
+
+  renderState();
+
+  const btn = createTag('button', {
+    type: 'button',
+    class: 'blade-read-more',
+    'aria-expanded': 'false',
+    'aria-label': `Read more about ${fullName}'s bio`,
+  }, 'Read more');
+
+  btn.addEventListener('click', () => {
+    expanded = !expanded;
+    renderState();
+    btn.textContent = expanded ? 'Collapse' : 'Read more';
+    btn.setAttribute('aria-expanded', String(expanded));
+    btn.setAttribute('aria-label', expanded
+      ? `Collapse ${fullName}'s bio`
+      : `Read more about ${fullName}'s bio`);
+  });
+
+  desc.append(btn);
+}
+
+function decorateContentBlade(cardContainer, data) {
+  const contentContainer = createTag('div', { class: 'card-content' });
+  const textContainer = createTag('div', { class: 'card-text-container' });
+  const fullName = getProfileName(data);
+  const name = createTag('h2', { class: 'card-name' }, fullName);
+
+  textContainer.append(name);
+  if (data.title) {
+    textContainer.append(createTag('p', { class: 'card-title' }, data.title));
+  }
+  appendBioBlade(textContainer, data.bio, fullName);
+
+  contentContainer.append(textContainer);
+  cardContainer.append(contentContainer);
+}
+
 function appendBio(contentContainer, bio) {
   const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
   if (!trimmedBio) return;
@@ -441,10 +525,10 @@ function parseStaticCard(row) {
   };
 }
 
-function decorateStaticCards(el, { modal } = {}) {
+function decorateStaticCards(el, { modal, blade } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const rows = Array.from(el.querySelectorAll(':scope > div:not(.cards-wrapper)'));
-  
+
   // First row is the heading, skip it
   const cardRows = rows.slice(1);
 
@@ -459,29 +543,33 @@ function decorateStaticCards(el, { modal } = {}) {
 
     const cardContainer = createTag('div', { class: 'card-container' });
     decorateImage(cardContainer, cardData.photo);
-    decorateContent(cardContainer, cardData);
-    if (modal) {
+    if (blade) {
+      decorateContentBlade(cardContainer, cardData);
+    } else {
+      decorateContent(cardContainer, cardData);
+    }
+    if (modal && !blade) {
       decorateModalTrigger(cardContainer, cardData, index);
     }
     cardsWrapper.append(cardContainer);
-    
+
     // Remove the original row
     row.remove();
   });
 
   const cardCount = cardsWrapper.querySelectorAll('.card-container').length;
   const isGrid = el.classList.contains('grid');
-  
-  if (cardCount === 1) {
+
+  if (cardCount === 1 && !blade) {
     el.classList.add('single');
-  } else if (cardCount > 3 && !isGrid) {
+  } else if (cardCount > 3 && !isGrid && !blade) {
     cardsWrapper.classList.add('carousel-plugin', 'show-3');
     el.classList.add('with-carousel');
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
 }
 
-function decorateCards(el, data, { simple, modal, speakerType } = {}) {
+function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const filteredData = speakerType
     ? data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType)
@@ -496,12 +584,14 @@ function decorateCards(el, data, { simple, modal, speakerType } = {}) {
     const cardContainer = createTag('div', { class: 'card-container' });
 
     decorateImage(cardContainer, speaker.photo);
-    if (simple) {
+    if (blade) {
+      decorateContentBlade(cardContainer, speaker);
+    } else if (simple) {
       decorateContentSimple(cardContainer, speaker);
     } else {
       decorateContent(cardContainer, speaker);
     }
-    if (modal) {
+    if (modal && !blade) {
       decorateModalTrigger(cardContainer, speaker, index);
     }
 
@@ -510,9 +600,9 @@ function decorateCards(el, data, { simple, modal, speakerType } = {}) {
 
   const isGrid = el.classList.contains('grid');
 
-  if (filteredData.length === 1) {
+  if (filteredData.length === 1 && !blade) {
     el.classList.add('single');
-  } else if (filteredData.length > 3 && !isGrid) {
+  } else if (filteredData.length > 3 && !isGrid && !blade) {
     cardsWrapper.classList.add('carousel-plugin', 'show-3');
     el.classList.add('with-carousel');
 
@@ -561,9 +651,10 @@ function parseConfigRows(el) {
 
 export default function init(el) {
   const isModal = el.classList.contains('modal');
+  const isBlade = el.classList.contains('blade');
 
   // Handle grid variant: add default three-up if no *-up class is present
-  if (el.classList.contains('grid')) {
+  if (el.classList.contains('grid') && !isBlade) {
     const hasUpVariant = Array.from(el.classList).some((cls) => cls.endsWith('-up'));
     if (!hasUpVariant) {
       el.classList.add('three-up');
@@ -607,8 +698,10 @@ export default function init(el) {
       sortedData = sortDataByOrdinals(data);
     }
 
-    decorateCards(el, sortedData, { simple: isSimple, modal: isModal, speakerType });
+    decorateCards(el, sortedData, {
+      simple: isSimple, modal: isModal, blade: isBlade, speakerType,
+    });
   } else {
-    decorateStaticCards(el, { modal: isModal });
+    decorateStaticCards(el, { modal: isModal, blade: isBlade });
   }
 }

--- a/test/unit/blocks/profile-cards/mocks/default.html
+++ b/test/unit/blocks/profile-cards/mocks/default.html
@@ -159,4 +159,46 @@
     </div>
   </div>
 </div>
+<div>
+  <div id='blade-cards' class="profile-cards blade">
+    <div>
+      <div>
+        <h2 id="blade-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>type</div>
+      <div>speaker</div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
+<div>
+  <div id='blade-static-cards' class="profile-cards blade">
+    <div>
+      <div>
+        <h2 id="blade-static-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture><img src="https://example.com/photo.jpg" alt="Static Blade Speaker"></picture>
+        <p>VP of Marketing, Adobe</p>
+        <h3>Static Blade Speaker</h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
 </body>

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -317,6 +317,157 @@ describe('Profile Cards Module', () => {
     });
   });
 
+  describe('blade variant', () => {
+    const LOREM = 'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor';
+    const SHORT_BIO = LOREM.slice(0, 100);
+    const LONG_BIO = LOREM.slice(0, 250);
+    const VERY_LONG_BIO = `${LOREM} ${LOREM}`;
+
+    function makeBladeBlock(speakers, { classes = 'blade', configRows = '<div><div>type</div><div>speaker</div></div>' } = {}) {
+      setMetadata('speakers', JSON.stringify(speakers));
+      const el = document.createElement('div');
+      el.className = `profile-cards ${classes}`;
+      el.innerHTML = `<div><div><h2>Heading</h2></div></div>${configRows}`;
+      document.body.appendChild(el);
+      return el;
+    }
+
+    beforeEach(() => {
+      document.body.innerHTML = body;
+      document.head.innerHTML = head;
+    });
+
+    it('renders name and title but no company field, social icons, or modal trigger', () => {
+      const el = document.querySelector('#blade-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      expect(cards).to.have.lengthOf(3);
+
+      cards.forEach((card) => {
+        expect(card.querySelector('.card-name')).to.not.be.null;
+        expect(card.querySelector('.card-title')).to.not.be.null;
+        expect(card.querySelector('.card-company')).to.be.null;
+        expect(card.querySelector('.card-social-icons')).to.be.null;
+        expect(card.getAttribute('role')).to.not.equal('button');
+        expect(card.hasAttribute('aria-haspopup')).to.be.false;
+      });
+    });
+
+    it('does not add the single class or center a 3-card blade block', () => {
+      const el = document.querySelector('#blade-cards');
+      init(el);
+
+      expect(el.classList.contains('single')).to.be.false;
+    });
+
+    it('does not enable modal even when the modal class is also authored', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Ada', lastName: 'Lovelace', speakerType: 'Speaker', title: 'Mathematician', bio: SHORT_BIO },
+      ], { classes: 'blade modal' });
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      expect(card.getAttribute('role')).to.not.equal('button');
+      expect(card.hasAttribute('aria-haspopup')).to.be.false;
+      expect(card.classList.contains('modal-trigger')).to.be.false;
+    });
+
+    it('does not enable the carousel even with more than 3 speakers', () => {
+      const el = makeBladeBlock([
+        { firstName: 'A', lastName: 'One', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'B', lastName: 'Two', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'C', lastName: 'Three', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'D', lastName: 'Four', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(4);
+      expect(el.classList.contains('with-carousel')).to.be.false;
+      expect(el.querySelector('.carousel-plugin')).to.be.null;
+    });
+
+    it('does not add the single class for a lone blade speaker', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Solo', lastName: 'Speaker', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(1);
+      expect(el.classList.contains('single')).to.be.false;
+    });
+
+    it('renders the full bio with no Read more button when it is 144 characters or fewer', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Short', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+      ]);
+      init(el);
+
+      const desc = el.querySelector('.blade-desc');
+      expect(desc.querySelector('.blade-desc-text').textContent).to.equal(SHORT_BIO);
+      expect(desc.querySelector('.blade-read-more')).to.be.null;
+    });
+
+    it('truncates a long bio with a working Read more / Collapse toggle', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Long', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: LONG_BIO },
+      ]);
+      init(el);
+
+      const textEl = el.querySelector('.blade-desc-text');
+      const btn = el.querySelector('.blade-read-more');
+
+      expect(btn).to.not.be.null;
+      expect(btn.textContent).to.equal('Read more');
+      expect(btn.getAttribute('aria-expanded')).to.equal('false');
+      expect(textEl.textContent.endsWith('…')).to.be.true;
+      expect(textEl.textContent.length).to.be.at.most(145);
+      const collapsedText = textEl.textContent;
+
+      btn.click();
+      expect(btn.textContent).to.equal('Collapse');
+      expect(btn.getAttribute('aria-expanded')).to.equal('true');
+      expect(textEl.textContent.length).to.be.greaterThan(collapsedText.length);
+
+      btn.click();
+      expect(btn.textContent).to.equal('Read more');
+      expect(btn.getAttribute('aria-expanded')).to.equal('false');
+      expect(textEl.textContent).to.equal(collapsedText);
+    });
+
+    it('shows the full bio with no dangling ellipsis once expanded, even past 292 characters', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Very', lastName: 'Long', speakerType: 'Speaker', title: 't', bio: VERY_LONG_BIO },
+      ]);
+      init(el);
+
+      const textEl = el.querySelector('.blade-desc-text');
+      const btn = el.querySelector('.blade-read-more');
+
+      btn.click();
+      expect(textEl.textContent).to.equal(VERY_LONG_BIO);
+      expect(textEl.textContent.endsWith('…')).to.be.false;
+    });
+
+    it('renders a static-authored blade card with a working Read more toggle', () => {
+      const el = document.querySelector('#blade-static-cards');
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      expect(card.querySelector('.card-name').textContent.trim()).to.equal('Static Blade Speaker');
+      expect(card.querySelector('.card-title').textContent.trim()).to.equal('VP of Marketing, Adobe');
+      expect(card.querySelector('.card-social-icons')).to.be.null;
+
+      const btn = card.querySelector('.blade-read-more');
+      expect(btn).to.not.be.null;
+
+      const textEl = card.querySelector('.blade-desc-text');
+      const collapsedText = textEl.textContent;
+      btn.click();
+      expect(textEl.textContent.length).to.be.greaterThan(collapsedText.length);
+    });
+  });
+
   describe('createSocialIcon', () => {
     it('should return a social icon element', () => {
       const icon = createSocialIcon(document.createElement('svg'), 'facebook');

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init, { createSocialIcon, buildModalContent } from '../../../../event-libs/v1/blocks/profile-cards/profile-cards.js';
+import init, {
+  createSocialIcon, buildModalContent, syncBladeBiosOverflow,
+} from '../../../../event-libs/v1/blocks/profile-cards/profile-cards.js';
 import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
 
 /** Mirrors Milo modal.js FOCUSABLES selector for initial-focus assertions */
@@ -318,10 +320,7 @@ describe('Profile Cards Module', () => {
   });
 
   describe('blade variant', () => {
-    const LOREM = 'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor';
-    const SHORT_BIO = LOREM.slice(0, 100);
-    const LONG_BIO = LOREM.slice(0, 250);
-    const VERY_LONG_BIO = `${LOREM} ${LOREM}`;
+    const BIO = 'A short bio used across blade variant tests.';
 
     function makeBladeBlock(speakers, { classes = 'blade', configRows = '<div><div>type</div><div>speaker</div></div>' } = {}) {
       setMetadata('speakers', JSON.stringify(speakers));
@@ -330,6 +329,13 @@ describe('Profile Cards Module', () => {
       el.innerHTML = `<div><div><h2>Heading</h2></div></div>${configRows}`;
       document.body.appendChild(el);
       return el;
+    }
+
+    // Mirrors the sessions-hub line-clamp overflow pattern: stub scrollHeight/
+    // clientHeight rather than relying on real layout, then sync directly.
+    function stubOverflow(desc, isOverflowing) {
+      Object.defineProperty(desc, 'scrollHeight', { configurable: true, get: () => (isOverflowing ? 200 : 100) });
+      Object.defineProperty(desc, 'clientHeight', { configurable: true, get: () => 100 });
     }
 
     beforeEach(() => {
@@ -363,7 +369,7 @@ describe('Profile Cards Module', () => {
 
     it('does not enable modal even when the modal class is also authored', () => {
       const el = makeBladeBlock([
-        { firstName: 'Ada', lastName: 'Lovelace', speakerType: 'Speaker', title: 'Mathematician', bio: SHORT_BIO },
+        { firstName: 'Ada', lastName: 'Lovelace', speakerType: 'Speaker', title: 'Mathematician', bio: BIO },
       ], { classes: 'blade modal' });
       init(el);
 
@@ -375,10 +381,10 @@ describe('Profile Cards Module', () => {
 
     it('does not enable the carousel even with more than 3 speakers', () => {
       const el = makeBladeBlock([
-        { firstName: 'A', lastName: 'One', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
-        { firstName: 'B', lastName: 'Two', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
-        { firstName: 'C', lastName: 'Three', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
-        { firstName: 'D', lastName: 'Four', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'A', lastName: 'One', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'B', lastName: 'Two', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'C', lastName: 'Three', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'D', lastName: 'Four', speakerType: 'Speaker', title: 't', bio: BIO },
       ]);
       init(el);
 
@@ -389,7 +395,7 @@ describe('Profile Cards Module', () => {
 
     it('does not add the single class for a lone blade speaker', () => {
       const el = makeBladeBlock([
-        { firstName: 'Solo', lastName: 'Speaker', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'Solo', lastName: 'Speaker', speakerType: 'Speaker', title: 't', bio: BIO },
       ]);
       init(el);
 
@@ -397,59 +403,78 @@ describe('Profile Cards Module', () => {
       expect(el.classList.contains('single')).to.be.false;
     });
 
-    it('renders the full bio with no Read more button when it is 144 characters or fewer', () => {
+    it('always renders the full bio text (no character-based truncation)', () => {
       const el = makeBladeBlock([
-        { firstName: 'Short', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: SHORT_BIO },
+        { firstName: 'Full', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelector('.blade-desc').textContent).to.equal(BIO);
+    });
+
+    it('keeps the Read more button hidden when the 2-line-clamped bio does not overflow', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Fits', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
       ]);
       init(el);
 
       const desc = el.querySelector('.blade-desc');
-      expect(desc.querySelector('.blade-desc-text').textContent).to.equal(SHORT_BIO);
-      expect(desc.querySelector('.blade-read-more')).to.be.null;
+      stubOverflow(desc, false);
+      syncBladeBiosOverflow(el);
+
+      expect(el.querySelector('.blade-read-more').hidden).to.be.true;
     });
 
-    it('truncates a long bio with a working Read more / Collapse toggle', () => {
+    it('reveals the Read more button when the 2-line-clamped bio overflows, and toggles Collapse on click', () => {
       const el = makeBladeBlock([
-        { firstName: 'Long', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: LONG_BIO },
+        { firstName: 'Overflow', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
       ]);
       init(el);
 
-      const textEl = el.querySelector('.blade-desc-text');
-      const btn = el.querySelector('.blade-read-more');
+      const card = el.querySelector('.card-container');
+      const desc = el.querySelector('.blade-desc');
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
 
-      expect(btn).to.not.be.null;
+      const btn = el.querySelector('.blade-read-more');
+      expect(btn.hidden).to.be.false;
       expect(btn.textContent).to.equal('Read more');
       expect(btn.getAttribute('aria-expanded')).to.equal('false');
-      expect(textEl.textContent.endsWith('…')).to.be.true;
-      expect(textEl.textContent.length).to.be.at.most(145);
-      const collapsedText = textEl.textContent;
+      expect(card.classList.contains('expanded')).to.be.false;
 
       btn.click();
+      expect(card.classList.contains('expanded')).to.be.true;
       expect(btn.textContent).to.equal('Collapse');
       expect(btn.getAttribute('aria-expanded')).to.equal('true');
-      expect(textEl.textContent.length).to.be.greaterThan(collapsedText.length);
+      // the bio text itself never changes - CSS line-clamp handles the visual truncation
+      expect(desc.textContent).to.equal(BIO);
 
       btn.click();
+      expect(card.classList.contains('expanded')).to.be.false;
       expect(btn.textContent).to.equal('Read more');
       expect(btn.getAttribute('aria-expanded')).to.equal('false');
-      expect(textEl.textContent).to.equal(collapsedText);
     });
 
-    it('shows the full bio with no dangling ellipsis once expanded, even past 292 characters', () => {
+    it('keeps the Read more button visible once expanded even if a later sync re-runs', () => {
       const el = makeBladeBlock([
-        { firstName: 'Very', lastName: 'Long', speakerType: 'Speaker', title: 't', bio: VERY_LONG_BIO },
+        { firstName: 'Overflow', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
       ]);
       init(el);
 
-      const textEl = el.querySelector('.blade-desc-text');
-      const btn = el.querySelector('.blade-read-more');
+      const card = el.querySelector('.card-container');
+      const desc = el.querySelector('.blade-desc');
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
+      el.querySelector('.blade-read-more').click();
 
-      btn.click();
-      expect(textEl.textContent).to.equal(VERY_LONG_BIO);
-      expect(textEl.textContent.endsWith('…')).to.be.false;
+      // simulate re-running the overflow sync (e.g. from a resize) while expanded
+      syncBladeBiosOverflow(el);
+
+      expect(card.classList.contains('expanded')).to.be.true;
+      expect(el.querySelector('.blade-read-more').hidden).to.be.false;
     });
 
-    it('renders a static-authored blade card with a working Read more toggle', () => {
+    it('renders a static-authored blade card whose Read more toggle expands without changing the bio text', () => {
       const el = document.querySelector('#blade-static-cards');
       init(el);
 
@@ -458,13 +483,17 @@ describe('Profile Cards Module', () => {
       expect(card.querySelector('.card-title').textContent.trim()).to.equal('VP of Marketing, Adobe');
       expect(card.querySelector('.card-social-icons')).to.be.null;
 
-      const btn = card.querySelector('.blade-read-more');
-      expect(btn).to.not.be.null;
+      const desc = card.querySelector('.blade-desc');
+      const originalText = desc.textContent;
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
 
-      const textEl = card.querySelector('.blade-desc-text');
-      const collapsedText = textEl.textContent;
+      const btn = card.querySelector('.blade-read-more');
+      expect(btn.hidden).to.be.false;
+
       btn.click();
-      expect(textEl.textContent.length).to.be.greaterThan(collapsedText.length);
+      expect(card.classList.contains('expanded')).to.be.true;
+      expect(desc.textContent).to.equal(originalText);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a new `blade` variant to the `profile-cards` block matching the updated BACOM/EMC speaker section design ([Figma](https://www.figma.com/design/Zr1EMcb24aJcNo6zh2E4Bg/Speaker-section-UX-update-to-align-EMC-speaker-component-to-BACOM-Speaker-section-patterns?node-id=6982-26086)): a 98px circular avatar with name/title/bio in a horizontal row, wrapped 2-up on tablet/desktop and stacked on mobile (reusing the existing `.grid.two-up` breakpoints), with a bio "Read more" ↔ "Collapse" toggle.
- Supports both authoring modes (metadata-driven and static/table-authored). Per product decision, there's no separate company field — `title` does double duty (e.g. "VP of Marketing, Adobe").
- Modal, carousel, and the auto-added `single` centering class are all explicitly disabled for this variant; a lone card is centered via a CSS `:only-child` rule instead.
- Bio truncation uses CSS `-webkit-line-clamp: 2` (always 2 lines, no character counting), matching the existing `sessions-hub` pattern: the "Read more" button is only revealed when the clamped bio actually overflows (measured via `scrollHeight`/`clientHeight`, synced via `requestAnimationFrame` after render). Clicking toggles an `expanded` class that lifts the clamp — the bio text itself is never rewritten, so any HTML formatting in the bio is preserved.

## Test plan
- [x] `npm run lint` (JS + CSS) — clean
- [x] `npx wtr test/unit/blocks/profile-cards/profile-cards.test.js` — 36/36 passing (`blade variant` describe block covers company-less title, no social icons/modal/carousel, single-card handling, overflow-based Read more visibility via stubbed `scrollHeight`/`clientHeight`, expand/collapse toggle, and the static-authoring path)
- [x] `npm test` — full suite, 1152/1152 passing
- [x] Reviewed by two independent agents (correctness; accessibility/CSS) on an earlier revision — one real bug found and fixed there (dangling ellipsis on long bios), since superseded by this line-clamp approach which removes character-based truncation entirely
- [ ] Manual visual check via `npm run event-libs` against the Figma states (2/3/4/1-speaker layouts) — not yet done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)