### PR TITLE
Add PR workflow to list changed code files for cache purging

### DIFF
--- a/.github/workflows/pr-changed-files-comment.yml
+++ b/.github/workflows/pr-changed-files-comment.yml
@@ -1,0 +1,81 @@
+name: List changed code files
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  list-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const MARKER = '<!-- pr-changed-files-comment -->';
+
+            const DOC_EXTENSIONS = new Set([
+              '.md', '.mdx', '.markdown', '.txt', '.rst', '.adoc',
+              '.doc', '.docx', '.pdf', '.rtf',
+            ]);
+            const DOC_BASENAMES = new Set([
+              'license', 'changelog', 'contributing', 'notice', 'authors', 'readme',
+            ]);
+
+            function isDocFile(path) {
+              const base = path.split('/').pop();
+              const dotIndex = base.lastIndexOf('.');
+              if (dotIndex === -1) {
+                return DOC_BASENAMES.has(base.toLowerCase());
+              }
+              const ext = base.slice(dotIndex).toLowerCase();
+              return DOC_EXTENSIONS.has(ext);
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const codeFiles = files
+              .filter((file) => !isDocFile(file.filename))
+              .map((file) => file.filename)
+              .sort();
+
+            let body;
+            if (codeFiles.length === 0) {
+              body = `${MARKER}\n### Changed files for cache purging\n\nNo purge-relevant files changed in this PR.`;
+            } else {
+              const list = codeFiles.map((path) => `<domain>/${path}`).join('\n');
+              body = `${MARKER}\n### Changed files for cache purging\n\n`
+                + 'Replace `<domain>` with the target host (e.g. `main--event-libs--adobecom.aem.live`) '
+                + "before purging — files must be purged individually, wildcards aren't supported.\n\n"
+                + `\`\`\`\n${list}\n\`\`\``;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find((comment) => comment.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/pr-changed-files-comment.yml` runs on every PR targeting `main` and posts/updates a comment listing changed non-doc files (JS, CSS, JSON, YAML, etc.), each prefixed with a literal `<domain>` placeholder for find-and-replace before manual Helix cache purging (which only supports exact file paths, not wildcards).
- Uses `pull_request_target` + `actions/github-script` (no checkout, no git diff) so it also works for PRs opened from forks; only reads the file list via `pulls.listFiles` and upserts a single comment via a hidden marker so repeated pushes don't spam the thread.
- Filters out doc/text files (`.md`, `.mdx`, `.txt`, `LICENSE`, `README`, etc.) rather than allow-listing code extensions, so new file types show up automatically.

## Test plan
- [ ] Open a real PR against `main` with a mix of code + doc file changes and confirm the comment lists only the code files, each as `<domain>/path`, inside a fenced code block
- [ ] Push an additional commit to that PR and confirm the existing comment is updated in place rather than duplicated
- [ ] Confirm the workflow also runs/comments correctly on a fork-originated PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)