### PR TITLE
Fix card-c2 hydrator to recognize multi-letter session-code prefixes

### DIFF
--- a/event-libs/v1/hydrate/card-c2.js
+++ b/event-libs/v1/hydrate/card-c2.js
@@ -1,7 +1,7 @@
 import { META_REG } from '../utils/constances.js';
 import { getMetadata } from '../utils/utils.js';
 
-const SESSION_CODE_PATTERN = /^s\d+$/i;
+const SESSION_CODE_PATTERN = /^[a-z]{1,4}\d+$/i;
 // card-c2.js's own aspect-ratio variant classes (e.g. "ratio-3-4") can be authored
 // alongside the hydrate classes on the same block — exclude them here too, or they'd
 // get mistaken for the metadata-key class.

--- a/test/unit/hydrate/card-c2.test.js
+++ b/test/unit/hydrate/card-c2.test.js
@@ -22,6 +22,14 @@ const SESSIONS = [
     mrStreamId: 'mr-stream-s6522',
     sessionTime: { startTimeMillis: 1784624404633, endTimeMillis: 1784628904633, timezone: 'America/Los_Angeles' },
   },
+  {
+    sessionId: '0d646e37-b0e9-4d86-9dab-927ccb37f04e',
+    sessionCode: 'OS565',
+    enTitle: 'One Voice, Many Platforms',
+    track: 'Creator',
+    url: 'https://www.adobe.com/max/2026/sessions/os565',
+    sessionTime: { startTimeMillis: 1784624404633, endTimeMillis: 1784628904633, timezone: 'America/Los_Angeles' },
+  },
 ];
 
 // DA percent-encodes `[[`/`]]` inside attribute values on save.
@@ -92,6 +100,25 @@ describe('card-c2 hydrator', () => {
     expect(block.querySelector('a').getAttribute('href')).to.equal('[[featured-sessions:1.url]]');
     expect(block.dataset.mrStreamId).to.equal('mr-stream-s6522');
     expect(block.dataset.watchUrl).to.equal('https://www.adobe.com/max/2026/live/session-broadcast/s6522');
+  });
+
+  it('matches a multi-letter session-code prefix (e.g. OS565), not just S####', async () => {
+    document.body.innerHTML = `
+      <div class="card-c2 hydrate featured-sessions os565">
+        <div><div><picture><img src="/media/os565.jpg" alt=""></picture></div></div>
+        ${AUTHORED_CONTENT}
+      </div>
+    `;
+
+    await hydrateBlocks(document);
+
+    const block = document.querySelector('.card-c2');
+    expect(tokensIn(block)).to.deep.equal([
+      'featured-sessions:2.enTitle',
+      'featured-sessions:2.track',
+      'featured-sessions:2.url',
+    ]);
+    expect(block.dataset.sessionId).to.equal('0d646e37-b0e9-4d86-9dab-927ccb37f04e');
   });
 
   it('leaves the authored tokens un-rewritten when the session code has no match', async () => {


### PR DESCRIPTION
## Summary

`event-libs/v1/hydrate/card-c2.js`'s `SESSION_CODE_PATTERN` only matched an `S` prefix
(`/^s\d+$/i`, e.g. `s6304`). Real authored data can include other RainFocus session-code
prefixes (`OS565`, `AL687`, `OS705`, `OS709`, ...), which failed that pattern.

When a card's session-code class fails the pattern, `getMetadataKeyAndSessionCode()`
falls into its `else` branch and treats the class as the **metadata key** instead of a
session code — so a card authored `card-c2 hydrate featured-sessions os565` had its real
`featured-sessions` key overwritten by the bogus key `os565`, `getMetadata('os565')`
returned nothing, and the hydrator silently returned `false` — leaving that card's
`[[featured-sessions.*]]` tokens unresolved/blank in production, with no error.

Confirmed against a real authored `featured-sessions` payload — cards for `S6304`,
`S6006`, `S6302` hydrated correctly; `OS565`, `OS705`, `AL687`, `OS709` silently didn't.

## Fix

Broadens `SESSION_CODE_PATTERN` to `/^[a-z]{1,4}\d+$/i` — any short letter prefix (1-4
chars) followed by digits, not just `S`.

## Test plan
- [x] New regression test for an `OS`-prefixed code (`test/unit/hydrate/card-c2.test.js`)
- [x] `npm run lint` clean
- [x] `npx wtr test/unit/hydrate/card-c2.test.js` — 8/8 passing