### PR TITLE
Cherry-pick: Profile-cards blade variant fixes (stage → main)

### DIFF
--- a/event-libs/v1/blocks/profile-cards/profile-cards.css
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.css
@@ -59,7 +59,7 @@
   grid-template-columns: 1fr;
   row-gap: 24px;
   column-gap: 24px;
-  padding: 32px 16px;
+  padding: 32px var(--grid-margins-width);
 }
 
 .profile-cards.blade .card-container {
@@ -92,6 +92,10 @@
   cursor: pointer;
   color: inherit;
   display: block;
+}
+
+.profile-cards.blade .blade-read-more[hidden] {
+  display: none;
 }
 
 .profile-cards.single .card-container {
@@ -406,7 +410,7 @@
   .profile-cards.blade .cards-wrapper {
     column-gap: 48px;
     row-gap: 40px;
-    padding: 56px 16px;
+    padding: 56px var(--grid-margins-width);
   }
 
   /* Grid variants: Desktop */

--- a/event-libs/v1/blocks/profile-cards/profile-cards.js
+++ b/event-libs/v1/blocks/profile-cards/profile-cards.js
@@ -268,12 +268,50 @@ export function syncBladeBiosOverflow(el) {
   el.querySelectorAll('.card-container').forEach(syncBladeBioOverflow);
 }
 
-function scheduleBladeBiosOverflowSync(el) {
+function debounce(fn, delay) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
+const bladeOverflowObservers = new WeakMap();
+
+function disconnectBladeBiosOverflowObserver(el) {
+  const disconnect = bladeOverflowObservers.get(el);
+  if (disconnect) {
+    disconnect();
+    bladeOverflowObservers.delete(el);
+  }
+}
+
+function connectBladeBiosOverflowObserver(el) {
+  if (typeof ResizeObserver === 'undefined') return;
+  disconnectBladeBiosOverflowObserver(el);
+
+  const cardsWrapper = el.querySelector('.cards-wrapper');
+  if (!cardsWrapper) return;
+
+  const debouncedSync = debounce(() => syncBladeBiosOverflow(el), 100);
+  const ro = new ResizeObserver(() => debouncedSync());
+  ro.observe(cardsWrapper);
+  bladeOverflowObservers.set(el, () => ro.disconnect());
+}
+
+/** Waits for fonts.ready first - otherwise the ResizeObserver's unconditional initial observe() callback would measure against fallback-font metrics. */
+async function initBladeBiosOverflowSync(el) {
+  try {
+    await document.fonts?.ready;
+  } catch {
+    // ignore font loading errors
+  }
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       syncBladeBiosOverflow(el);
     });
   });
+  connectBladeBiosOverflowObserver(el);
 }
 
 function decorateContentBlade(cardContainer, data) {
@@ -563,7 +601,7 @@ function decorateStaticCards(el, { modal, blade } = {}) {
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
 
-  if (blade) scheduleBladeBiosOverflowSync(el);
+  if (blade) initBladeBiosOverflowSync(el);
 }
 
 function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
@@ -606,7 +644,7 @@ function decorateCards(el, data, { simple, modal, blade, speakerType } = {}) {
     buildMiloCarousel(cardsWrapper, Array.from(cardsWrapper.querySelectorAll('.card-container')));
   }
 
-  if (blade) scheduleBladeBiosOverflowSync(el);
+  if (blade) initBladeBiosOverflowSync(el);
 }
 
 function sortDataByOrdinals(data) {

--- a/event-libs/v1/utils/decorate.js
+++ b/event-libs/v1/utils/decorate.js
@@ -1037,7 +1037,9 @@ function addStylesToEventPage() {
   document.head.appendChild(link);
 }
 
-// e.g. "dark" or "dark(blocks:hero-marquee,profile-cards)"
+// e.g. "dark", "dark(blocks:hero-marquee,profile-cards)", or "dark(blocks:text[first],agenda)"
+const BLOCK_TOKEN_RE = /^([^[\]]+?)(?:\[\s*(first|last|[1-9]\d*)\s*\])?$/;
+
 function parseThemeValue(raw) {
   const value = raw?.toLowerCase().trim();
   const match = value?.match(/^(dark|light)(?:\(\s*blocks\s*:\s*([^)]*)\)\s*)?$/);
@@ -1045,10 +1047,17 @@ function parseThemeValue(raw) {
   const [, theme, blocksParam] = match;
   // undefined (no parens) means whole-page; '' (empty blocks: list) must stay
   // distinct from that so it scopes to zero blocks instead of falling back.
-  const blockNames = blocksParam !== undefined
-    ? blocksParam.split(',').map((b) => b.trim()).filter(Boolean)
-    : null;
-  return { theme, blockNames };
+  if (blocksParam === undefined) return { theme, blockTokens: null };
+
+  const rawTokens = blocksParam.split(',').map((b) => b.trim()).filter(Boolean);
+  const blockTokens = [];
+  for (const token of rawTokens) {
+    const tokenMatch = token.match(BLOCK_TOKEN_RE);
+    if (!tokenMatch) return null;
+    const [, name, selector] = tokenMatch;
+    blockTokens.push({ name: name.trim(), selector: selector ?? null });
+  }
+  return { theme, blockTokens };
 }
 
 export function applyAreaTheme(area = document) {
@@ -1061,20 +1070,36 @@ export function applyAreaTheme(area = document) {
 
     const parsed = parseThemeValue(theme.values?.[0]?.value);
     if (!parsed) return;
-    const { theme: themeValue, blockNames } = parsed;
+    const { theme: themeValue, blockTokens } = parsed;
 
     const isDocument = area === document;
     const blocks = isDocument
       ? area.body.querySelectorAll('main > div > div[class]')
       : area.querySelectorAll('div[class]');
-    blocks.forEach((block) => {
-      if (blockNames) {
-        if (!blockNames.some((name) => block.classList.contains(name))) return;
+
+    if (blockTokens) {
+      const blockList = Array.from(blocks);
+      const plainNames = blockTokens.filter((t) => !t.selector).map((t) => t.name);
+      const positionalTargets = new Set();
+      blockTokens.filter((t) => t.selector).forEach(({ name, selector }) => {
+        const group = blockList.filter((b) => b.classList.contains(name));
+        const index = selector === 'first' ? 0
+          : selector === 'last' ? group.length - 1
+            : Number(selector) - 1;
+        if (group[index]) positionalTargets.add(group[index]);
+      });
+
+      blockList.forEach((block) => {
+        const matches = plainNames.some((name) => block.classList.contains(name))
+          || positionalTargets.has(block);
+        if (!matches) return;
         block.classList.remove('dark', 'light');
         block.classList.add(themeValue);
-        return;
-      }
+      });
+      return;
+    }
 
+    blocks.forEach((block) => {
       const isSectionMetadata = block.classList.contains('section-metadata');
       if (isSectionMetadata) {
         const blockRows = block.querySelectorAll(':scope > div');

--- a/test/unit/blocks/profile-cards/profile-cards.test.js
+++ b/test/unit/blocks/profile-cards/profile-cards.test.js
@@ -19,6 +19,16 @@ async function waitForSocialIcons(el, timeoutMs = 5000) {
   }
 }
 
+/** Polls rather than waiting a fixed number of rAFs/ms, which get throttled unpredictably when many test files run concurrently. */
+async function waitFor(conditionFn, timeoutMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (conditionFn()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error('waitFor: condition not met within timeout');
+}
+
 describe('Profile Cards Module', () => {
   describe('init', () => {
     beforeEach(() => {
@@ -494,6 +504,140 @@ describe('Profile Cards Module', () => {
       btn.click();
       expect(card.classList.contains('expanded')).to.be.true;
       expect(desc.textContent).to.equal(originalText);
+    });
+
+    // Real rAF/ResizeObserver can be suspended indefinitely on a backgrounded page when many WTR sessions share a browser, so stub both instead of racing that.
+    function stubRaf() {
+      const original = window.requestAnimationFrame;
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: (cb) => setTimeout(cb, 0),
+      });
+      return () => Object.defineProperty(window, 'requestAnimationFrame', { configurable: true, value: original });
+    }
+
+    function stubResizeObserver() {
+      const original = window.ResizeObserver;
+      const instances = [];
+      class FakeResizeObserver {
+        constructor(callback) {
+          this.callback = callback;
+          instances.push(this);
+        }
+
+        observe() {}
+
+        disconnect() {}
+      }
+      Object.defineProperty(window, 'ResizeObserver', { configurable: true, value: FakeResizeObserver });
+      return {
+        instances,
+        restore: () => Object.defineProperty(window, 'ResizeObserver', { configurable: true, value: original }),
+      };
+    }
+
+    it('waits for document.fonts.ready before performing the initial overflow sync', async function bladeFontsReadyGate() {
+      this.timeout(10000);
+      const restoreRaf = stubRaf();
+      const { restore: restoreRo } = stubResizeObserver();
+      const originalFonts = document.fonts;
+      let resolveFonts;
+      const fontsReady = new Promise((resolve) => { resolveFonts = resolve; });
+      Object.defineProperty(document, 'fonts', { configurable: true, value: { ready: fontsReady } });
+
+      try {
+        const el = makeBladeBlock([
+          { firstName: 'Wait', lastName: 'ForFonts', speakerType: 'Speaker', title: 't', bio: BIO },
+        ]);
+        init(el);
+
+        const desc = el.querySelector('.blade-desc');
+        stubOverflow(desc, true);
+
+        // fontsReady is still unresolved, so the sync can't have run yet.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(el.querySelector('.blade-read-more').hidden).to.be.true;
+
+        resolveFonts();
+        await waitFor(() => el.querySelector('.blade-read-more').hidden === false);
+      } finally {
+        Object.defineProperty(document, 'fonts', { configurable: true, value: originalFonts });
+        restoreRo();
+        restoreRaf();
+      }
+    });
+
+    it('does not throw when document.fonts is unavailable', async function bladeNoFontsApi() {
+      this.timeout(10000);
+      const restoreRaf = stubRaf();
+      const { restore: restoreRo } = stubResizeObserver();
+      const originalFonts = document.fonts;
+      Object.defineProperty(document, 'fonts', { configurable: true, value: undefined });
+
+      try {
+        const el = makeBladeBlock([
+          { firstName: 'No', lastName: 'FontsApi', speakerType: 'Speaker', title: 't', bio: BIO },
+        ]);
+        expect(() => init(el)).to.not.throw();
+
+        const desc = el.querySelector('.blade-desc');
+        stubOverflow(desc, true);
+        await waitFor(() => el.querySelector('.blade-read-more').hidden === false);
+      } finally {
+        Object.defineProperty(document, 'fonts', { configurable: true, value: originalFonts });
+        restoreRo();
+        restoreRaf();
+      }
+    });
+
+    it('does not throw when ResizeObserver is unavailable', async function bladeNoResizeObserver() {
+      this.timeout(10000);
+      const restoreRaf = stubRaf();
+      const originalResizeObserver = window.ResizeObserver;
+      Object.defineProperty(window, 'ResizeObserver', { configurable: true, value: undefined });
+
+      try {
+        const el = makeBladeBlock([
+          { firstName: 'No', lastName: 'ResizeObserverApi', speakerType: 'Speaker', title: 't', bio: BIO },
+        ]);
+        expect(() => init(el)).to.not.throw();
+
+        const desc = el.querySelector('.blade-desc');
+        stubOverflow(desc, true);
+        await waitFor(() => el.querySelector('.blade-read-more').hidden === false);
+      } finally {
+        Object.defineProperty(window, 'ResizeObserver', { configurable: true, value: originalResizeObserver });
+        restoreRaf();
+      }
+    });
+
+    it('re-syncs via the ResizeObserver backstop when the cards wrapper resizes', async function bladeResizeObserverBackstop() {
+      this.timeout(10000);
+      const restoreRaf = stubRaf();
+      const { instances, restore: restoreRo } = stubResizeObserver();
+
+      try {
+        const el = makeBladeBlock([
+          { firstName: 'Resize', lastName: 'Card', speakerType: 'Speaker', title: 't', bio: BIO },
+        ]);
+        init(el);
+
+        const desc = el.querySelector('.blade-desc');
+        stubOverflow(desc, true);
+
+        // Prove the one-shot initial sync already ran, so it can't fire again.
+        await waitFor(() => el.querySelector('.blade-read-more').hidden === false);
+
+        // Only the (manually-triggered) ResizeObserver callback can flip this now.
+        stubOverflow(desc, false);
+        expect(instances).to.have.lengthOf(1);
+        instances[0].callback();
+
+        await waitFor(() => el.querySelector('.blade-read-more').hidden === true);
+      } finally {
+        restoreRo();
+        restoreRaf();
+      }
     });
   });
 

--- a/test/unit/scripts/decorate.test.js
+++ b/test/unit/scripts/decorate.test.js
@@ -809,6 +809,105 @@ describe('applyAreaTheme', () => {
     const cols = document.querySelectorAll('.section-metadata > div > div');
     expect(cols[1].textContent).to.equal('xxl-spacing');
   });
+
+  it('applies a positional theme only to the first matching block', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[first])');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text" id="t1"></div>
+        <div class="text" id="t2"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.getElementById('t1').classList.contains('dark')).to.be.true;
+    expect(document.getElementById('t2').classList.contains('dark')).to.be.false;
+  });
+
+  it('applies a positional theme only to the last matching block', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[last])');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text" id="t1"></div>
+        <div class="text" id="t2"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.getElementById('t1').classList.contains('dark')).to.be.false;
+    expect(document.getElementById('t2').classList.contains('dark')).to.be.true;
+  });
+
+  it('applies a positional theme to the block at a 1-based numeric index', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[2])');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text" id="t1"></div>
+        <div class="text" id="t2"></div>
+        <div class="text" id="t3"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.getElementById('t1').classList.contains('dark')).to.be.false;
+    expect(document.getElementById('t2').classList.contains('dark')).to.be.true;
+    expect(document.getElementById('t3').classList.contains('dark')).to.be.false;
+  });
+
+  it('combines a positional selector with a plain block name', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[first],agenda)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text" id="t1"></div>
+        <div class="text" id="t2"></div>
+        <div class="agenda"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.getElementById('t1').classList.contains('dark')).to.be.true;
+    expect(document.getElementById('t2').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.agenda').classList.contains('dark')).to.be.true;
+  });
+
+  it('silently skips an out-of-range positional selector while applying the rest of the list', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[5],agenda)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text" id="t1"></div>
+        <div class="text" id="t2"></div>
+        <div class="agenda"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.getElementById('t1').classList.contains('dark')).to.be.false;
+    expect(document.getElementById('t2').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.agenda').classList.contains('dark')).to.be.true;
+  });
+
+  it('does nothing when a positional selector keyword is malformed', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[foo],agenda)');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text"></div>
+        <div class="agenda"></div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    expect(document.querySelector('.text').classList.contains('dark')).to.be.false;
+    expect(document.querySelector('.agenda').classList.contains('dark')).to.be.false;
+  });
+
+  it('does not sync the section-metadata style row when using a positional selector', () => {
+    setThemeAttribute('theme', 'dark(blocks:text[first])');
+    document.body.innerHTML = `
+      <main><div>
+        <div class="text"></div>
+        <div class="section-metadata">
+          <div><div>style</div><div>xxl-spacing</div></div>
+        </div>
+      </div></main>
+    `;
+    applyAreaTheme();
+    const cols = document.querySelectorAll('.section-metadata > div > div');
+    expect(cols[1].textContent).to.equal('xxl-spacing');
+  });
 });
 
 describe('getNonProdData', () => {


### PR DESCRIPTION
## Release Notes

Fast-track cherry-pick from `stage` — only the three fixes below, not a full stage promotion.

(Supersedes #227 — that branch was rebuilt fresh here since it was suspected dead in EDS code sync after the earlier rename.)

**Fixes**
- Profile-cards blade variant: "Read more" toggle no longer shows for short bios. (#222)
- Block-scoped theme syntax: positional selectors support. (#223)
- Profile-cards blade variant: additional CSS fix. (#224)

Cherry-picked commits (via `-m 1` on each PR's merge commit, preserving the exact diff as reviewed). These are already present on `stage` (merged there via PR #225):
- `9641944` Merge pull request #222 (blade Read more toggle fix)
- `457a0cb` Merge pull request #223 (positional selectors for block-scoped theme syntax)
- `3cafd81` Merge pull request #224 (profile-cards.css fix)

Verified: `npx wtr test/unit/blocks/profile-cards/profile-cards.test.js test/unit/scripts/decorate.test.js` — 169/169 passing.