### PR TITLE
Cherry-pick: Profile-cards blade variant + block-scoped theming (stage → main)

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -48,6 +48,52 @@
   flex-direction: column;
 }
 
+/* Blade variant - Mobile first */
+.profile-cards.blade {
+  max-width: 1200px;
+  margin: auto;
+}
+
+.profile-cards.blade .cards-wrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 24px;
+  column-gap: 24px;
+  padding: 32px 16px;
+}
+
+.profile-cards.blade .card-container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 16px;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+}
+
+.profile-cards.blade .card-content {
+  padding: 0;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.profile-cards.blade .blade-read-more {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  font-weight: 400;
+  text-decoration: underline;
+  cursor: pointer;
+  color: inherit;
+  display: block;
+}
+
 .profile-cards.single .card-container {
   display: flex;
   align-items: flex-start;
@@ -136,6 +182,33 @@
   font-weight: 400;
   line-height: var(--type-body-l-lh);
   margin-top: 0;
+}
+
+.profile-cards.blade .card-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: #2c2c2c;
+}
+
+.profile-cards.blade .card-title {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  font-weight: 400;
+  margin: 0;
+}
+
+.profile-cards.blade .card-desc {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  font-weight: 400;
+  margin: 0;
+  color: #2c2c2c;
+  overflow: hidden;
+  /* stylelint-disable-next-line value-no-vendor-prefix -- required for -webkit-line-clamp */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .profile-cards .card-social-icons {
@@ -231,8 +304,29 @@
   display: block;
 }
 
+.profile-cards.blade .card-container .card-image-container {
+  flex: 0 0 98px;
+  width: 98px;
+  height: 98px;
+  border-radius: 50%;
+}
+
+.profile-cards.blade .cards-wrapper .card-container:only-child {
+  grid-column: 1 / -1;
+  justify-self: center;
+}
+
+.profile-cards.blade .card-container.expanded .card-desc {
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
 /* Tablet and up */
 @media screen and (min-width: 600px) {
+  .profile-cards.blade .cards-wrapper {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   /* Grid variants: Tablet - all variants get 2 columns */
   .profile-cards.grid.two-up .cards-wrapper,
   .profile-cards.grid.three-up .cards-wrapper,
@@ -307,6 +401,12 @@
 
   .profile-cards.single .cards-wrapper .card-social-icons {
     margin-left: 15px;
+  }
+
+  .profile-cards.blade .cards-wrapper {
+    column-gap: 48px;
+    row-gap: 40px;
+    padding: 56px 16px;
   }
 
   /* Grid variants: Desktop */

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -213,6 +213,85 @@ function getSocialLinks(data) {
   return data?.socialLinks || data?.socialMedia || [];
 }
 
+function appendBioBlade(container, bio, fullName) {
+  const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
+  if (!trimmedBio) return;
+
+  const desc = createTag('div', { class: 'card-desc blade-desc' });
+  if (trimmedBio.includes('<')) {
+    desc.innerHTML = trimmedBio;
+  } else {
+    desc.textContent = trimmedBio;
+  }
+  container.append(desc);
+
+  const btn = createTag('button', {
+    type: 'button',
+    class: 'blade-read-more',
+    hidden: '',
+    'aria-expanded': 'false',
+    'aria-label': `Read more about ${fullName}'s bio`,
+  }, 'Read more');
+
+  btn.addEventListener('click', () => {
+    const cardContainer = btn.closest('.card-container');
+    const expanded = cardContainer.classList.toggle('expanded');
+    btn.textContent = expanded ? 'Collapse' : 'Read more';
+    btn.setAttribute('aria-expanded', String(expanded));
+    btn.setAttribute('aria-label', expanded
+      ? `Collapse ${fullName}'s bio`
+      : `Read more about ${fullName}'s bio`);
+  });
+
+  container.append(btn);
+}
+
+function syncBladeBioOverflow(cardContainer) {
+  const desc = cardContainer.querySelector('.blade-desc');
+  const btn = cardContainer.querySelector('.blade-read-more');
+  if (!desc || !btn) return;
+
+  if (cardContainer.classList.contains('expanded')) {
+    btn.hidden = false;
+    return;
+  }
+
+  btn.hidden = desc.scrollHeight <= desc.clientHeight;
+}
+
+/**
+ * Reveals the Read more toggle only for blade cards whose 2-line-clamped
+ * bio actually overflows. Exported so tests can call it directly after
+ * stubbing scrollHeight/clientHeight, matching the sessions-hub pattern.
+ */
+export function syncBladeBiosOverflow(el) {
+  el.querySelectorAll('.card-container').forEach(syncBladeBioOverflow);
+}
+
+function scheduleBladeBiosOverflowSync(el) {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      syncBladeBiosOverflow(el);
+    });
+  });
+}
+
+function decorateContentBlade(cardContainer, data) {
+  const contentContainer = createTag('div', { class: 'card-content' });
+  const textContainer = createTag('div', { class: 'card-text-container' });
+  const fullName = getProfileName(data);
+  const name = createTag('h2', { class: 'card-name' }, fullName);
+
+  textContainer.append(name);
+  if (data.title) {
+    textContainer.append(createTag('p', { class: 'card-title' }, data.title));
+  }
+  appendBioBlade(textContainer, data.bio, fullName);
+
+  contentContainer.append(textContainer);
+  cardContainer.append(contentContainer);
+}
+
 function appendBio(contentContainer, bio) {
   const trimmedBio = typeof bio === 'string' ? bio.trim() : '';
   if (!trimmedBio) return;
@@ -441,10 +520,10 @@ function parseStaticCard(row) {
   };
 }
 
-function decorateStaticCards(el, { modal } = {}) {
+function decorateStaticCards(el, { modal, blade } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const rows = Array.from(el.querySelectorAll(':scope > div:not(.cards-wrapper)'));
-  
+
   // First row is the heading, skip it
   const cardRows = rows.slice(1);
 
@@ -459,29 +538,35 @@ function decorateStaticCards(el, { modal } = {}) {
 
     const cardContainer = createTag('div', { class: 'card-container' });
     decorateImage(cardContainer, cardData.photo);
-    decorateContent(cardContainer, cardData);
-    if (modal) {
+    if (blade) {
+      decorateContentBlade(cardContainer, cardData);
+    } else {
+      decorateContent(cardContainer, cardData);
+    }
+    if (modal && !blade) {
       decorateModalTrigger(cardContainer, cardData, index);
     }
     cardsWrapper.append(cardContainer);
-    
+
     // Remove the original row
     row.remove();
   });
 
   const cardCount = cardsWrapper.querySelectorAll('.card-container').length;
   const isGrid = el.classList.contains('grid');
-  
-  if (cardCount === 1) {
+
+  if (cardCount === 1 && !blade) {
     el.classList.add('single');
-  } else if (cardCount > 3 && !isGrid) {
+  } else if (cardCount > 3 && !isGrid && !blade) {
     cardsWrapper.classList.add('carousel-plugin', 'show-3');
     el.classList.add('with-carousel');
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
+
+  if (blade) scheduleBladeBiosOverflowSync(el);
 }
 
-function decorateCards(el, data, { simple, modal, speakerType } = {}) {
+function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
   const cardsWrapper = el.querySelector('.cards-wrapper');
   const filteredData = speakerType
     ? data.filter((speaker) => speaker.speakerType?.toLowerCase() === speakerType)
@@ -496,12 +581,14 @@ function decorateCards(el, data, { simple, modal, speakerType } = {}) {
     const cardContainer = createTag('div', { class: 'card-container' });
 
     decorateImage(cardContainer, speaker.photo);
-    if (simple) {
+    if (blade) {
+      decorateContentBlade(cardContainer, speaker);
+    } else if (simple) {
       decorateContentSimple(cardContainer, speaker);
     } else {
       decorateContent(cardContainer, speaker);
     }
-    if (modal) {
+    if (modal && !blade) {
       decorateModalTrigger(cardContainer, speaker, index);
     }
 
@@ -510,14 +597,16 @@ function decorateCards(el, data, { simple, modal, speakerType } = {}) {
 
   const isGrid = el.classList.contains('grid');
 
-  if (filteredData.length === 1) {
+  if (filteredData.length === 1 && !blade) {
     el.classList.add('single');
-  } else if (filteredData.length > 3 && !isGrid) {
+  } else if (filteredData.length > 3 && !isGrid && !blade) {
     cardsWrapper.classList.add('carousel-plugin', 'show-3');
     el.classList.add('with-carousel');
 
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
+
+  if (blade) scheduleBladeBiosOverflowSync(el);
 }
 
 function sortDataByOrdinals(data) {
@@ -561,9 +650,10 @@ function parseConfigRows(el) {
 
 export default function init(el) {
   const isModal = el.classList.contains('modal');
+  const isBlade = el.classList.contains('blade');
 
   // Handle grid variant: add default three-up if no *-up class is present
-  if (el.classList.contains('grid')) {
+  if (el.classList.contains('grid') && !isBlade) {
     const hasUpVariant = Array.from(el.classList).some((cls) => cls.endsWith('-up'));
     if (!hasUpVariant) {
       el.classList.add('three-up');
@@ -607,8 +697,10 @@ export default function init(el) {
       sortedData = sortDataByOrdinals(data);
     }
 
-    decorateCards(el, sortedData, { simple: isSimple, modal: isModal, speakerType });
+    decorateCards(el, sortedData, {
+      simple: isSimple, modal: isModal, blade: isBlade, speakerType,
+    });
   } else {
-    decorateStaticCards(el, { modal: isModal });
+    decorateStaticCards(el, { modal: isModal, blade: isBlade });
   }
 }

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -1037,6 +1037,20 @@ function addStylesToEventPage() {
   document.head.appendChild(link);
 }
 
+// e.g. "dark" or "dark(blocks:hero-marquee,profile-cards)"
+function parseThemeValue(raw) {
+  const value = raw?.toLowerCase().trim();
+  const match = value?.match(/^(dark|light)(?:\(\s*blocks\s*:\s*([^)]*)\)\s*)?$/);
+  if (!match) return null;
+  const [, theme, blocksParam] = match;
+  // undefined (no parens) means whole-page; '' (empty blocks: list) must stay
+  // distinct from that so it scopes to zero blocks instead of falling back.
+  const blockNames = blocksParam !== undefined
+    ? blocksParam.split(',').map((b) => b.trim()).filter(Boolean)
+    : null;
+  return { theme, blockNames };
+}
+
 export function applyAreaTheme(area = document) {
   try {
     const customAttributes = JSON.parse(getMetadata('custom-attributes'));
@@ -1045,14 +1059,22 @@ export function applyAreaTheme(area = document) {
     );
     if (!theme) return;
 
-    const themeValue = theme.values?.[0]?.value?.toLowerCase().trim();
-    if (themeValue !== 'dark' && themeValue !== 'light') return;
+    const parsed = parseThemeValue(theme.values?.[0]?.value);
+    if (!parsed) return;
+    const { theme: themeValue, blockNames } = parsed;
 
     const isDocument = area === document;
     const blocks = isDocument
       ? area.body.querySelectorAll('main > div > div[class]')
       : area.querySelectorAll('div[class]');
     blocks.forEach((block) => {
+      if (blockNames) {
+        if (!blockNames.some((name) => block.classList.contains(name))) return;
+        block.classList.remove('dark', 'light');
+        block.classList.add(themeValue);
+        return;
+      }
+
       const isSectionMetadata = block.classList.contains('section-metadata');
       if (isSectionMetadata) {
         const blockRows = block.querySelectorAll(':scope > div');

--- a/test/unit/blocks/profile-cards/mocks/default.html
+++ b/test/unit/blocks/profile-cards/mocks/default.html
@@ -159,4 +159,46 @@
     </div>
   </div>
 </div>
+<div>
+  <div id='blade-cards' class="profile-cards blade">
+    <div>
+      <div>
+        <h2 id="blade-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>type</div>
+      <div>speaker</div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
+<div>
+  <div id='blade-static-cards' class="profile-cards blade">
+    <div>
+      <div>
+        <h2 id="blade-static-speakers">Speakers</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture><img src="https://example.com/photo.jpg" alt="Static Blade Speaker"></picture>
+        <p>VP of Marketing, Adobe</p>
+        <h3>Static Blade Speaker</h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      </div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div data-valign="middle">style</div>
+      <div data-valign="middle"><strong>Center, m spacing</strong></div>
+    </div>
+  </div>
+</div>
 </body>

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import init, { createSocialIcon, buildModalContent } from '../../../../event-libs/v1/blocks/profile-cards/profile-cards.js';
+import init, {
+  createSocialIcon, buildModalContent, syncBladeBiosOverflow,
+} from '../../../../event-libs/v1/blocks/profile-cards/profile-cards.js';
 import { setMetadata } from '../../../../event-libs/v1/utils/utils.js';
 
 /** Mirrors Milo modal.js FOCUSABLES selector for initial-focus assertions */
@@ -314,6 +316,184 @@ describe('Profile Cards Module', () => {
       init(el);
       const configRows = Array.from(el.querySelectorAll(':scope > div:not(.cards-wrapper)')).slice(1);
       expect(configRows).to.have.lengthOf(0);
+    });
+  });
+
+  describe('blade variant', () => {
+    const BIO = 'A short bio used across blade variant tests.';
+
+    function makeBladeBlock(speakers, { classes = 'blade', configRows = '<div><div>type</div><div>speaker</div></div>' } = {}) {
+      setMetadata('speakers', JSON.stringify(speakers));
+      const el = document.createElement('div');
+      el.className = `profile-cards ${classes}`;
+      el.innerHTML = `<div><div><h2>Heading</h2></div></div>${configRows}`;
+      document.body.appendChild(el);
+      return el;
+    }
+
+    // Mirrors the sessions-hub line-clamp overflow pattern: stub scrollHeight/
+    // clientHeight rather than relying on real layout, then sync directly.
+    function stubOverflow(desc, isOverflowing) {
+      Object.defineProperty(desc, 'scrollHeight', { configurable: true, get: () => (isOverflowing ? 200 : 100) });
+      Object.defineProperty(desc, 'clientHeight', { configurable: true, get: () => 100 });
+    }
+
+    beforeEach(() => {
+      document.body.innerHTML = body;
+      document.head.innerHTML = head;
+    });
+
+    it('renders name and title but no company field, social icons, or modal trigger', () => {
+      const el = document.querySelector('#blade-cards');
+      init(el);
+
+      const cards = el.querySelectorAll('.card-container');
+      expect(cards).to.have.lengthOf(3);
+
+      cards.forEach((card) => {
+        expect(card.querySelector('.card-name')).to.not.be.null;
+        expect(card.querySelector('.card-title')).to.not.be.null;
+        expect(card.querySelector('.card-company')).to.be.null;
+        expect(card.querySelector('.card-social-icons')).to.be.null;
+        expect(card.getAttribute('role')).to.not.equal('button');
+        expect(card.hasAttribute('aria-haspopup')).to.be.false;
+      });
+    });
+
+    it('does not add the single class or center a 3-card blade block', () => {
+      const el = document.querySelector('#blade-cards');
+      init(el);
+
+      expect(el.classList.contains('single')).to.be.false;
+    });
+
+    it('does not enable modal even when the modal class is also authored', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Ada', lastName: 'Lovelace', speakerType: 'Speaker', title: 'Mathematician', bio: BIO },
+      ], { classes: 'blade modal' });
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      expect(card.getAttribute('role')).to.not.equal('button');
+      expect(card.hasAttribute('aria-haspopup')).to.be.false;
+      expect(card.classList.contains('modal-trigger')).to.be.false;
+    });
+
+    it('does not enable the carousel even with more than 3 speakers', () => {
+      const el = makeBladeBlock([
+        { firstName: 'A', lastName: 'One', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'B', lastName: 'Two', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'C', lastName: 'Three', speakerType: 'Speaker', title: 't', bio: BIO },
+        { firstName: 'D', lastName: 'Four', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(4);
+      expect(el.classList.contains('with-carousel')).to.be.false;
+      expect(el.querySelector('.carousel-plugin')).to.be.null;
+    });
+
+    it('does not add the single class for a lone blade speaker', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Solo', lastName: 'Speaker', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelectorAll('.card-container')).to.have.lengthOf(1);
+      expect(el.classList.contains('single')).to.be.false;
+    });
+
+    it('always renders the full bio text (no character-based truncation)', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Full', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      expect(el.querySelector('.blade-desc').textContent).to.equal(BIO);
+    });
+
+    it('keeps the Read more button hidden when the 2-line-clamped bio does not overflow', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Fits', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      const desc = el.querySelector('.blade-desc');
+      stubOverflow(desc, false);
+      syncBladeBiosOverflow(el);
+
+      expect(el.querySelector('.blade-read-more').hidden).to.be.true;
+    });
+
+    it('reveals the Read more button when the 2-line-clamped bio overflows, and toggles Collapse on click', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Overflow', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      const desc = el.querySelector('.blade-desc');
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
+
+      const btn = el.querySelector('.blade-read-more');
+      expect(btn.hidden).to.be.false;
+      expect(btn.textContent).to.equal('Read more');
+      expect(btn.getAttribute('aria-expanded')).to.equal('false');
+      expect(card.classList.contains('expanded')).to.be.false;
+
+      btn.click();
+      expect(card.classList.contains('expanded')).to.be.true;
+      expect(btn.textContent).to.equal('Collapse');
+      expect(btn.getAttribute('aria-expanded')).to.equal('true');
+      // the bio text itself never changes - CSS line-clamp handles the visual truncation
+      expect(desc.textContent).to.equal(BIO);
+
+      btn.click();
+      expect(card.classList.contains('expanded')).to.be.false;
+      expect(btn.textContent).to.equal('Read more');
+      expect(btn.getAttribute('aria-expanded')).to.equal('false');
+    });
+
+    it('keeps the Read more button visible once expanded even if a later sync re-runs', () => {
+      const el = makeBladeBlock([
+        { firstName: 'Overflow', lastName: 'Bio', speakerType: 'Speaker', title: 't', bio: BIO },
+      ]);
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      const desc = el.querySelector('.blade-desc');
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
+      el.querySelector('.blade-read-more').click();
+
+      // simulate re-running the overflow sync (e.g. from a resize) while expanded
+      syncBladeBiosOverflow(el);
+
+      expect(card.classList.contains('expanded')).to.be.true;
+      expect(el.querySelector('.blade-read-more').hidden).to.be.false;
+    });
+
+    it('renders a static-authored blade card whose Read more toggle expands without changing the bio text', () => {
+      const el = document.querySelector('#blade-static-cards');
+      init(el);
+
+      const card = el.querySelector('.card-container');
+      expect(card.querySelector('.card-name').textContent.trim()).to.equal('Static Blade Speaker');
+      expect(card.querySelector('.card-title').textContent.trim()).to.equal('VP of Marketing, Adobe');
+      expect(card.querySelector('.card-social-icons')).to.be.null;
+
+      const desc = card.querySelector('.blade-desc');
+      const originalText = desc.textContent;
+      stubOverflow(desc, true);
+      syncBladeBiosOverflow(el);
+
+      const btn = card.querySelector('.blade-read-more');
+      expect(btn.hidden).to.be.false;
+
+      btn.click();
+      expect(card.classList.contains('expanded')).to.be.true;
+      expect(desc.textContent).to.equal(originalText);
     });
   });
 

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -688,6 +688,127 @@ describe('applyAreaTheme', () => {
     const block = document.querySelector('.foo');
     expect(block.classList.contains('dark')).to.be.true;
   });
+
+  it('applies a block-scoped theme only to the named block', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.profile-cards').classList.contains('light')).to.be.false;
+  });
+
+  it('applies a block-scoped theme to multiple named blocks', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee,profile-cards)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+        <div class="event-agenda"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.event-agenda').classList.contains('dark')).to.be.false;
+  });
+
+  it('matches block names as exact tokens, not prefixes', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero"></div>
+        <div class="hero-marquee"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.false;
+  });
+
+  it('matches block names case-insensitively', () => {
+    setThemeAttribute('theme', 'dark(blocks:Hero-Marquee)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+  });
+
+  it('applies a block-scoped theme when area is a specific element', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <div id="area">
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div>
+    `;
+    const area = document.getElementById('area');
+    applyAreaTheme(area);
+    expect(area.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(area.querySelector('.profile-cards').classList.contains('dark')).to.be.false;
+  });
+
+  it('tolerates whitespace inside the block-scoped syntax', () => {
+    setThemeAttribute('theme', ' dark( blocks: hero-marquee , profile-cards ) ');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="profile-cards"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.true;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+  });
+
+  it('replaces a pre-existing opposite theme class only on scoped blocks', () => {
+    setThemeAttribute('theme', 'light(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee dark"></div>
+        <div class="profile-cards dark"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.hero-marquee').classList.contains('light')).to.be.true;
+    expect(document.querySelector('.hero-marquee').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.profile-cards').classList.contains('dark')).to.be.true;
+  });
+
+  it('does nothing when the block-scoped syntax uses an unsupported keyword', () => {
+    setThemeAttribute('theme', 'dark(sections:hero-marquee)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.hero-marquee');
+    expect(block.classList.contains('dark')).to.be.false;
+  });
+
+  it('does nothing when the block-scoped syntax has an empty block list', () => {
+    setThemeAttribute('theme', 'dark(blocks:)');
+    document.body.innerHTML = '<main><div><div class="hero-marquee"></div></div></main>';
+    applyAreaTheme();
+    const block = document.querySelector('.hero-marquee');
+    expect(block.classList.contains('dark')).to.be.false;
+  });
+
+  it('does not sync the section-metadata style row when the theme is block-scoped', () => {
+    setThemeAttribute('theme', 'dark(blocks:hero-marquee)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="hero-marquee"></div>
+        <div class="section-metadata">
+          <div><div>style</div><div>xxl-spacing</div></div>
+        </div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    const cols = document.querySelectorAll('.section-metadata > div > div');
+    expect(cols[1].textContent).to.equal('xxl-spacing');
+  });
 });
 
 describe('getNonProdData', () => {


### PR DESCRIPTION
## Release Notes

Selective cherry-pick from `stage` — only the two features below, not a full stage promotion.

**New**
- **Profile-cards blade variant** for the BACOM speaker section design, with CSS line-clamp bio truncation and a Read more/Collapse toggle. (#217)
- **Block-scoped theme syntax** in `custom-attributes` theme metadata, allowing light/dark theming per block. (#218)

Cherry-picked commits (via `-m 1` on each PR's merge commit, preserving the exact diff as reviewed):
- `9143c26` Merge pull request #217 (profile-cards blade variant)
- `225f731` Merge pull request #218 (block-scoped theme syntax)

Verified: `npx wtr test/unit/blocks/profile-cards/profile-cards.test.js test/unit/scripts/decorate.test.js` — 158/158 passing.

Test URLs:
- Before: https://main--event-libs--adobecom.aem.live/?martech=off
- After: https://cherry-pick-blade-variant-theme-scoping-main--event-libs--adobecom.aem.live/?martech=off