### PR TITLE
Add block-scoped theme syntax to custom-attributes theme value

### DIFF
--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -1043,13 +1043,14 @@ function addStylesToEventPage() {
   document.head.appendChild(link);
 }
 
-// Parses "dark", "light", or a block-scoped form like "dark(blocks:hero-marquee,profile-cards)".
-// A scoped value themes only the listed blocks instead of the whole page.
+// e.g. "dark" or "dark(blocks:hero-marquee,profile-cards)"
 function parseThemeValue(raw) {
   const value = raw?.toLowerCase().trim();
   const match = value?.match(/^(dark|light)(?:\(\s*blocks\s*:\s*([^)]*)\)\s*)?$/);
   if (!match) return null;
   const [, theme, blocksParam] = match;
+  // undefined (no parens) means whole-page; '' (empty blocks: list) must stay
+  // distinct from that so it scopes to zero blocks instead of falling back.
   const blockNames = blocksParam !== undefined
     ? blocksParam.split(',').map((b) => b.trim()).filter(Boolean)
     : null;

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -1043,6 +1043,19 @@ function addStylesToEventPage() {
   document.head.appendChild(link);
 }
 
+// Parses "dark", "light", or a block-scoped form like "dark(blocks:hero-marquee,profile-cards)".
+// A scoped value themes only the listed blocks instead of the whole page.
+function parseThemeValue(raw) {
+  const value = raw?.toLowerCase().trim();
+  const match = value?.match(/^(dark|light)(?:\(\s*blocks\s*:\s*([^)]*)\)\s*)?$/);
+  if (!match) return null;
+  const [, theme, blocksParam] = match;
+  const blockNames = blocksParam !== undefined
+    ? blocksParam.split(',').map((b) => b.trim()).filter(Boolean)
+    : null;
+  return { theme, blockNames };
+}
+
 export function applyAreaTheme(area = document) {
   try {
     const customAttributes = JSON.parse(getMetadata('custom-attributes'));
@@ -1051,14 +1064,22 @@ export function applyAreaTheme(area = document) {
     );
     if (!theme) return;
 
-    const themeValue = theme.values?.[0]?.value?.toLowerCase().trim();
-    if (themeValue !== 'dark' && themeValue !== 'light') return;
+    const parsed = parseThemeValue(theme.values?.[0]?.value);
+    if (!parsed) return;
+    const { theme: themeValue, blockNames } = parsed;
 
     const isDocument = area === document;
     const blocks = isDocument
       ? area.body.querySelectorAll('main > div > div[class]')
       : area.querySelectorAll('div[class]');
     blocks.forEach((block) => {
+      if (blockNames) {
+        if (!blockNames.some((name) => block.classList.contains(name))) return;
+        block.classList.remove('dark', 'light');
+        block.classList.add(themeValue);
+        return;
+      }
+
       const isSectionMetadata = block.classList.contains('section-metadata');
       if (isSectionMetadata) {
         const blockRows = block.querySelectorAll(':scope > div');

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -762,6 +762,40 @@ describe('applyAreaTheme', () => {
     expect(document.querySelector('.event-agenda').classList.contains('dark')).to.be.false;
   });
 
+  it('matches block names as exact tokens, not prefixes', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero"></div>
+        <div class="hero-marquee"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.false;
+  });
+
+  it('matches block names case-insensitively', () => {
+    setThemeAttribute('theme', 'dark(blocks:Hero-Marquee)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+  });
+
+  it('applies a block-scoped theme when area is a specific element', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <div id="area">
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div>
+    `;
+    const area = document.getElementById('area');
+    applyAreaTheme(area);
+    expect(area.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(area.querySelector('.profile-cards').classList.contains('dark')).to.be.false;
+  });
+
   it('tolerates whitespace inside the block-scoped syntax', () => {
     setThemeAttribute('theme', ' dark( blocks: hero-marquee , profile-cards ) ');
     document.body.innerHTML = `

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -732,6 +732,93 @@ describe('applyAreaTheme', () => {
     const block = document.querySelector('.foo');
     expect(block.classList.contains('dark')).to.be.true;
   });
+
+  it('applies a block-scoped theme only to the named block', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.profile-cards').classList.contains('light')).to.be.false;
+  });
+
+  it('applies a block-scoped theme to multiple named blocks', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee,profile-cards)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+        <div class="event-agenda"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.event-agenda').classList.contains('dark')).to.be.false;
+  });
+
+  it('tolerates whitespace inside the block-scoped syntax', () => {
+    setThemeAttribute('theme', ' dark( blocks: hero-marquee , profile-cards ) ');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+  });
+
+  it('replaces a pre-existing opposite theme class only on scoped blocks', () => {
+    setThemeAttribute('theme', 'light(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee dark"></div>
+        <div class="profile-cards dark"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('light')).to.be.true;
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+  });
+
+  it('does nothing when the block-scoped syntax uses an unsupported keyword', () => {
+    setThemeAttribute('theme', 'dark(sections:hero-marquee)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.hero-marquee');
+    expect(block.classList.contains('dark')).to.be.false;
+  });
+
+  it('does nothing when the block-scoped syntax has an empty block list', () => {
+    setThemeAttribute('theme', 'dark(blocks:)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.hero-marquee');
+    expect(block.classList.contains('dark')).to.be.false;
+  });
+
+  it('does not sync the section-metadata style row when the theme is block-scoped', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="section-metadata">
+          <div><div>style</div><div>xxl-spacing</div></div>
+        </div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    const cols = document.querySelectorAll('.section-metadata > div > div');
+    expect(cols[1].textContent).to.equal('xxl-spacing');
+  });
 });
 
 describe('getNonProdData', () => {


### PR DESCRIPTION
## Summary
- Extend the `theme` custom-attribute value syntax to support `dark(blocks:name1,name2)` / `light(blocks:...)`, letting authors scope a theme to specific blocks instead of the whole page.
- Plain `dark`/`light` (no parens) keeps today's whole-page behavior unchanged, including the `section-metadata` style-row sync.
- Scoped mode only touches the listed blocks (exact-token match against `classList`, case-insensitive); every other block, and `section-metadata`, is left untouched.

## Review
Reviewed by three independent agents (correctness/edge-cases, test coverage, style/convention compliance). Fixed the gaps they surfaced: added tests for exact-token matching (`blocks:hero` must not match `hero-marquee`), case-insensitive block names, and the element-scoped (non-`document`) call path that production actually uses; tightened the `parseThemeValue` comment to explain the empty-vs-undefined `blocksParam` invariant instead of restating the code.

## Test plan
- [x] `npx wtr test/unit/scripts/decorate.test.js --node-resolve --port=2000` — 124/124 passing
- [x] `npm test` — full suite, 1152/1152 passing
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)