### PR TITLE
[MWPW-201134] Support bare-token shorthand in card-c2 hydrator

### DIFF
--- a/event-libs/v1/c2/blocks/card-c2/docs/session-hydration.md
+++ b/event-libs/v1/c2/blocks/card-c2/docs/session-hydration.md
@@ -57,6 +57,17 @@ local `rewriteTokensToIndex` helper in `event-libs/v1/hydrate/card-c2.js`
 everywhere else on the page. The hydrator never reads `enTitle`/`track`/`url`
 values and never builds `<p>`/`<a>` elements.
 
+### 3.1 Bare-token shorthand
+
+Since the card already authors its own metadata key as a class (`featured-sessions`
+above), repeating that key in every token is redundant. `rewriteToken()` also
+accepts a bare, prefix-less token — `[[enTitle]]` rewrites to the same
+`[[featured-sessions:3.enTitle]]` as `[[featured-sessions.enTitle]]` would. Both
+forms can be mixed freely on the same card. A token containing a `.` that
+doesn't start with this card's own metadata key (e.g. `[[some-other-key.title]]`)
+is left untouched — it's assumed to reference an unrelated metadata collection,
+not a typo.
+
 ## 4. Matching a card to its session
 
 Per the authored markup:

--- a/event-libs/v1/hydrate/card-c2.js
+++ b/event-libs/v1/hydrate/card-c2.js
@@ -35,8 +35,14 @@ function getSessions(metadataKey) {
 
 function rewriteToken(str, metadataKey, index) {
   return str.replace(META_REG, (match, token) => {
-    if (!token.startsWith(metadataKey) || token.includes(':')) return match;
-    return `[[${metadataKey}:${index}${token.slice(metadataKey.length)}]]`;
+    if (token.includes(':')) return match;
+    if (token.startsWith(metadataKey)) {
+      return `[[${metadataKey}:${index}${token.slice(metadataKey.length)}]]`;
+    }
+    if (!token.includes('.')) {
+      return `[[${metadataKey}:${index}.${token}]]`;
+    }
+    return match;
   });
 }
 

--- a/test/unit/hydrate/card-c2.test.js
+++ b/test/unit/hydrate/card-c2.test.js
@@ -121,6 +121,46 @@ describe('card-c2 hydrator', () => {
     expect(block.dataset.sessionId).to.equal('0d646e37-b0e9-4d86-9dab-927ccb37f04e');
   });
 
+  it('rewrites bare, prefix-less tokens (e.g. [[enTitle]]) using the card\'s own metadata key', async () => {
+    document.body.innerHTML = `
+      <div class="card-c2 hydrate featured-sessions s6210">
+        <div><div><picture><img src="/media/s6210.jpg" alt=""></picture></div></div>
+        <div><div>
+          <p>[[enTitle]]</p>
+          <p>[[track]]</p>
+          <p><a href="${encodeURIComponent('[[url]]')}">Learn more</a></p>
+        </div></div>
+      </div>
+    `;
+
+    await hydrateBlocks(document);
+
+    const block = document.querySelector('.card-c2');
+    expect(tokensIn(block)).to.deep.equal([
+      'featured-sessions:0.enTitle',
+      'featured-sessions:0.track',
+      'featured-sessions:0.url',
+    ]);
+    expect(block.querySelector('a').getAttribute('href')).to.equal('[[featured-sessions:0.url]]');
+    expect(block.dataset.sessionId).to.equal('1c2f7e9a-3b4d-4e21-9a6f-6d1f1a2b3c4d');
+  });
+
+  it('leaves a dotted token referencing a different metadata key untouched', async () => {
+    document.body.innerHTML = `
+      <div class="card-c2 hydrate featured-sessions s6210">
+        <div><div><picture><img src="/media/s6210.jpg" alt=""></picture></div></div>
+        <div><div>
+          <p>[[some-other-key.title]]</p>
+        </div></div>
+      </div>
+    `;
+
+    await hydrateBlocks(document);
+
+    const block = document.querySelector('.card-c2');
+    expect(tokensIn(block)).to.deep.equal(['some-other-key.title']);
+  });
+
   it('leaves the authored tokens un-rewritten when the session code has no match', async () => {
     document.body.innerHTML = `
       <div class="card-c2 hydrate featured-sessions s9999">


### PR DESCRIPTION
## Summary

A card already declares its own metadata key as an authored class (e.g.
`featured-sessions`), so repeating that key in every content token —
`[[featured-sessions.enTitle]]` — is redundant.

`rewriteToken()` in `event-libs/v1/hydrate/card-c2.js` now also accepts a bare,
prefix-less token. `[[enTitle]]` rewrites to the exact same
`[[featured-sessions:3.enTitle]]` output as `[[featured-sessions.enTitle]]`
would — the downstream `processTemplateInAllNodes` resolver never sees a
difference. Both forms can be mixed freely on the same card (including in
`href` attributes, which reuse the same rewrite function). A dotted token that
doesn't start with this card's own metadata key (e.g. `[[some-other-key.title]]`)
is left untouched, on the assumption it references an unrelated metadata
collection rather than being a typo.

## Test plan
- [x] New tests for the bare-token shorthand (plain text + href) and for a
  dotted token referencing a different key being left alone
- [x] `npm run lint` clean
- [x] `npx wtr test/unit/hydrate/card-c2.test.js` — 10/10 passing