### PR TITLE
Forward unrecognized RSVP fields to event-attendee payload; deprecate submittable

### DIFF
--- a/event-libs/v1/utils/data-utils.js
+++ b/event-libs/v1/utils/data-utils.js
@@ -1,67 +1,65 @@
 /**
  * @typedef {Object} EventAttendeeDataFilter
  * @property {string} type - The type of the attribute.
- * @property {boolean} submittable - Whether the attribute can be submitted.
  */
 
 export const EVENT_ATTENDEE_DATA_FILTER = {
-  attendeeId: { type: 'string', submittable: true },
-  externalAttendeeId: { type: 'string', submittable: true },
-  firstName: { type: 'string', submittable: true },
-  lastName: { type: 'string', submittable: true },
-  email: { type: 'string', submittable: true },
-  registrationStatus: { type: 'string', submittable: true },
-  invitedBy: { type: 'string', submittable: true },
-  shareInfoWithPartners: { type: 'boolean', submittable: true },
-  requiresTicket: { type: 'boolean', submittable: true },
-  ccSentiment: { type: 'string', submittable: true },
-  campaignId: { type: 'string', submittable: true },
-  phoneticFirstName: { type: 'string', submittable: true },
-  phoneticLastName: { type: 'string', submittable: true },
+  attendeeId: { type: 'string' },
+  externalAttendeeId: { type: 'string' },
+  firstName: { type: 'string' },
+  lastName: { type: 'string' },
+  email: { type: 'string' },
+  registrationStatus: { type: 'string' },
+  invitedBy: { type: 'string' },
+  shareInfoWithPartners: { type: 'boolean' },
+  requiresTicket: { type: 'boolean' },
+  ccSentiment: { type: 'string' },
+  campaignId: { type: 'string' },
+  phoneticFirstName: { type: 'string' },
+  phoneticLastName: { type: 'string' },
 };
 
 /**
  * @typedef {Object} BaseAttendeeDataFilter
  * @property {string} type - The type of the attribute.
- * @property {boolean} submittable - Whether the attribute can be submitted.
  */
 
 export const BASE_ATTENDEE_DATA_FILTER = {
-  attendeeId: { type: 'string', submittable: true },
-  firstName: { type: 'string', submittable: true },
-  lastName: { type: 'string', submittable: true },
-  email: { type: 'string', submittable: true },
-  companyName: { type: 'string', submittable: true },
-  jobTitle: { type: 'string', submittable: true },
-  jobRole: { type: 'string', submittable: true },
-  mobilePhone: { type: 'string', submittable: true },
-  businessPhone: { type: 'string', submittable: true },
-  organizationName: { type: 'string', submittable: true },
-  countryRegion: { type: 'string', submittable: true },
-  zipPostalCode: { type: 'string', submittable: true },
-  industry: { type: 'string', submittable: true },
-  productsOfInterest: { type: 'array', submittable: true },
-  primaryProductOfInterest: { type: 'string', submittable: true },
-  companySize: { type: 'string', submittable: true },
-  specialRequirements: { type: 'string', submittable: true },
-  primarySocialMediaAccount: { type: 'string', submittable: true },
-  approximateFollowerCount: { type: 'string', submittable: true },
-  dietaryRestrictions: { type: 'string', submittable: true },
-  executiveAssistantName: { type: 'string', submittable: true },
-  executiveAssistantEmail: { type: 'string', submittable: true },
-  website: { type: 'string', submittable: true },
-  employeesInOrganization: { type: 'string', submittable: true },
-  department: { type: 'string', submittable: true },
-  dxDepartment: { type: 'string', submittable: true },
-  title: { type: 'string', submittable: true },
-  age: { type: 'string', submittable: true },
-  jobLevel: { type: 'string', submittable: true },
-  contactMethods: { type: 'array', submittable: true },
-  isGuest: { type: 'boolean', submittable: true },
-  consentStringId: { type: 'string', submittable: true },
-  modificationTime: { type: 'string', submittable: true },
-  phoneticFirstName: { type: 'string', submittable: true },
-  phoneticLastName: { type: 'string', submittable: true },
+  attendeeId: { type: 'string' },
+  firstName: { type: 'string' },
+  lastName: { type: 'string' },
+  email: { type: 'string' },
+  companyName: { type: 'string' },
+  jobTitle: { type: 'string' },
+  jobRole: { type: 'string' },
+  mobilePhone: { type: 'string' },
+  businessPhone: { type: 'string' },
+  organizationName: { type: 'string' },
+  countryRegion: { type: 'string' },
+  zipPostalCode: { type: 'string' },
+  industry: { type: 'string' },
+  productsOfInterest: { type: 'array' },
+  primaryProductOfInterest: { type: 'string' },
+  companySize: { type: 'string' },
+  specialRequirements: { type: 'string' },
+  primarySocialMediaAccount: { type: 'string' },
+  approximateFollowerCount: { type: 'string' },
+  dietaryRestrictions: { type: 'string' },
+  executiveAssistantName: { type: 'string' },
+  executiveAssistantEmail: { type: 'string' },
+  website: { type: 'string' },
+  employeesInOrganization: { type: 'string' },
+  department: { type: 'string' },
+  dxDepartment: { type: 'string' },
+  title: { type: 'string' },
+  age: { type: 'string' },
+  jobLevel: { type: 'string' },
+  contactMethods: { type: 'array' },
+  isGuest: { type: 'boolean' },
+  consentStringId: { type: 'string' },
+  modificationTime: { type: 'string' },
+  phoneticFirstName: { type: 'string' },
+  phoneticLastName: { type: 'string' },
 };
 
 export function isValidAttribute(attr) {
@@ -91,10 +89,11 @@ function coerceBoolean(key, value) {
 export function getEventAttendeePayload(attendeeData) {
   if (!attendeeData) return attendeeData;
   return Object.entries(attendeeData).reduce((acc, [key, value]) => {
-    const nextValue = EVENT_ATTENDEE_DATA_FILTER[key]?.type === 'boolean'
+    if (!EVENT_ATTENDEE_DATA_FILTER[key]) return acc;
+    const nextValue = EVENT_ATTENDEE_DATA_FILTER[key].type === 'boolean'
       ? coerceBoolean(key, value)
       : value;
-    if (EVENT_ATTENDEE_DATA_FILTER[key]?.submittable && isValidAttribute(nextValue)) {
+    if (isValidAttribute(nextValue)) {
       acc[key] = nextValue;
     }
     return acc;
@@ -104,7 +103,25 @@ export function getEventAttendeePayload(attendeeData) {
 export function getBaseAttendeePayload(attendeeData) {
   if (!attendeeData) return attendeeData;
   return Object.entries(attendeeData).reduce((acc, [key, value]) => {
-    if (BASE_ATTENDEE_DATA_FILTER[key]?.submittable && isValidAttribute(value)) {
+    if (BASE_ATTENDEE_DATA_FILTER[key] && isValidAttribute(value)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+// Unlike the two allowlists above, this key-space isn't fixed, so explicitly
+// reject prototype-chain property names rather than relying on the filter
+// lookups incidentally treating them as "recognized".
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function getUnrecognizedAttendeeFields(attendeeData) {
+  if (!attendeeData) return {};
+  return Object.entries(attendeeData).reduce((acc, [key, value]) => {
+    if (!UNSAFE_KEYS.has(key)
+      && !EVENT_ATTENDEE_DATA_FILTER[key]
+      && !BASE_ATTENDEE_DATA_FILTER[key]
+      && isValidAttribute(value)) {
       acc[key] = value;
     }
     return acc;

--- a/event-libs/v1/utils/esp-controller.js
+++ b/event-libs/v1/utils/esp-controller.js
@@ -1,6 +1,10 @@
 import { LIBS } from './utils.js';
 import BlockMediator from '../deps/block-mediator.min.js';
-import { getBaseAttendeePayload, getEventAttendeePayload } from './data-utils.js';
+import {
+  getBaseAttendeePayload,
+  getEventAttendeePayload,
+  getUnrecognizedAttendeeFields,
+} from './data-utils.js';
 import { ENV_MAP } from './constances.js';
 import { getEventConfig, getEventServiceEnv } from './utils.js';
 
@@ -752,12 +756,16 @@ export async function getAndCreateAndAddAttendee(eventId, attendeeData, rsvpToke
     }
   }
 
-  // Use EventAttendee filter for adding attendee to event
-  const eventAttendeePayload = getEventAttendeePayload({
-    ...newAttendeeData,
-    ...attendeeData,
-    registrationStatus,
-  });
+  // Use EventAttendee filter for adding attendee to event; forward any
+  // custom fields the RSVP form submitted that neither filter recognizes.
+  const eventAttendeePayload = {
+    ...getEventAttendeePayload({
+      ...newAttendeeData,
+      ...attendeeData,
+      registrationStatus,
+    }),
+    ...getUnrecognizedAttendeeFields(attendeeData),
+  };
 
   // For a guest, this call both registers and consumes the rsvp token
   // server-side in one step.

--- a/test/unit/scripts/esp-controller.test.js
+++ b/test/unit/scripts/esp-controller.test.js
@@ -537,6 +537,26 @@ describe('Adobe Event Service API', () => {
       expect(result.data.registrationStatus).to.equal('waitlisted');
     });
 
+    it('should forward custom fields unrecognized by either filter into the add-to-event payload, but not fields recognized only by the base attendee filter', async () => {
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onCall(0).resolves({ json: () => ({ eventId, isFull: false }), ok: true });
+      fetchStub.onCall(1).resolves({ json: () => (attendeeResp), ok: true, status: 200 });
+      fetchStub.onCall(2).resolves({ json: () => (attendeeResp), ok: true });
+      fetchStub.onCall(3).resolves({ json: () => ({ registrationStatus: 'registered' }), ok: true });
+
+      const dataWithCustomField = {
+        ...attendeeData,
+        jobTitle: 'Engineer',
+        customEventQuestion: 'Yes, I will attend the workshop',
+      };
+      await api.getAndCreateAndAddAttendee(eventId, dataWithCustomField);
+
+      const addToEventOptions = fetchStub.getCall(3).args[1];
+      const addToEventBody = JSON.parse(addToEventOptions.body);
+      expect(addToEventBody.customEventQuestion).to.equal('Yes, I will attend the workshop');
+      expect(addToEventBody).to.not.have.property('jobTitle');
+    });
+
     it('should fall back to event-level status when campaign lookup fails', async () => {
       BlockMediator.set('imsProfile', { account_type: 'guest' });
       const fetchStub = sandbox.stub(window, 'fetch');

--- a/test/unit/utils/data-utils.test.js
+++ b/test/unit/utils/data-utils.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import {
   getBaseAttendeePayload,
   getEventAttendeePayload,
+  getUnrecognizedAttendeeFields,
 } from '../../../event-libs/v1/utils/data-utils.js';
 
 describe('data-utils', () => {
@@ -100,6 +101,61 @@ describe('data-utils', () => {
     it('returns argument unchanged when falsy', () => {
       expect(getBaseAttendeePayload(null)).to.equal(null);
       expect(getBaseAttendeePayload(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('getUnrecognizedAttendeeFields', () => {
+    it('returns fields not recognized by either filter', () => {
+      const out = getUnrecognizedAttendeeFields({
+        firstName: 'Ada',
+        customEventQuestion: 'Yes, I will attend the workshop',
+      });
+      expect(out).to.deep.equal({ customEventQuestion: 'Yes, I will attend the workshop' });
+    });
+
+    it('excludes fields recognized by the base attendee filter even when absent from the event filter', () => {
+      const out = getUnrecognizedAttendeeFields({
+        jobTitle: 'Engineer',
+        customField: 'x',
+      });
+      expect(out).to.deep.equal({ customField: 'x' });
+    });
+
+    it('excludes fields recognized by the event attendee filter', () => {
+      const out = getUnrecognizedAttendeeFields({
+        requiresTicket: true,
+        customField: 'x',
+      });
+      expect(out).to.deep.equal({ customField: 'x' });
+    });
+
+    it('drops invalid values (empty string, null, undefined)', () => {
+      const out = getUnrecognizedAttendeeFields({
+        customField: '',
+        anotherCustomField: null,
+        thirdCustomField: undefined,
+        keepMe: 'value',
+      });
+      expect(out).to.deep.equal({ keepMe: 'value' });
+    });
+
+    it('returns an empty object when falsy', () => {
+      expect(getUnrecognizedAttendeeFields(null)).to.deep.equal({});
+      expect(getUnrecognizedAttendeeFields(undefined)).to.deep.equal({});
+    });
+
+    it('excludes a key recognized by both filters', () => {
+      const out = getUnrecognizedAttendeeFields({
+        firstName: 'Ada',
+        customField: 'x',
+      });
+      expect(out).to.deep.equal({ customField: 'x' });
+    });
+
+    it('rejects prototype-chain property names', () => {
+      const out = getUnrecognizedAttendeeFields(JSON.parse('{"__proto__":{"polluted":true},"constructor":"x","customField":"y"}'));
+      expect(out).to.deep.equal({ customField: 'y' });
+      expect({}.polluted).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## Summary
- RSVP submission previously silently dropped any attendee field not explicitly listed in `BASE_ATTENDEE_DATA_FILTER` or `EVENT_ATTENDEE_DATA_FILTER` (`event-libs/v1/utils/data-utils.js`). A new `getUnrecognizedAttendeeFields()` now forwards fields unrecognized by **either** filter into the **event-attendee** payload sent to `addAttendeeToEvent` in `esp-controller.js`'s `getAndCreateAndAddAttendee()`, so custom/event-specific form questions aren't lost. This intentionally does **not** apply to the base-attendee (`createAttendee`/`updateAttendee`) payload — custom fields are scoped to that one event's registration, not the attendee's cross-event profile.
- The pass-through is sourced only from the raw client-submitted `attendeeData`, never from `newAttendeeData` (the server's attendee record), so server-side metadata can't leak into the outbound request.
- Removed the `submittable` flag from both filter objects: it was read (gated the filter checks) but hardcoded to `true` on all 48 fields with no exception anywhere in git history, so it never actually discriminated anything. The two filter functions now gate on key existence in the filter map instead.
- Added a defensive guard (`__proto__`/`constructor`/`prototype`) in `getUnrecognizedAttendeeFields` since, unlike the two fixed allowlists, its key-space is influenced by client input.

## Caveats worth a second look
- **ESP schema compatibility**: this is a behavior change from "unknown fields silently dropped" to "unknown fields forwarded as-is." If the `addAttendeeToEvent` endpoint enforces strict/`additionalProperties: false` validation, previously-succeeding submissions with an unrecognized field could now get a 400 instead of silently ignoring it. Recommend confirming the ESP contract tolerates extra fields before this reaches production traffic with authored custom questions.

## Test plan
- [x] `npx wtr test/unit/utils/data-utils.test.js test/unit/scripts/esp-controller.test.js --node-resolve --port=2000` — 85/85 passing
- [x] `npm test` (full suite) — 1432/1432 passing
- [x] `npm run lint` — clean
- [x] Reviewed by two independent agents (correctness + security pass); addressed the prototype-pollution hardening and added a shared-key test case they flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)