### PR TITLE
MWPW-200891: Condense products-of-interest multi-select summary

### DIFF
--- a/event-libs/v1/blocks/events-form/events-form.js
+++ b/event-libs/v1/blocks/events-form/events-form.js
@@ -1,7 +1,7 @@
 import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent, getCampaign, registerForSessionTime } from '../../utils/esp-controller.js';
 import BlockMediator from '../../deps/block-mediator.min.js';
 import { signIn, decorateEvent } from '../../utils/decorate.js';
-import { dictionaryManager, getInviteOnlyNoCampaignMessage, getRsvpTokenInvalidMessage, getRsvpTokenAlreadyRegisteredMessage } from '../../utils/dictionary-manager.js';
+import { dictionaryManager, getInviteOnlyNoCampaignMessage, getRsvpTokenInvalidMessage, getRsvpTokenAlreadyRegisteredMessage, getMultiSelectMoreSuffixMessage } from '../../utils/dictionary-manager.js';
 import { getEventConfig, LIBS, getMetadata, getSusiOptions, getValidCampaignIdFromUrl, resolveRoutedCampaignId, shouldForceGuestSignIn } from '../../utils/utils.js';
 import { FALLBACK_LOCALES, CAMPAIGN_ID_PATTERN, PHONE_FIELD_RE, PHONE_PATTERN  } from '../../utils/constances.js';
 import { BASE_ATTENDEE_DATA_FILTER } from '../../utils/data-utils.js';
@@ -54,15 +54,18 @@ function applyConsentCountrySelectValue(selectEl, stored) {
   if (byConsentId) selectEl.value = byConsentId.value;
 }
 
-function createSelect(fd) {
+const MULTI_SELECT_CONDENSED_VISIBLE_COUNT = 2;
+
+export function createSelect(fd) {
   const {
     field, placeholder, options, defval, required, type,
   } = fd;
 
+  const optionValues = options.split(';').map((o) => o.trim());
+
   const select = createTag('select', { id: field });
   if (placeholder) select.append(createTag('option', { class: 'placeholder-option', selected: '', disabled: '', value: '' }, dictionaryManager.getValue(placeholder, 'rsvp-fields')));
-  options.split(';').forEach(async (o) => {
-    const text = o.trim();
+  optionValues.forEach((text) => {
     const optionText = dictionaryManager.getValue(text, 'rsvp-fields');
     const option = createTag('option', { value: text }, optionText);
     select.append(option);
@@ -86,12 +89,35 @@ function createSelect(fd) {
 
     const selectedValues = new Set();
 
+    optionValues.forEach((text) => {
+      const label = createTag('label', {}, dictionaryManager.getValue(text, 'rsvp-fields'), { parent: customDropdown });
+      createTag('input', { type: 'checkbox', value: text, class: 'no-submit' }, '', { parent: label });
+    });
+
+    // Immutable snapshot of authoring order: re-sorting is always derived from this
+    // fixed reference rather than the (possibly already-reordered) live DOM, so a
+    // deselected option reliably returns to its original position.
+    const originalLabels = Array.from(customDropdown.children);
+
+    const sortDropdownOptions = () => {
+      const sorted = [...originalLabels].sort((a, b) => {
+        const aSelected = selectedValues.has(a.querySelector('input').value);
+        const bSelected = selectedValues.has(b.querySelector('input').value);
+        return Number(bSelected) - Number(aSelected);
+      });
+      sorted.forEach((label) => customDropdown.append(label));
+    };
+
     const updateSelectUI = () => {
       if (selectedValues.size === 0) {
         selectedOptions.textContent = placeholder || '-';
       } else {
-        const valuesArr = Array.from(selectedValues);
-        selectedOptions.textContent = valuesArr.join(', ');
+        const orderedSelected = optionValues.filter((v) => selectedValues.has(v));
+        const visible = orderedSelected.slice(0, MULTI_SELECT_CONDENSED_VISIBLE_COUNT);
+        const remaining = orderedSelected.length - visible.length;
+        selectedOptions.textContent = remaining > 0
+          ? `${visible.join(', ')} ${getMultiSelectMoreSuffixMessage(dictionaryManager, { count: remaining })}`
+          : visible.join(', ');
       }
 
       Array.from(select.options).forEach((opt) => {
@@ -102,13 +128,9 @@ function createSelect(fd) {
       customSelectBoxes.forEach((cb) => {
         cb.checked = selectedValues.has(cb.value);
       });
-    };
 
-    options.split(';').forEach((o) => {
-      const text = o.trim();
-      const label = createTag('label', {}, dictionaryManager.getValue(text, 'rsvp-fields'), { parent: customDropdown });
-      createTag('input', { type: 'checkbox', value: text, class: 'no-submit' }, '', { parent: label });
-    });
+      sortDropdownOptions();
+    };
 
     customSelect.addEventListener('click', () => {
       customDropdown.classList.toggle('hidden');

--- a/event-libs/v1/utils/dictionary-manager.js
+++ b/event-libs/v1/utils/dictionary-manager.js
@@ -229,3 +229,21 @@ export function getEventWaitlistBannerMessage(manager, { eventTitle = '' } = {})
     : raw;
   return text.replace(/\{eventTitle\}/g, eventTitle);
 }
+
+export const MULTI_SELECT_MORE_SUFFIX_KEY = 'multi-select-more-suffix';
+
+/**
+ * "+N more" suffix appended to a multi-select combobox's condensed summary
+ * (events-form's `createSelect`) once more options are selected than fit inline.
+ * Looked up from the `rsvp-fields` sheet, same as every other string rendered by
+ * that widget. Supports `{count}` token substitution.
+ * @param {DictionaryManager} manager - Initialized dictionary manager instance
+ * @param {Object} [tokens] - Tokens to interpolate into the dictionary value
+ * @param {number} [tokens.count] - Number of additional selected options to substitute for `{count}`
+ * @returns {string}
+ */
+export function getMultiSelectMoreSuffixMessage(manager, { count = 0 } = {}) {
+  const raw = manager.getValue(MULTI_SELECT_MORE_SUFFIX_KEY, 'rsvp-fields');
+  const text = raw === MULTI_SELECT_MORE_SUFFIX_KEY ? '+{count} more' : raw;
+  return text.replace(/\{count\}/g, count);
+}

--- a/test/unit/blocks/events-form/events-form.test.js
+++ b/test/unit/blocks/events-form/events-form.test.js
@@ -1374,6 +1374,93 @@ describe('Events Form', () => {
   });
 });
 
+describe('createSelect - multi-select combobox condensed view', () => {
+  let createSelect;
+  let sandbox;
+
+  before(async () => {
+    const module = await import('../../../../event-libs/v1/blocks/events-form/events-form.js');
+    createSelect = module.createSelect;
+  });
+
+  beforeEach(async () => {
+    const { dictionaryManager } = await import('../../../../event-libs/v1/utils/dictionary-manager.js');
+    sandbox = sinon.createSandbox();
+    sandbox.stub(dictionaryManager, 'getValue').callsFake((key) => key);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function buildField(overrides = {}) {
+    return {
+      field: 'productsOfInterest',
+      placeholder: 'Select products',
+      options: 'Acrobat;Illustrator;InDesign;Lightroom;Photoshop',
+      defval: '',
+      required: '',
+      type: 'multi-select',
+      ...overrides,
+    };
+  }
+
+  function check(wrapper, value, checked) {
+    const checkbox = wrapper.querySelector(`.custom-dropdown input[value="${value}"]`);
+    checkbox.checked = checked;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  function dropdownOrder(wrapper) {
+    return Array.from(wrapper.querySelectorAll('.custom-dropdown input'))
+      .map((cb) => cb.value);
+  }
+
+  it('shows the plain comma list when 2 or fewer options are selected', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Acrobat', true);
+    check(wrapper, 'Illustrator', true);
+    expect(wrapper.querySelector('.selected-options').textContent).to.equal('Acrobat, Illustrator');
+  });
+
+  it('condenses to "+N more" once selection exceeds the visible count', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Acrobat', true);
+    check(wrapper, 'Illustrator', true);
+    check(wrapper, 'Photoshop', true);
+    expect(wrapper.querySelector('.selected-options').textContent).to.equal('Acrobat, Illustrator +1 more');
+  });
+
+  it('drops the "+N more" suffix again once deselecting back under the threshold', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Acrobat', true);
+    check(wrapper, 'Illustrator', true);
+    check(wrapper, 'Photoshop', true);
+    check(wrapper, 'Photoshop', false);
+    expect(wrapper.querySelector('.selected-options').textContent).to.equal('Acrobat, Illustrator');
+  });
+
+  it('orders the condensed summary by the original option order, not selection order', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Photoshop', true);
+    check(wrapper, 'Acrobat', true);
+    expect(wrapper.querySelector('.selected-options').textContent).to.equal('Acrobat, Photoshop');
+  });
+
+  it('sorts a selected option to the top of the dropdown, preserving original relative order otherwise', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Lightroom', true);
+    expect(dropdownOrder(wrapper)).to.deep.equal(['Lightroom', 'Acrobat', 'Illustrator', 'InDesign', 'Photoshop']);
+  });
+
+  it('returns a deselected option to its original position in the dropdown', () => {
+    const wrapper = createSelect(buildField());
+    check(wrapper, 'Lightroom', true);
+    check(wrapper, 'Lightroom', false);
+    expect(dropdownOrder(wrapper)).to.deep.equal(['Acrobat', 'Illustrator', 'InDesign', 'Lightroom', 'Photoshop']);
+  });
+});
+
 describe('stripTags', () => {
   it('removes script tags and keeps inner text', () => {
     expect(stripTags('<script>alert()</script>')).to.equal('alert()');


### PR DESCRIPTION
## Summary

Jira: [MWPW-200891](https://jira.corp.adobe.com/browse/MWPW-200891)

The RSVP form's "Products of interest" multi-select combobox (`createSelect()` in `events-form.js`) had a condensed summary that grew unbounded — `Array.from(selectedValues).join(', ')` — with no cap, and the checkbox dropdown never reordered to reflect selections, so a user's picks got buried once they scrolled past them.

- Condensed summary now shows the first 2 selected options (in original option order) plus a localized `+N more` suffix once there are more than 2 selected. New `getMultiSelectMoreSuffixMessage()` helper added to `dictionary-manager.js`, following the same `{token}`-substitution / echo-key-if-untranslated convention already used by `getEventWaitlistBannerMessage` and friends.
- The dropdown auto-sorts selected options to the top on every change, and deselecting one returns it to its original position — implemented as a stable partition re-derived from an immutable snapshot of the original authoring order each time, so it's correct regardless of how many times it's re-sorted.
- Deriving the summary's item order from the same original-option order (rather than selection/insertion order) also fixes the ordering inconsistency called out in the ticket, so the summary now matches the top of the resorted dropdown.
- `createSelect` is now exported for direct unit testing (previously private).

Out of scope per the ticket owner: the open questions in the ticket description (fixed-height/scroll alternative), and the pre-existing inconsistency where the condensed summary shows raw option values while the dropdown/native-select show dictionary-translated labels (unchanged by this PR).

## Test plan

- [x] `npm run lint` — clean (JS + CSS)
- [x] `npm test` — full suite green (1179/1179), run twice to confirm stability
- [x] New tests in `test/unit/blocks/events-form/events-form.test.js` (`createSelect - multi-select combobox condensed view`) cover: truncation to "+N more", un-truncation on deselect, condensed-order independence from click order, dropdown re-sort to top, and restoration to original position on deselect
- [x] Independently verified (adversarial review pass) that these tests fail against the pre-change code and pass against the new code — not tautological
- [ ] Manual check in a browser against a live RSVP form with a multi-select combobox field (not done in this sandboxed environment — recommend a quick smoke test before merge)